### PR TITLE
Configure dependabot to ignore JUnit 6.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,6 +34,12 @@ updates:
     directory: "/java/jdbc"
     schedule:
       interval: "weekly"
+    ignore:
+      # JUnit 6.x requires Java 17+, project targets Java 8
+      - dependency-name: "org.junit.platform:*"
+        versions: [">=6.0.0"]
+      - dependency-name: "org.junit.jupiter:*"
+        versions: [">=6.0.0"]
 
   # Go connector
   - package-ecosystem: "gomod"


### PR DESCRIPTION
This PR configures dependabot to ignore JUnit 6.x releases, since they require Java 17 and are incompatible with this project.

This is related to #9 which is currently failing.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
