### PR TITLE
Fix jreleaserDeploy with Gradle 9.3 configuration cache

### DIFF
--- a/.github/workflows/java-jdbc-release.yml
+++ b/.github/workflows/java-jdbc-release.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           ./gradlew build
           ./gradlew publish
-          ./gradlew jreleaserDeploy
+          ./gradlew jreleaserDeploy --no-configuration-cache
         env:
           JRELEASER_MAVENCENTRAL_STAGE: "UPLOAD"
           JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.GPG_PUBLIC_KEY }}


### PR DESCRIPTION
## Summary

Disable configuration cache for jreleaserDeploy task to work around incompatibility with Gradle 9.3.x.

## Problem

The recent gradle-wrapper bump from 9.1.0 to 9.3.1 broke the Maven Central deploy:

```
Execution failed for task ':jreleaserDeploy'.
> Invocation of 'Task.project' by task ':jreleaserDeploy' at execution time is unsupported with the configuration cache.
```

## Solution

Add `--no-configuration-cache` flag to `jreleaserDeploy` command.