### PR TITLE
Grant write permissions for changelog in Rust release

### DIFF
--- a/.github/workflows/rust-sqlx-release.yml
+++ b/.github/workflows/rust-sqlx-release.yml
@@ -46,6 +46,9 @@ jobs:
 
   update-changelog:
     needs: publish
+    permissions:
+      contents: write
+      pull-requests: write
     uses: ./.github/workflows/update-changelog.yml
     with:
       tag: ${{ github.ref_name }}


### PR DESCRIPTION
## Summary
- Adds `contents: write` and `pull-requests: write` permissions to the `update-changelog` job in the Rust release workflow
- The reusable `update-changelog` workflow needs these permissions but top-level `permissions: {}` blocks them, causing `startup_failure`

## Test plan
- [ ] Merge, delete and re-push `rust/sqlx/v0.0.2` tag, verify workflow starts