### PR TITLE
Do not trigger pre-commit on PR (already part of ci-gate)

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -6,8 +6,6 @@ on:
   workflow_call: {}
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This PR removes the `pull_request` trigger for the `pre-commit` workflow, as it's already triggered by the `ci-gate` workflow. Right now it is running twice which is redundant.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
