### PR TITLE
Use rustup directly in Rust release workflow

### DIFF
--- a/.github/workflows/rust-sqlx-release.yml
+++ b/.github/workflows/rust-sqlx-release.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        run: rustup update stable && rustup default stable
 
       - name: Set version from tag
         run: |


### PR DESCRIPTION
## Summary
- Replaces `dtolnay/rust-toolchain@stable` with `rustup update stable` in the Rust SQLx release workflow
- The action is not on the org allow-list, causing `startup_failure` on tag push

## Test plan
- [ ] Merge, re-tag `rust/sqlx/v0.0.1`, and verify the workflow starts successfully