### PR TITLE
Add release workflow for Go pgx connector

### DIFF
--- a/.github/workflows/go-pgx-release.yml
+++ b/.github/workflows/go-pgx-release.yml
@@ -1,0 +1,30 @@
+name: Release Go pgx Connector
+
+permissions: {}
+
+on:
+  push:
+    tags:
+      - "go/pgx/v*"
+
+jobs:
+  wait-for-ci:
+    name: Wait for CI to pass
+    runs-on: ubuntu-latest
+    steps:
+      - uses: lewagon/wait-on-check-action@v1.5.0
+        with:
+          ref: ${{ github.sha }}
+          running-workflow-name: "Wait for CI to pass"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 30
+
+  update-changelog:
+    needs: wait-for-ci
+    permissions:
+      contents: write
+      pull-requests: write
+    uses: ./.github/workflows/update-changelog.yml
+    with:
+      tag: ${{ github.ref_name }}
+    secrets: inherit


### PR DESCRIPTION
## Summary
- Adds `go-pgx-release.yml` triggered on `go/pgx/v*` tags
- Go modules don't need a publish step (the module proxy picks up tags automatically), so this just gates on CI then updates the changelog via the shared reusable workflow
- Follows the same pattern as all other connector release workflows (Rust, Java, Python, Node)

## Context
Go was the only connector without a release workflow. Previous releases (v0.1.1, v0.1.2) were bare git tags with no GitHub Releases or changelog automation.

## After merge
1. Tag `go/pgx/v0.1.3` on main
2. Create GitHub Release with release notes
3. Workflow triggers automatically → waits for CI → generates CHANGELOG.md PR