### PR TITLE
chore: bump Node package versions for release

### DIFF
--- a/node/node-postgres/package.json
+++ b/node/node-postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws/aurora-dsql-node-postgres-connector",
-  "version": "0.1.7",
+  "version": "0.1.11",
   "description": "An AWS Aurora DSQL connector with IAM authentication for node-postgres",
   "license": "Apache-2.0",
   "repository": {

--- a/node/postgres-js/package.json
+++ b/node/postgres-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws/aurora-dsql-postgresjs-connector",
-  "version": "0.2.0",
+  "version": "0.2.4",
   "description": "An AWS Aurora DSQL connector with IAM authentication for Postgres.js",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Summary
Bump Node package versions so they can be published to npm.

Previous release attempts failed because the package.json versions weren't updated - npm rejected the publish since those versions already exist.

- node-postgres: 0.1.7 -> 0.1.11
- postgres-js: 0.2.0 -> 0.2.4