### PR TITLE
fix: use --no-daemon to ensure fresh env vars for JReleaser

### DIFF
--- a/.github/workflows/java-jdbc-release.yml
+++ b/.github/workflows/java-jdbc-release.yml
@@ -38,9 +38,9 @@ jobs:
 
       - name: Deploy to Central Portal
         run: |
-          ./gradlew build
-          ./gradlew publish
-          ./gradlew jreleaserDeploy --no-configuration-cache
+          ./gradlew build --no-daemon
+          ./gradlew publish --no-daemon
+          ./gradlew jreleaserDeploy --no-daemon --no-configuration-cache
         env:
           JRELEASER_MAVENCENTRAL_STAGE: "UPLOAD"
           JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.GPG_PUBLIC_KEY }}


### PR DESCRIPTION
## Summary
The v1.3.3 release workflow didn't actually deploy to Maven Central despite "succeeding".

### Root Cause
JReleaser logged: `[maven] Deploying is not enabled. Skipping`

The build.gradle.kts has a conditional that checks `JRELEASER_MAVENCENTRAL_STAGE` env var:
```kotlin
if ("UPLOAD".equals(System.getenv("JRELEASER_MAVENCENTRAL_STAGE"))) {
    jreleaser { ... }
}
```

The env var was correctly set in the workflow, but the Gradle daemon may have cached a previous build configuration where this env var wasn't set.

### Fix
Add `--no-daemon` to all Gradle invocations, ensuring each starts a fresh JVM with the current environment variables.

### Testing
After merging:
1. Delete tag `java/jdbc/v1.3.3`
2. Recreate tag on new commit
3. Verify workflow deploys to Maven Central