### PR TITLE
Update junit version for JDBC

### DIFF
--- a/java/jdbc/integration-tests/build.gradle.kts
+++ b/java/jdbc/integration-tests/build.gradle.kts
@@ -17,8 +17,8 @@ tasks.withType<JavaCompile> {
 dependencies {
     testImplementation(project(":"))
 
-    testImplementation("org.junit.jupiter:junit-jupiter:5.9.2")
-    testRuntimeOnly("org.junit.platform:junit-platform-console-standalone:1.9.2")
+    testImplementation("org.junit.jupiter:junit-jupiter:5.14.2")
+    testRuntimeOnly("org.junit.platform:junit-platform-console-standalone:1.14.2")
 }
 
 sourceSets {


### PR DESCRIPTION
This PR replaces #53 and #54, which must be updated together.

The PR CI builds are failing due to incompatibility between the dependencies, which doesn't exist if they are upgraded together.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
