### PR TITLE
Replace gitleaks with git-secrets

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -15,4 +15,9 @@ jobs:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v7
       - run: uv sync --directory python/connector
+      - name: Install git-secrets and register AWS patterns
+        run: |
+          git clone https://github.com/awslabs/git-secrets.git /tmp/git-secrets
+          cd /tmp/git-secrets && sudo make install
+          git secrets --register-aws
       - uses: pre-commit/action@v3.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
     hooks:
       - id: actionlint
 
-  - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.21.2
+  - repo: https://github.com/awslabs/git-secrets
+    rev: 7d6b970cbd3c216353cb22b383b70c150140662e
     hooks:
-      - id: gitleaks
+      - id: git-secrets


### PR DESCRIPTION
## Summary
- Replace gitleaks with AWS-maintained git-secrets for pre-commit secret scanning
- Update CI workflow to install git-secrets and register AWS patterns

## Changes
- `.pre-commit-config.yaml`: swap `gitleaks/gitleaks` (v8.21.2) for `awslabs/git-secrets` (1.3.0)
- `.github/workflows/pre-commit.yml`: add step to install git-secrets and run `git secrets --register-aws` before pre-commit

## Local developer setup
git-secrets uses `language: script` in pre-commit, so it needs to be installed on the system:

```bash
# macOS
brew install git-secrets

# Linux
git clone https://github.com/awslabs/git-secrets.git && cd git-secrets && sudo make install
```

Then register AWS patterns in your local clone:

```bash
git secrets --register-aws
```