### PR TITLE
chore: use placeholder version in Node package.json files

### DIFF
--- a/node/node-postgres/package.json
+++ b/node/node-postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws/aurora-dsql-node-postgres-connector",
-  "version": "0.1.8",
+  "version": "0.0.0-development",
   "description": "An AWS Aurora DSQL connector with IAM authentication for node-postgres",
   "license": "Apache-2.0",
   "repository": {

--- a/node/postgres-js/package.json
+++ b/node/postgres-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws/aurora-dsql-postgresjs-connector",
-  "version": "0.2.1",
+  "version": "0.0.0-development",
   "description": "An AWS Aurora DSQL connector with IAM authentication for Postgres.js",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Summary
Replace hardcoded versions in Node package.json files with `0.0.0-development` placeholder.

Since PR #66, the release workflow extracts the version from the git tag and sets it during publish:
```bash
VERSION=${GITHUB_REF_NAME#node/node-postgres/v}
npm version "$VERSION" --no-git-tag-version --allow-same-version
```

Using a placeholder version:
- Makes it clear the version is set at release time, not from package.json
- Avoids confusion about what version is "current"
- Eliminates the need to update package.json after each release

## Changes
- `node/node-postgres/package.json`: `0.1.8` → `0.0.0-development`
- `node/postgres-js/package.json`: `0.2.1` → `0.0.0-development`