### PR TITLE
Add manual changelog update workflow

### DIFF
--- a/.github/workflows/java-jdbc-release.yml
+++ b/.github/workflows/java-jdbc-release.yml
@@ -56,20 +56,8 @@ jobs:
           JRELEASER_MAVENCENTRAL_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
 
   update-changelog:
-    name: Update changelog
     needs: deploy
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write # required by rhysd/changelog-from-release/action
-      pull-requests: write # required by rhysd/changelog-from-release/action
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          ref: main
-      - uses: rhysd/changelog-from-release/action@v3
-        with:
-          file: java/jdbc/CHANGELOG.md
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          pull_request: true
-          version: ${{ github.ref_name }}
-          args: -e ^java/jdbc/
+    uses: ./.github/workflows/update-changelog.yml
+    with:
+      tag: ${{ github.ref_name }}
+    secrets: inherit

--- a/.github/workflows/node-postgres-release.yml
+++ b/.github/workflows/node-postgres-release.yml
@@ -50,20 +50,8 @@ jobs:
       - run: npm publish --provenance
 
   update-changelog:
-    name: Update changelog
     needs: publish
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          ref: main
-      - uses: rhysd/changelog-from-release/action@v3
-        with:
-          file: node/node-postgres/CHANGELOG.md
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          pull_request: true
-          version: ${{ github.ref_name }}
-          args: -e ^node/node-postgres/
+    uses: ./.github/workflows/update-changelog.yml
+    with:
+      tag: ${{ github.ref_name }}
+    secrets: inherit

--- a/.github/workflows/postgres-js-release.yml
+++ b/.github/workflows/postgres-js-release.yml
@@ -50,20 +50,8 @@ jobs:
       - run: npm publish --provenance
 
   update-changelog:
-    name: Update changelog
     needs: publish
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          ref: main
-      - uses: rhysd/changelog-from-release/action@v3
-        with:
-          file: node/postgres-js/CHANGELOG.md
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          pull_request: true
-          version: ${{ github.ref_name }}
-          args: -e ^node/postgres-js/
+    uses: ./.github/workflows/update-changelog.yml
+    with:
+      tag: ${{ github.ref_name }}
+    secrets: inherit

--- a/.github/workflows/python-connector-release.yml
+++ b/.github/workflows/python-connector-release.yml
@@ -64,20 +64,8 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
 
   update-changelog:
-    name: Update changelog
     needs: publish-to-pypi
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          ref: main
-      - uses: rhysd/changelog-from-release/action@v3
-        with:
-          file: python/connector/CHANGELOG.md
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          pull_request: true
-          version: ${{ github.ref_name }}
-          args: -e ^python/connector/
+    uses: ./.github/workflows/update-changelog.yml
+    with:
+      tag: ${{ github.ref_name }}
+    secrets: inherit

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -1,0 +1,44 @@
+name: Update Changelog
+
+permissions: {}
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag name (e.g., python/connector/v1.0.0)"
+        required: true
+        type: string
+  workflow_call:
+    inputs:
+      tag:
+        required: true
+        type: string
+
+jobs:
+  update-changelog:
+    name: Update changelog
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # required by rhysd/changelog-from-release/action
+      pull-requests: write # required by rhysd/changelog-from-release/action
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+
+      - name: Determine changelog file
+        id: changelog
+        run: |
+          TAG="${{ inputs.tag }}"
+          PREFIX="${TAG%/v*}"
+          echo "file=${PREFIX}/CHANGELOG.md" >> "$GITHUB_OUTPUT"
+          echo "filter=^${PREFIX}/" >> "$GITHUB_OUTPUT"
+
+      - uses: rhysd/changelog-from-release/action@v3
+        with:
+          file: ${{ steps.changelog.outputs.file }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          pull_request: true
+          version: ${{ inputs.tag }}
+          args: -e ${{ steps.changelog.outputs.filter }}


### PR DESCRIPTION
## Summary
Add a shared workflow for changelog generation that can be:
- Manually triggered via `workflow_dispatch`
- Called by release workflows via `workflow_call`

Updates all release workflows to use this shared workflow instead of inline changelog steps.

Based on the workflow from [aurora-dsql-orms#118](https://github.com/awslabs/aurora-dsql-orms/pull/118).

## Changes
- New: `.github/workflows/update-changelog.yml`
- Updated: `java-jdbc-release.yml`, `node-postgres-release.yml`, `postgres-js-release.yml`, `python-connector-release.yml`

## Usage (manual trigger)
1. Go to Actions → "Update Changelog"
2. Click "Run workflow"
3. Enter the tag name (e.g., `python/connector/v0.2.6`)
4. The workflow will create a PR with the updated changelog