### PR TITLE
fix: set PROJECT_VERSION from git tag for Java JDBC release

### DIFF
--- a/.github/workflows/java-jdbc-release.yml
+++ b/.github/workflows/java-jdbc-release.yml
@@ -48,7 +48,6 @@ jobs:
           ./gradlew publish
           ./gradlew jreleaserDeploy --no-configuration-cache
         env:
-          PROJECT_VERSION: ${{ env.PROJECT_VERSION }}
           JRELEASER_MAVENCENTRAL_STAGE: "UPLOAD"
           JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.GPG_PUBLIC_KEY }}
           JRELEASER_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}


### PR DESCRIPTION
## Summary

- Extract version from git tag (e.g., `java/jdbc/v1.3.3` → `1.3.3`)
- Pass `PROJECT_VERSION` env var to Gradle so JReleaser gets the correct version

## Problem

The `build.gradle.kts` uses:
```kotlin
version = System.getenv("PROJECT_VERSION") ?: "0.0.0-SNAPSHOT"
```

Without setting `PROJECT_VERSION`, JReleaser sees `0.0.0-SNAPSHOT` and refuses to deploy:
```
[WARN]    [validation] Deployer mavenCentral.sonatype disabled because project is snapshot
[INFO]  Project version set to 0.0.0-SNAPSHOT
```

This is why v1.3.3 "succeeded" but nothing was published to Maven Central.

## Test plan

- [ ] Merge this PR
- [ ] Delete existing `java/jdbc/v1.3.3` tag
- [ ] Create new `java/jdbc/v1.3.3` tag on main
- [ ] Verify workflow extracts version correctly in logs
- [ ] Verify package appears on Maven Central