### PR TITLE
Add scaffold and release workflow for .NET Npgsql connector

### DIFF
--- a/.github/workflows/dotnet-npgsql-release.yml
+++ b/.github/workflows/dotnet-npgsql-release.yml
@@ -1,0 +1,58 @@
+name: Publish .NET Npgsql Connector to NuGet
+
+permissions: {}
+
+on:
+  push:
+    tags:
+      - "dotnet/npgsql/v*"
+
+defaults:
+  run:
+    working-directory: dotnet/npgsql/src/Amazon.AuroraDsql.Npgsql
+
+jobs:
+  wait-for-ci:
+    name: Wait for CI to pass
+    runs-on: ubuntu-latest
+    steps:
+      - uses: lewagon/wait-on-check-action@v1.5.0
+        with:
+          ref: ${{ github.sha }}
+          running-workflow-name: "Wait for CI to pass"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 30
+
+  publish:
+    needs: wait-for-ci
+    runs-on: ubuntu-latest
+    environment: .NET
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "8.0.x"
+
+      - name: Set version from tag
+        run: |
+          VERSION="${GITHUB_REF_NAME#dotnet/npgsql/v}"
+          echo "Publishing version $VERSION"
+          sed -i "s/<Version>.*<\/Version>/<Version>$VERSION<\/Version>/" Amazon.AuroraDsql.Npgsql.csproj
+
+      - name: Pack
+        run: dotnet pack -c Release -o ./nupkg
+
+      - name: Publish to NuGet
+        run: dotnet nuget push ./nupkg/*.nupkg --api-key ${{ secrets.NU_GET_API_KEY }} --source https://api.nuget.org/v3/index.json
+
+  update-changelog:
+    needs: publish
+    permissions:
+      contents: write
+      pull-requests: write
+    uses: ./.github/workflows/update-changelog.yml
+    with:
+      tag: ${{ github.ref_name }}
+    secrets: inherit

--- a/dotnet/npgsql/src/Amazon.AuroraDsql.Npgsql/Amazon.AuroraDsql.Npgsql.csproj
+++ b/dotnet/npgsql/src/Amazon.AuroraDsql.Npgsql/Amazon.AuroraDsql.Npgsql.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <PackageId>Amazon.AuroraDsql.Npgsql</PackageId>
+    <Version>0.0.1</Version>
+    <Authors>Amazon Web Services</Authors>
+    <Description>Aurora DSQL connector for Npgsql</Description>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <RepositoryUrl>https://github.com/awslabs/aurora-dsql-connectors</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/awslabs/aurora-dsql-connectors/tree/main/dotnet/npgsql</PackageProjectUrl>
+    <PackageTags>aws;aurora;dsql;postgres;npgsql</PackageTags>
+  </PropertyGroup>
+
+</Project>

--- a/dotnet/npgsql/src/Amazon.AuroraDsql.Npgsql/AuroraDsql.cs
+++ b/dotnet/npgsql/src/Amazon.AuroraDsql.Npgsql/AuroraDsql.cs
@@ -1,0 +1,12 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace Amazon.AuroraDsql.Npgsql;
+
+/// <summary>
+/// Aurora DSQL connector for Npgsql.
+/// This package is under active development.
+/// </summary>
+public static class AuroraDsql
+{
+}


### PR DESCRIPTION
## Summary
- Reserve `Amazon.AuroraDsql.Npgsql` package name on NuGet
- Minimal project scaffold (csproj + stub class) at version 0.0.1
- Tag-based release workflow (`dotnet/npgsql/v*`) using `.NET` environment

Mirrors the Rust SQLx crate reservation (#168).

## Test plan
- [ ] Merge and tag `dotnet/npgsql/v0.0.1`
- [ ] Verify workflow publishes to NuGet successfully
- [ ] Confirm package appears on nuget.org