### PR TITLE
fix: enable JReleaser maven deployer at parent level

### DIFF
--- a/java/jdbc/build.gradle.kts
+++ b/java/jdbc/build.gradle.kts
@@ -297,6 +297,7 @@ if ("UPLOAD".equals(System.getenv("JRELEASER_MAVENCENTRAL_STAGE"))) {
 
         deploy {
             maven {
+                active.set(org.jreleaser.model.Active.ALWAYS)
                 mavenCentral {
                     register("sonatype") {
                         active.set(org.jreleaser.model.Active.ALWAYS)


### PR DESCRIPTION
## Summary

The v1.3.3 Java JDBC release workflow completed "successfully" but **did not actually publish to Maven Central**.

### Root Cause
JReleaser logged:
```
[maven] Deploying is not enabled. Skipping
```

The config had `active.set(ALWAYS)` only on the `sonatype` deployer, but the parent `maven` category also needs it:

```kotlin
deploy {
    maven {
        active.set(ALWAYS)  // <-- Added this
        mavenCentral {
            register("sonatype") {
                active.set(ALWAYS)  // Existing
            }
        }
    }
}
```

### After Merging
Need to create a new tag (v1.3.4) to trigger a new release since v1.3.3 is burned.