### PR TITLE
Preserve Python connector git history

### DIFF
--- a/python/.env.example
+++ b/python/.env.example
@@ -1,0 +1,8 @@
+# Aurora DSQL cluster endpoint
+CLUSTER_ENDPOINT=your-cluster.dsql.us-east-1.on.aws
+
+# Database user (default: admin)
+# CLUSTER_USER=admin
+
+# AWS region (default: extracted from endpoint)
+# REGION=us-east-1

--- a/python/.github/dependabot.yml
+++ b/python/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    target-branch: "main"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "pip"
+    directory: "/examples/asyncpg"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "pip"
+    directory: "/examples/psycopg"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "pip"
+    directory: "/examples/psycopg2"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "gitleaks/gitleaks-action"

--- a/python/.github/workflows/dsql-cluster-create.yml
+++ b/python/.github/workflows/dsql-cluster-create.yml
@@ -1,0 +1,77 @@
+name: Create Aurora DSQL Cluster
+
+permissions: {}
+
+on:
+  workflow_call:
+    inputs:
+      workflow_name:
+        required: true
+        type: string
+        description: "Name of the calling workflow (used for cluster naming)"
+    secrets:
+      AWS_IAM_ROLE:
+        required: true
+    outputs:
+      cluster-id:
+        description: "The cluster identifier"
+        value: ${{ jobs.create.outputs.cluster-id }}
+      cluster-endpoint:
+        description: "The cluster endpoint"
+        value: ${{ jobs.create.outputs.cluster-endpoint }}
+      region:
+        description: "The AWS region"
+        value: ${{ jobs.create.outputs.region }}
+
+env:
+  AWS_REGION: us-east-1
+  MAX_RETRIES: 5
+  INITIAL_BACKOFF: 10
+
+jobs:
+  create:
+    name: Create Aurora DSQL Cluster
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      id-token: write # required by aws-actions/configure-aws-credentials
+    outputs:
+      cluster-id: ${{ steps.create.outputs.cluster-id }}
+      cluster-endpoint: ${{ steps.create.outputs.cluster-endpoint }}
+      region: ${{ steps.create.outputs.region }}
+
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v5
+        with:
+          role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Create cluster
+        id: create
+        run: |
+          CLUSTER_NAME="${{ inputs.workflow_name }}-${{ github.run_id }}"
+
+          for attempt in $(seq 1 "$MAX_RETRIES"); do
+            RESULT=$(aws dsql create-cluster \
+              --no-deletion-protection-enabled \
+              --tags "Name=$CLUSTER_NAME,Repo=${{ github.repository }},Type=integration-test" 2>&1) && break
+            BACKOFF=$((INITIAL_BACKOFF * attempt))
+            echo "Attempt $attempt failed, retrying in ${BACKOFF}s..."
+            sleep "$BACKOFF"
+          done
+
+          CLUSTER_ID=$(echo "$RESULT" | jq -r '.identifier')
+          if [ -z "$CLUSTER_ID" ] || [ "$CLUSTER_ID" = "null" ]; then
+            echo "Failed to create cluster: $RESULT"
+            exit 1
+          fi
+
+          echo "Waiting for cluster $CLUSTER_ID to become active..."
+          aws dsql wait cluster-active --identifier "$CLUSTER_ID"
+
+          {
+            echo "cluster-id=$CLUSTER_ID"
+            echo "cluster-endpoint=${CLUSTER_ID}.dsql.${{ env.AWS_REGION }}.on.aws"
+            echo "region=${{ env.AWS_REGION }}"
+          } >> "$GITHUB_OUTPUT"

--- a/python/.github/workflows/dsql-cluster-delete.yml
+++ b/python/.github/workflows/dsql-cluster-delete.yml
@@ -1,0 +1,38 @@
+name: Delete Aurora DSQL Cluster
+
+permissions: {}
+
+on:
+  workflow_call:
+    inputs:
+      cluster-id:
+        required: true
+        type: string
+        description: "The cluster identifier to delete"
+      region:
+        required: true
+        type: string
+        description: "The AWS region where the cluster exists"
+    secrets:
+      AWS_IAM_ROLE:
+        required: true
+
+jobs:
+  delete:
+    name: Delete Aurora DSQL Cluster
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      id-token: write # required by aws-actions/configure-aws-credentials
+
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v5
+        with:
+          role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
+          aws-region: ${{ inputs.region }}
+
+      - name: Delete cluster
+        run: |
+          echo "Deleting cluster ${{ inputs.cluster-id }}..."
+          aws dsql delete-cluster --identifier "${{ inputs.cluster-id }}" > /dev/null

--- a/python/.github/workflows/gitleaks-scan.yml
+++ b/python/.github/workflows/gitleaks-scan.yml
@@ -1,0 +1,24 @@
+name: Gitleaks scan
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: gitleaks
+        uses: gitleaks/gitleaks-action@v1.6.0
+        env:
+          # GitHub Token automatically created on run
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/python/.github/workflows/pre-commit.yml
+++ b/python/.github/workflows/pre-commit.yml
@@ -1,0 +1,22 @@
+name: Pre-commit
+
+permissions: {}
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v7
+      - run: uv sync
+      - uses: pre-commit/action@v3.0.1

--- a/python/.github/workflows/publish-pypi.yml
+++ b/python/.github/workflows/publish-pypi.yml
@@ -1,0 +1,51 @@
+name: Publish Aurora DSQL Connector for Python Distribution to PyPI
+
+permissions: {}
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    name: Build python distribution packages
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Build distribution packages
+        run: uv build
+
+      - name: Store the distribution packages
+        uses: actions/upload-artifact@v6
+        with:
+          name: python-package-distributions
+          path: dist/
+
+  publish-to-pypi:
+    name: Publish Python distribution packages to PyPI
+    needs:
+      - build
+    runs-on: ubuntu-latest
+
+    environment:
+      name: pypi
+      url: https://pypi.org/project/aurora-dsql-python-connector
+
+    permissions:
+      id-token: write # required by pypa/gh-action-pypi-publish
+
+    steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@v7
+        with:
+          name: python-package-distributions
+          path: dist/
+      - name: Publish distribution package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/python/.github/workflows/python-connector-integration-tests.yml
+++ b/python/.github/workflows/python-connector-integration-tests.yml
@@ -1,0 +1,119 @@
+name: Python connector integration tests
+
+permissions: {}
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "src/**"
+      - "tests/**"
+      - "examples/**"
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".github/workflows/python-connector-integration-tests.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "src/**"
+      - "tests/**"
+      - "examples/**"
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".github/workflows/python-connector-integration-tests.yml"
+  workflow_dispatch:
+
+jobs:
+  create-cluster:
+    uses: ./.github/workflows/dsql-cluster-create.yml
+    with:
+      workflow_name: python-connector-integ
+    secrets:
+      AWS_IAM_ROLE: ${{ secrets.PYTHON_CONNECTOR_IAM_ROLE }}
+    permissions:
+      id-token: write # required by aws-actions/configure-aws-credentials
+
+  connector-integ-test:
+    name: Python connector integration tests
+    needs: create-cluster
+    runs-on: ubuntu-latest
+    strategy:
+      # Ensure only 1 job uses the workflow cluster at a time.
+      max-parallel: 1
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+    permissions:
+      contents: read
+      id-token: write # required by aws-actions/configure-aws-credentials
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v5
+        with:
+          role-to-assume: ${{ secrets.PYTHON_CONNECTOR_IAM_ROLE }}
+          aws-region: ${{ needs.create-cluster.outputs.region }}
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Run integration tests
+        env:
+          CLUSTER_USER: "admin"
+          CLUSTER_ENDPOINT: ${{ needs.create-cluster.outputs.cluster-endpoint }}
+          REGION: ${{ needs.create-cluster.outputs.region }}
+        run: |
+          uv sync
+          uv run pytest tests/integration
+
+      - name: Run psycopg example smoke tests
+        working-directory: ./examples/psycopg
+        env:
+          CLUSTER_USER: "admin"
+          CLUSTER_ENDPOINT: ${{ needs.create-cluster.outputs.cluster-endpoint }}
+          REGION: ${{ needs.create-cluster.outputs.region }}
+          SSL_CERT_PATH: "./root.pem"
+        run: |
+          uv sync
+          wget https://www.amazontrust.com/repository/AmazonRootCA1.pem -O root.pem
+          uv run pytest
+
+      - name: Run psycopg2 example smoke tests
+        working-directory: ./examples/psycopg2
+        env:
+          CLUSTER_USER: "admin"
+          CLUSTER_ENDPOINT: ${{ needs.create-cluster.outputs.cluster-endpoint }}
+          REGION: ${{ needs.create-cluster.outputs.region }}
+          SSL_CERT_PATH: "./root.pem"
+        run: |
+          uv sync
+          wget https://www.amazontrust.com/repository/AmazonRootCA1.pem -O root.pem
+          uv run pytest
+
+      - name: Run asyncpg example smoke tests
+        working-directory: ./examples/asyncpg
+        env:
+          CLUSTER_USER: "admin"
+          CLUSTER_ENDPOINT: ${{ needs.create-cluster.outputs.cluster-endpoint }}
+          REGION: ${{ needs.create-cluster.outputs.region }}
+          SSL_CERT_PATH: "./root.pem"
+        run: |
+          uv sync
+          wget https://www.amazontrust.com/repository/AmazonRootCA1.pem -O root.pem
+          uv run pytest
+
+  delete-cluster:
+    if: always() && needs.create-cluster.result == 'success'
+    needs: [create-cluster, connector-integ-test]
+    uses: ./.github/workflows/dsql-cluster-delete.yml
+    with:
+      cluster-id: ${{ needs.create-cluster.outputs.cluster-id }}
+      region: ${{ needs.create-cluster.outputs.region }}
+    secrets:
+      AWS_IAM_ROLE: ${{ secrets.PYTHON_CONNECTOR_IAM_ROLE }}
+    permissions:
+      id-token: write # required by aws-actions/configure-aws-credentials

--- a/python/.gitignore
+++ b/python/.gitignore
@@ -1,0 +1,143 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+src/dsql_core/_version.py
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+Pipfile.lock
+
+# poetry
+poetry.lock
+
+# pdm
+.pdm.toml
+
+# PEP 582
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+.idea/
+
+# VS Code
+.vscode/

--- a/python/.mise.toml
+++ b/python/.mise.toml
@@ -1,0 +1,3 @@
+[tools]
+shellcheck = "latest"
+uv = "latest"

--- a/python/.pre-commit-config.yaml
+++ b/python/.pre-commit-config.yaml
@@ -1,0 +1,37 @@
+repos:
+  - repo: https://github.com/Lucas-C/pre-commit-hooks
+    rev: v1.5.5
+    hooks:
+      - id: insert-license
+        files: \.py$
+        args:
+          - --license-filepath=LICENSE_HEADER.txt
+
+  - repo: local
+    hooks:
+      - id: ruff
+        name: ruff
+        entry: uv run ruff check --fix
+        language: system
+        types: [python]
+      - id: ruff-format
+        name: ruff-format
+        entry: uv run ruff format
+        language: system
+        types: [python]
+      - id: mypy
+        name: mypy
+        entry: uv run mypy
+        language: system
+        types: [python]
+
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v4.0.0-alpha.8
+    hooks:
+      - id: prettier
+        types: [yaml]
+
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.4
+    hooks:
+      - id: actionlint

--- a/python/CODE_OF_CONDUCT.md
+++ b/python/CODE_OF_CONDUCT.md
@@ -1,0 +1,4 @@
+## Code of Conduct
+This project has adopted the [Amazon Open Source Code of Conduct](https://aws.github.io/code-of-conduct).
+For more information see the [Code of Conduct FAQ](https://aws.github.io/code-of-conduct-faq) or contact
+opensource-codeofconduct@amazon.com with any additional questions or comments.

--- a/python/CONTRIBUTING.md
+++ b/python/CONTRIBUTING.md
@@ -1,0 +1,59 @@
+# Contributing Guidelines
+
+Thank you for your interest in contributing to our project. Whether it's a bug report, new feature, correction, or additional
+documentation, we greatly value feedback and contributions from our community.
+
+Please read through this document before submitting any issues or pull requests to ensure we have all the necessary
+information to effectively respond to your bug report or contribution.
+
+
+## Reporting Bugs/Feature Requests
+
+We welcome you to use the GitHub issue tracker to report bugs or suggest features.
+
+When filing an issue, please check existing open, or recently closed, issues to make sure somebody else hasn't already
+reported the issue. Please try to include as much information as you can. Details like these are incredibly useful:
+
+* A reproducible test case or series of steps
+* The version of our code being used
+* Any modifications you've made relevant to the bug
+* Anything unusual about your environment or deployment
+
+
+## Contributing via Pull Requests
+Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:
+
+1. You are working against the latest source on the *main* branch.
+2. You check existing open, and recently merged, pull requests to make sure someone else hasn't addressed the problem already.
+3. You open an issue to discuss any significant work - we would hate for your time to be wasted.
+
+To send us a pull request, please:
+
+1. Fork the repository.
+2. Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
+3. Ensure local tests pass.
+4. Commit to your fork using clear commit messages.
+5. Send us a pull request, answering any default questions in the pull request interface.
+6. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
+
+GitHub provides additional document on [forking a repository](https://help.github.com/articles/fork-a-repo/) and
+[creating a pull request](https://help.github.com/articles/creating-a-pull-request/).
+
+
+## Finding contributions to work on
+Looking at the existing issues is a great way to find something to contribute on. As our projects, by default, use the default GitHub issue labels (enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at any 'help wanted' issues is a great place to start.
+
+
+## Code of Conduct
+This project has adopted the [Amazon Open Source Code of Conduct](https://aws.github.io/code-of-conduct).
+For more information see the [Code of Conduct FAQ](https://aws.github.io/code-of-conduct-faq) or contact
+opensource-codeofconduct@amazon.com with any additional questions or comments.
+
+
+## Security issue notifications
+If you discover a potential security issue in this project we ask that you notify AWS/Amazon Security via our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/). Please do **not** create a public github issue.
+
+
+## Licensing
+
+See the [LICENSE](LICENSE) file for our project's licensing. We will ask you to confirm the licensing of your contribution.

--- a/python/LICENSE
+++ b/python/LICENSE
@@ -1,0 +1,175 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.

--- a/python/LICENSE_HEADER.txt
+++ b/python/LICENSE_HEADER.txt
@@ -1,0 +1,2 @@
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0

--- a/python/NOTICE
+++ b/python/NOTICE
@@ -1,0 +1,1 @@
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -71,7 +71,6 @@ Repository = "https://github.com/awslabs/aurora-dsql-python-connector"
 Documentation = "https://github.com/awslabs/aurora-dsql-python-connector"
 "Bug Tracker" = "https://github.com/awslabs/aurora-dsql-python-connector/issues"
 
-
 [tool.hatch.build.targets.wheel]
 packages = ["src/aurora_dsql_asyncpg", "src/aurora_dsql_psycopg", "src/aurora_dsql_psycopg2", "src/dsql_core"]
 


### PR DESCRIPTION
This PR brings in the complete commit history (47 commits) from aurora-dsql-python-connector into the python/ subdirectory.

## Approach

Based on the method used in https://github.com/awslabs/aurora-dsql-orms/pull/2

## What This Does

- Adds aurora-dsql-python-connector as a remote
- Fetches all 47 commits + 5 tags from the python-connector repo
- Creates a temporary branch with the python-connector history
- Moves all files into the python/ subdirectory structure
- Merges using `--no-ff --allow-unrelated-histories` to preserve all commit SHAs

## Result

All original commit SHAs and tags are preserved, maintaining the full development history of the Python connector. Users can now use `git blame` and see the complete evolution of the Python connector code.