### PR TITLE
Add scaffold and release workflow for Rust SQLx connector

### DIFF
--- a/.github/workflows/rust-sqlx-release.yml
+++ b/.github/workflows/rust-sqlx-release.yml
@@ -1,0 +1,52 @@
+name: Publish Rust SQLx Connector to crates.io
+
+permissions: {}
+
+on:
+  push:
+    tags:
+      - "rust/sqlx/v*"
+
+defaults:
+  run:
+    working-directory: rust/sqlx
+
+jobs:
+  wait-for-ci:
+    name: Wait for CI to pass
+    runs-on: ubuntu-latest
+    steps:
+      - uses: lewagon/wait-on-check-action@v1.5.0
+        with:
+          ref: ${{ github.sha }}
+          running-workflow-name: "Wait for CI to pass"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 30
+
+  publish:
+    needs: wait-for-ci
+    runs-on: ubuntu-latest
+    environment: rust
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Set version from tag
+        run: |
+          VERSION="${GITHUB_REF_NAME#rust/sqlx/v}"
+          echo "Publishing version $VERSION"
+          sed -i "s/^version = .*/version = \"$VERSION\"/" Cargo.toml
+
+      - name: Publish to crates.io
+        run: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_KEY }}
+
+  update-changelog:
+    needs: publish
+    uses: ./.github/workflows/update-changelog.yml
+    with:
+      tag: ${{ github.ref_name }}
+    secrets: inherit

--- a/rust/sqlx/Cargo.toml
+++ b/rust/sqlx/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "aurora-dsql-sqlx-connector"
+version = "0.0.1"
+edition = "2021"
+description = "Aurora DSQL connector for SQLx"
+authors = ["Amazon Web Services"]
+license = "Apache-2.0"
+repository = "https://github.com/awslabs/aurora-dsql-connectors"
+homepage = "https://github.com/awslabs/aurora-dsql-connectors/tree/main/rust/sqlx"
+keywords = ["aws", "aurora", "dsql", "postgres", "sqlx"]
+categories = ["database", "authentication"]

--- a/rust/sqlx/src/lib.rs
+++ b/rust/sqlx/src/lib.rs
@@ -1,0 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Aurora DSQL connector for SQLx.
+//!
+//! This crate is under active development.


### PR DESCRIPTION
## Summary
- Adds minimal `aurora-dsql-sqlx-connector` crate (`rust/sqlx/`) to reserve the name on crates.io
- Adds release workflow (`.github/workflows/rust-sqlx-release.yml`) triggered by `rust/sqlx/v*` tags, following the same pattern as the other connector release workflows
- Uses the `rust` GitHub environment with `CRATES_IO_KEY` secret

## To publish
After merging, push tag `rust/sqlx/v0.0.1` to trigger the release workflow.

## Test plan
- [ ] Verify workflow triggers correctly on tag push
- [ ] Verify crate appears on crates.io after publish