### PR TITLE
Add Ruby bundler config to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -72,6 +72,14 @@ updates:
         patterns:
           - "github.com/aws/*"
 
+  # Ruby connector
+  - package-ecosystem: "bundler"
+    directories:
+      - "/ruby/pg"
+      - "/ruby/pg/example"
+    schedule:
+      interval: "weekly"
+
   # GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Summary
- Adds weekly Dependabot updates for the Ruby `bundler` ecosystem
- Covers both `/ruby/pg` (connector) and `/ruby/pg/example` directories, grouped in a single entry to keep Gemfile.lock updates consistent

## Test plan
- [ ] Verify Dependabot picks up the new config and opens PRs for Ruby gem updates