### PR TITLE
fix: extract Node package versions from git tag during release

### DIFF
--- a/.github/workflows/node-postgres-release.yml
+++ b/.github/workflows/node-postgres-release.yml
@@ -37,6 +37,12 @@ jobs:
           node-version: "25"
           registry-url: "https://registry.npmjs.org"
 
+      - name: Set version from tag
+        run: |
+          VERSION=${GITHUB_REF_NAME#node/node-postgres/v}
+          echo "Setting version to $VERSION"
+          npm version "$VERSION" --no-git-tag-version --allow-same-version
+
       - run: |
           npm ci
           npm run build:prod

--- a/.github/workflows/postgres-js-release.yml
+++ b/.github/workflows/postgres-js-release.yml
@@ -37,6 +37,12 @@ jobs:
           node-version: "25"
           registry-url: "https://registry.npmjs.org"
 
+      - name: Set version from tag
+        run: |
+          VERSION=${GITHUB_REF_NAME#node/postgres-js/v}
+          echo "Setting version to $VERSION"
+          npm version "$VERSION" --no-git-tag-version --allow-same-version
+
       - run: |
           npm ci
           npm run build:prod

--- a/node/node-postgres/package.json
+++ b/node/node-postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws/aurora-dsql-node-postgres-connector",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "An AWS Aurora DSQL connector with IAM authentication for node-postgres",
   "license": "Apache-2.0",
   "repository": {

--- a/node/postgres-js/package.json
+++ b/node/postgres-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws/aurora-dsql-postgresjs-connector",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "An AWS Aurora DSQL connector with IAM authentication for Postgres.js",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Summary

Fixes the Node release workflows to extract version from the git tag instead of relying on package.json. This matches how Python (hatch-vcs) and Java (PROJECT_VERSION env var) connectors work.

### Problem
The previous release attempts failed because:
1. Tags `node/node-postgres/v0.1.10` and `node/postgres-js/v0.2.3` were created
2. But package.json still had versions `0.1.7` and `0.2.0`
3. npm rejected the publish since those versions already exist

### Solution
Add a step to extract version from the git tag and set it in package.json before publishing:
```yaml
- name: Set version from tag
  run: |
    VERSION=${GITHUB_REF_NAME#node/node-postgres/v}
    npm version "$VERSION" --no-git-tag-version --allow-same-version
```

### Changes
- **Workflows**: Add version extraction step to both Node release workflows
- **package.json**: Bump to next sequential versions (0.1.8 and 0.2.1)

### After merging
Create clean sequential release tags:
- `node/node-postgres/v0.1.8` (0.1.7 → 0.1.8, no gap)
- `node/postgres-js/v0.2.1` (0.2.0 → 0.2.1, no gap)