### PR TITLE
Revert JGit to 5.13.x to fix JReleaser GPG signing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,6 +40,10 @@ updates:
         versions: [">=6.0.0"]
       - dependency-name: "org.junit.jupiter:*"
         versions: [">=6.0.0"]
+      # JGit 7.x breaks JReleaser GPG signing. Keep pinned to 5.13.x.
+      # See: https://github.com/jreleaser/jreleaser/issues/1643
+      - dependency-name: "org.eclipse.jgit:*"
+        versions: [">=6.0.0"]
 
   # Go connector
   - package-ecosystem: "gomod"

--- a/java/jdbc/build.gradle.kts
+++ b/java/jdbc/build.gradle.kts
@@ -7,10 +7,11 @@ import java.io.Serializable
 
 // Temporary workaround for JReleaser/Spotless incompatibility.
 // https://github.com/jreleaser/jreleaser/issues/1643
+// JReleaser expects JGit 5.13.x, do NOT upgrade to 7.x (breaks GPG signing).
 buildscript {
     configurations.classpath {
         resolutionStrategy {
-            force("org.eclipse.jgit:org.eclipse.jgit:7.5.0.202512021534-r")
+            force("org.eclipse.jgit:org.eclipse.jgit:5.13.0.202109080827-r")
         }
     }
 }


### PR DESCRIPTION
## Summary
- Reverts JGit from 7.5.0 to 5.13.0.202109080827-r to fix JReleaser deploy failure
- Adds Dependabot ignore rule to prevent future JGit upgrades

## Problem
JGit 7.x restructured GPG support, causing JReleaser to fail with:
```
Execution failed for task ':jreleaserDeploy'.
> org/eclipse/jgit/lib/GpgObjectSigner
```

This broke the Java JDBC release workflow, which cascaded to fail Python and Node.js releases (they wait for CI to pass).

## Root Cause
PR #41 (Dependabot) upgraded JGit from 5.13.0 to 7.5.0. JReleaser 1.21.0 expects JGit 5.13.x and is incompatible with 7.x.

## References
- Original workaround: https://github.com/awslabs/aurora-dsql-jdbc-connector/pull/37
- JReleaser issue: https://github.com/jreleaser/jreleaser/issues/1643
- Dependabot upgrade: #41