### PR TITLE
Make OCC retry opt-in for Ruby pg connector

### DIFF
--- a/ruby/pg/CHANGELOG.md
+++ b/ruby/pg/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+### Breaking Changes
+- OCC retry on `pool.with` is now opt-in. Set `occ_max_retries` in the pool
+  config to enable automatic retry. Previously retry was enabled by default
+  with a hardcoded limit of 3.
+
 <a id="ruby/pg/v1.0.0"></a>
 # [Aurora DSQL Connector for Ruby pg v1.0.0 (ruby/pg/v1.0.0)](https://github.com/awslabs/aurora-dsql-connectors/releases/tag/ruby/pg/v1.0.0)
 

--- a/ruby/pg/README.md
+++ b/ruby/pg/README.md
@@ -13,7 +13,7 @@ A Ruby connector for Amazon Aurora DSQL that wraps the [pg](https://github.com/g
 - Region auto-detection from endpoint hostname
 - Support for AWS profiles and custom credentials providers
 - SSL always enabled with `verify-full` mode and direct TLS negotiation (libpq 17+)
-- Automatic OCC retry with exponential backoff on `pool.with`
+- Opt-in OCC retry with exponential backoff on `pool.with`
 
 ## Prerequisites
 
@@ -53,18 +53,19 @@ gem install aurora-dsql-ruby-pg
 ```ruby
 require "aurora_dsql_pg"
 
-# Create a connection pool
+# Create a connection pool with OCC retry enabled
 pool = AuroraDsql::Pg.create_pool(
-  host: "your-cluster.dsql.us-east-1.on.aws"
+  host: "your-cluster.dsql.us-east-1.on.aws",
+  occ_max_retries: 3
 )
 
-# Read — no OCC retry needed for reads
-pool.with(retry_occ: false) do |conn|
+# Read
+pool.with do |conn|
   result = conn.exec("SELECT 'Hello, DSQL!'")
   puts result[0]["?column?"]
 end
 
-# Write — OCC retry is automatic, but you must wrap writes in a transaction
+# Write — you must wrap writes in a transaction
 pool.with do |conn|
   conn.transaction do
     conn.exec_params("INSERT INTO users (id, name) VALUES (gen_random_uuid(), $1)", ["Alice"])
@@ -91,6 +92,7 @@ pool.shutdown
 | `max_lifetime` | `Integer` | `3300` (55 min) | Max connection lifetime in seconds |
 | `application_name` | `String` | `nil` | ORM prefix for application_name |
 | `logger` | `Logger` | `nil` | Logger for OCC retry warnings |
+| `occ_max_retries` | `Integer` | `nil` (disabled) | Max OCC retries on `pool.with`; enables retry when set |
 
 ## Connection String Format
 
@@ -114,7 +116,14 @@ The `Connection` wrapper delegates common methods (`exec_params`, `query`, `tran
 
 Aurora DSQL uses optimistic concurrency control (OCC). When two transactions modify the same data, the first to commit wins and the second receives an OCC error.
 
-`pool.with` automatically retries on OCC errors (up to 3 retries with exponential backoff and jitter). No special code is needed.
+OCC retry is **opt-in**. Set `occ_max_retries` when creating the pool to enable automatic retry with exponential backoff and jitter on `pool.with`:
+
+```ruby
+pool = AuroraDsql::Pg.create_pool(
+  host: "your-cluster.dsql.us-east-1.on.aws",
+  occ_max_retries: 3  # retries up to 3 times on OCC conflict
+)
+```
 
 > **Important:** `pool.with` does NOT automatically wrap your block in a transaction. You must call `conn.transaction` yourself for write operations. On OCC conflict the entire block is re-executed, so it should contain only database operations and be safe to retry.
 
@@ -127,7 +136,7 @@ pool.with do |conn|
 end
 ```
 
-To disable automatic retry (e.g., for read-only queries):
+To skip retry on individual calls, pass `retry_occ: false`:
 
 ```ruby
 pool.with(retry_occ: false) do |conn|
@@ -135,7 +144,7 @@ pool.with(retry_occ: false) do |conn|
 end
 ```
 
-For custom retry configuration (different max retries, backoff, etc.), use the `OCCRetry` module directly. Unlike `pool.with`, `OCCRetry.with_retry` automatically wraps the block in a transaction:
+For custom retry configuration (different backoff, etc.), use the `OCCRetry` module directly. Unlike `pool.with`, `OCCRetry.with_retry` automatically wraps the block in a transaction:
 
 ```ruby
 AuroraDsql::Pg::OCCRetry.with_retry(pool, max_retries: 10) do |conn|
@@ -154,6 +163,7 @@ To see OCC retries in your logs, pass a `logger` when creating the pool:
 ```ruby
 pool = AuroraDsql::Pg.create_pool(
   host: "your-cluster.dsql.us-east-1.on.aws",
+  occ_max_retries: 3,
   logger: Logger.new(STDOUT)
 )
 ```
@@ -196,7 +206,7 @@ bundle exec rake integration # Run integration tests (requires CLUSTER_ENDPOINT)
 When using this connector with Aurora DSQL, follow these practices:
 
 1. **UUID Primary Keys**: Always use `UUID DEFAULT gen_random_uuid()` - DSQL doesn't support sequences or SERIAL
-2. **OCC Handling**: DSQL uses optimistic concurrency control. `pool.with` retries OCC errors automatically; for single connections, use `OCCRetry` explicitly
+2. **OCC Handling**: DSQL uses optimistic concurrency control. Enable retry via `occ_max_retries` on the pool; for single connections, use `OCCRetry` explicitly
 3. **No Foreign Keys**: DSQL doesn't support foreign key constraints - enforce relationships in your application
 4. **Async Indexes**: Use `CREATE INDEX ASYNC` for index creation
 5. **Transaction Limits**: Transactions are limited to 3,000 rows, 10 MiB, and 5 minutes

--- a/ruby/pg/example/src/example_preferred.rb
+++ b/ruby/pg/example/src/example_preferred.rb
@@ -12,7 +12,8 @@ def example
 
   pool = AuroraDsql::Pg.create_pool(
     host: cluster_endpoint,
-    pool_size: 10
+    pool_size: 10,
+    occ_max_retries: 3
   )
 
   # Verify connection
@@ -26,7 +27,7 @@ def example
     end
   end
 
-  # Insert data (OCC retry is automatic)
+  # Insert data (OCC retry enabled via occ_max_retries config)
   pool.with do |conn|
     conn.transaction do
       conn.exec_params("INSERT INTO example_items (name) VALUES ($1)", ["test-item"])

--- a/ruby/pg/lib/aurora_dsql/pg/config.rb
+++ b/ruby/pg/lib/aurora_dsql/pg/config.rb
@@ -20,7 +20,7 @@ module AuroraDsql
       attr_accessor :host, :region, :user, :database, :port,
                     :profile, :token_duration, :credentials_provider,
                     :max_lifetime, :pool_size, :checkout_timeout,
-                    :application_name, :logger
+                    :application_name, :logger, :occ_max_retries
 
       def initialize(**options)
         @host = options[:host]
@@ -36,6 +36,7 @@ module AuroraDsql
         @checkout_timeout = options[:checkout_timeout]
         @application_name = options[:application_name]
         @logger = options[:logger]
+        @occ_max_retries = options[:occ_max_retries]
       end
 
       # Parse a connection string into a Config.
@@ -102,7 +103,8 @@ module AuroraDsql
           pool_size: @pool_size || DEFAULTS[:pool_size],
           checkout_timeout: @checkout_timeout || DEFAULTS[:checkout_timeout],
           application_name: @application_name,
-          logger: @logger
+          logger: @logger,
+          occ_max_retries: @occ_max_retries
         ).freeze
       end
 
@@ -134,6 +136,12 @@ module AuroraDsql
           raise Error, "port must be an integer, got #{@port.class}" unless @port.is_a?(Integer)
           raise Error, "port must be between 1 and 65535, got #{@port}" if @port < 1 || @port > 65_535
         end
+
+        if @occ_max_retries
+          unless @occ_max_retries.is_a?(Integer) && @occ_max_retries > 0
+            raise Error, "occ_max_retries must be a positive integer, got #{@occ_max_retries.inspect}"
+          end
+        end
       end
     end
 
@@ -142,7 +150,7 @@ module AuroraDsql
       :host, :region, :user, :database, :port,
       :profile, :token_duration, :credentials_provider,
       :max_lifetime, :pool_size, :checkout_timeout,
-      :application_name, :logger,
+      :application_name, :logger, :occ_max_retries,
       keyword_init: true
     ) do
       # Convert to pg connection parameters hash.

--- a/ruby/pg/lib/aurora_dsql/pg/pool.rb
+++ b/ruby/pg/lib/aurora_dsql/pg/pool.rb
@@ -33,12 +33,20 @@ module AuroraDsql
       MAX_STALE_RETRIES = 10
 
       # Check out a connection and yield it to the block.
-      # Enforces max_lifetime and retries on OCC errors with exponential
-      # backoff unless retry_occ: false is passed.
-      def with(retry_occ: true, &block)
+      # Enforces max_lifetime. Retries on OCC errors only when occ_max_retries
+      # is set in the pool config. Pass retry_occ: false to skip retry on
+      # individual calls.
+      def with(retry_occ: @config.occ_max_retries, &block)
         return checkout_and_execute(&block) unless retry_occ
 
-        OCCRetry.retry_on_occ(logger: @config.logger) { checkout_and_execute(&block) }
+        unless retry_occ.is_a?(Integer) && retry_occ > 0
+          raise ArgumentError,
+                "retry_occ must be false/nil or a positive integer, got #{retry_occ.inspect}. " \
+                "Configure occ_max_retries on the pool instead of passing retry_occ: true"
+        end
+
+        occ_config = OCCRetry::DEFAULT_CONFIG.merge(max_retries: retry_occ)
+        OCCRetry.retry_on_occ(occ_config, logger: @config.logger) { checkout_and_execute(&block) }
       end
 
       # Clear all cached authentication tokens.

--- a/ruby/pg/test/integration/occ_retry_test.rb
+++ b/ruby/pg/test/integration/occ_retry_test.rb
@@ -15,6 +15,7 @@ RSpec.describe "OCC retry integration", order: :defined do
       user: ENV.fetch("CLUSTER_USER", "admin"),
       region: ENV.fetch("REGION", nil),
       pool_size: 5,
+      occ_max_retries: 3,
       logger: Logger.new($stdout)
     )
 

--- a/ruby/pg/test/unit/config_test.rb
+++ b/ruby/pg/test/unit/config_test.rb
@@ -89,6 +89,42 @@ RSpec.describe AuroraDsql::Pg::Config do
       expect { config.resolve }.to raise_error(AuroraDsql::Pg::Error, /port must be an integer/)
     end
 
+    it "raises error for non-integer occ_max_retries" do
+      config = described_class.new(
+        host: "mycluster.dsql.us-east-1.on.aws",
+        occ_max_retries: "three"
+      )
+
+      expect { config.resolve }.to raise_error(AuroraDsql::Pg::Error, /occ_max_retries must be a positive integer/)
+    end
+
+    it "raises error for zero occ_max_retries" do
+      config = described_class.new(
+        host: "mycluster.dsql.us-east-1.on.aws",
+        occ_max_retries: 0
+      )
+
+      expect { config.resolve }.to raise_error(AuroraDsql::Pg::Error, /occ_max_retries must be a positive integer/)
+    end
+
+    it "raises error for negative occ_max_retries" do
+      config = described_class.new(
+        host: "mycluster.dsql.us-east-1.on.aws",
+        occ_max_retries: -1
+      )
+
+      expect { config.resolve }.to raise_error(AuroraDsql::Pg::Error, /occ_max_retries must be a positive integer/)
+    end
+
+    it "raises error for boolean occ_max_retries" do
+      config = described_class.new(
+        host: "mycluster.dsql.us-east-1.on.aws",
+        occ_max_retries: true
+      )
+
+      expect { config.resolve }.to raise_error(AuroraDsql::Pg::Error, /occ_max_retries must be a positive integer/)
+    end
+
     it "allows explicit region override" do
       config = described_class.new(
         host: "mycluster.dsql.us-east-1.on.aws",
@@ -109,7 +145,8 @@ RSpec.describe AuroraDsql::Pg::Config do
         token_duration: 300,
         pool_size: 10,
         checkout_timeout: 10,
-        application_name: "rails"
+        application_name: "rails",
+        occ_max_retries: 5
       )
       resolved = config.resolve
 
@@ -121,6 +158,14 @@ RSpec.describe AuroraDsql::Pg::Config do
       expect(resolved.pool_size).to eq(10)
       expect(resolved.checkout_timeout).to eq(10)
       expect(resolved.application_name).to eq("rails")
+      expect(resolved.occ_max_retries).to eq(5)
+    end
+
+    it "defaults occ_max_retries to nil" do
+      config = described_class.new(host: "mycluster.dsql.us-east-1.on.aws")
+      resolved = config.resolve
+
+      expect(resolved.occ_max_retries).to be_nil
     end
 
     it "passes logger through to resolved config" do

--- a/ruby/pg/test/unit/pool_test.rb
+++ b/ruby/pg/test/unit/pool_test.rb
@@ -83,8 +83,21 @@ RSpec.describe AuroraDsql::Pg::Pool do
   end
 
   describe "OCC retry" do
-    it "retries on OCC error and succeeds on next attempt" do
+    it "does not retry by default when occ_max_retries is not set" do
       pool = described_class.create(host: "cluster.dsql.us-east-1.on.aws")
+
+      call_count = 0
+      expect {
+        pool.with do |_conn|
+          call_count += 1
+          raise StandardError.new("OC000: transaction conflict")
+        end
+      }.to raise_error(StandardError, "OC000: transaction conflict")
+      expect(call_count).to eq(1)
+    end
+
+    it "retries on OCC error and succeeds on next attempt" do
+      pool = described_class.create(host: "cluster.dsql.us-east-1.on.aws", occ_max_retries: 3)
       allow(AuroraDsql::Pg::OCCRetry).to receive(:sleep)
 
       call_count = 0
@@ -99,7 +112,7 @@ RSpec.describe AuroraDsql::Pg::Pool do
     end
 
     it "raises after max retries exceeded" do
-      pool = described_class.create(host: "cluster.dsql.us-east-1.on.aws")
+      pool = described_class.create(host: "cluster.dsql.us-east-1.on.aws", occ_max_retries: 3)
       allow(AuroraDsql::Pg::OCCRetry).to receive(:sleep)
 
       expect {
@@ -110,7 +123,7 @@ RSpec.describe AuroraDsql::Pg::Pool do
     end
 
     it "does not retry non-OCC errors" do
-      pool = described_class.create(host: "cluster.dsql.us-east-1.on.aws")
+      pool = described_class.create(host: "cluster.dsql.us-east-1.on.aws", occ_max_retries: 3)
 
       expect {
         pool.with do |_conn|
@@ -120,7 +133,7 @@ RSpec.describe AuroraDsql::Pg::Pool do
     end
 
     it "skips retry when retry_occ: false" do
-      pool = described_class.create(host: "cluster.dsql.us-east-1.on.aws")
+      pool = described_class.create(host: "cluster.dsql.us-east-1.on.aws", occ_max_retries: 3)
 
       call_count = 0
       expect {
@@ -132,12 +145,48 @@ RSpec.describe AuroraDsql::Pg::Pool do
       expect(call_count).to eq(1)
     end
 
+    it "raises ArgumentError when retry_occ: true is passed explicitly" do
+      pool = described_class.create(host: "cluster.dsql.us-east-1.on.aws", occ_max_retries: 3)
+
+      expect {
+        pool.with(retry_occ: true) { |_conn| }
+      }.to raise_error(ArgumentError, /retry_occ must be false\/nil or a positive integer/)
+    end
+
+    it "skips retry when retry_occ: nil is passed explicitly" do
+      pool = described_class.create(host: "cluster.dsql.us-east-1.on.aws", occ_max_retries: 3)
+
+      call_count = 0
+      expect {
+        pool.with(retry_occ: nil) do |_conn|
+          call_count += 1
+          raise StandardError.new("OC000: transaction conflict")
+        end
+      }.to raise_error(StandardError, "OC000: transaction conflict")
+      expect(call_count).to eq(1)
+    end
+
+    it "respects the configured occ_max_retries count" do
+      pool = described_class.create(host: "cluster.dsql.us-east-1.on.aws", occ_max_retries: 1)
+      allow(AuroraDsql::Pg::OCCRetry).to receive(:sleep)
+
+      call_count = 0
+      expect {
+        pool.with do |_conn|
+          call_count += 1
+          raise StandardError.new("OC000: transaction conflict")
+        end
+      }.to raise_error(AuroraDsql::Pg::Error, /Max retries.*exceeded/)
+      expect(call_count).to eq(2) # initial + 1 retry
+    end
+
     it "logs OCC retries at warn level" do
       logger = double("logger")
       allow(logger).to receive(:warn)
 
       pool = described_class.create(
         host: "cluster.dsql.us-east-1.on.aws",
+        occ_max_retries: 3,
         logger: logger
       )
       allow(AuroraDsql::Pg::OCCRetry).to receive(:sleep)


### PR DESCRIPTION
## Summary
- Change `pool.with` OCC retry from default-on (hardcoded 3 retries) to opt-in via new `occ_max_retries` config option
- When `occ_max_retries` is not set (default `nil`), `pool.with` does not retry OCC errors
- Users enable retry by setting `occ_max_retries` at pool creation time, which also controls the retry count
- `retry_occ: false` on individual `pool.with` calls still works to skip retry
- `OCCRetry.with_retry` and `exec_with_retry` are unchanged (already explicit opt-in)

### Changed files
| File | What changed |
|------|-------------|
| `config.rb` | Added `occ_max_retries` attr, plumbed through to `ResolvedConfig` |
| `pool.rb` | `with()` default changed from `retry_occ: true` to `retry_occ: @config.occ_max_retries` |
| `example_preferred.rb` | Added `occ_max_retries: 3` to pool creation |
| `README.md` | Updated quick start, config table, OCC retry docs, best practices |
| `CHANGELOG.md` | Added breaking change entry |
| `config_test.rb` | Added tests for `occ_max_retries` passthrough and nil default |
| `pool_test.rb` | Added no-retry-by-default test, retry-count-respected test, updated existing OCC tests |
| `occ_retry_test.rb` (integration) | Added `occ_max_retries: 3` to pool creation |

### Not changed (intentionally)
- `occ_retry.rb` — core retry logic and `DEFAULT_CONFIG` unchanged
- `occ_retry_test.rb` (unit) — tests `OCCRetry` module directly, which didn't change

## Test plan
- [x] All 102 unit tests pass locally
- [ ] CI unit tests pass
- [ ] Integration tests pass with `CLUSTER_ENDPOINT` set