### PR TITLE
Add workflow_dispatch to release workflows

### DIFF
--- a/.github/workflows/java-jdbc-release.yml
+++ b/.github/workflows/java-jdbc-release.yml
@@ -3,6 +3,7 @@ name: Deploy Java JDBC to Maven Central
 permissions: {}
 
 on:
+  workflow_dispatch:
   push:
     tags:
       - "java/jdbc/v*"

--- a/.github/workflows/node-postgres-release.yml
+++ b/.github/workflows/node-postgres-release.yml
@@ -3,6 +3,7 @@ name: Publish Node Postgres
 permissions: {}
 
 on:
+  workflow_dispatch:
   push:
     tags:
       - "node/node-postgres/v*"

--- a/.github/workflows/postgres-js-release.yml
+++ b/.github/workflows/postgres-js-release.yml
@@ -3,6 +3,7 @@ name: Publish Postgres.js
 permissions: {}
 
 on:
+  workflow_dispatch:
   push:
     tags:
       - "node/postgres-js/v*"

--- a/.github/workflows/python-connector-release.yml
+++ b/.github/workflows/python-connector-release.yml
@@ -3,6 +3,7 @@ name: Publish Python Connector to PyPI
 permissions: {}
 
 on:
+  workflow_dispatch:
   push:
     tags:
       - "python/connector/v*"


### PR DESCRIPTION
## Summary
Adds `workflow_dispatch` trigger to all 4 release workflows to enable manual triggering.

## Why
GitHub Actions doesn't re-trigger workflows when tags are deleted and recreated with the same name. This allows us to manually trigger releases when needed.

## Changes
- java-jdbc-release.yml
- python-connector-release.yml
- node-postgres-release.yml
- postgres-js-release.yml