### PR TITLE
Add release workflow for Ruby pg connector

### DIFF
--- a/.github/workflows/ruby-pg-release.yml
+++ b/.github/workflows/ruby-pg-release.yml
@@ -1,0 +1,61 @@
+name: Publish Ruby pg Connector to RubyGems
+
+permissions: {}
+
+on:
+  push:
+    tags:
+      - "ruby/pg/v*"
+
+defaults:
+  run:
+    working-directory: ruby/pg
+
+jobs:
+  wait-for-ci:
+    name: Wait for CI to pass
+    runs-on: ubuntu-latest
+    steps:
+      - uses: lewagon/wait-on-check-action@v1.5.0
+        with:
+          ref: ${{ github.sha }}
+          running-workflow-name: "Wait for CI to pass"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 30
+
+  publish:
+    needs: wait-for-ci
+    runs-on: ubuntu-latest
+    environment: ruby
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+          working-directory: ruby/pg
+
+      - name: Set version from tag
+        run: |
+          VERSION="${GITHUB_REF_NAME#ruby/pg/v}"
+          echo "Publishing version $VERSION"
+          sed -i "s/VERSION = .*/VERSION = \"$VERSION\"/" lib/aurora_dsql/pg/version.rb
+
+      - name: Build gem
+        run: gem build aurora-dsql-ruby-pg.gemspec
+
+      - name: Publish to RubyGems
+        run: gem push aurora-dsql-ruby-pg-*.gem
+        env:
+          GEM_HOST_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
+
+  update-changelog:
+    needs: publish
+    permissions:
+      contents: write
+      pull-requests: write
+    uses: ./.github/workflows/update-changelog.yml
+    with:
+      tag: ${{ github.ref_name }}
+    secrets: inherit

--- a/ruby/pg/CHANGELOG.md
+++ b/ruby/pg/CHANGELOG.md
@@ -1,13 +1,3 @@
-## Unreleased
-
-### Breaking Changes
-- OCC retry on `pool.with` is now opt-in. Set `occ_max_retries` in the pool
-  config to enable automatic retry. Previously retry was enabled by default
-  with a hardcoded limit of 3.
-- Removed token caching from connection pool. Token generation is a local
-  SigV4 presigning operation with no network overhead, so caching is
-  unnecessary. The `clear_token_cache` method has been removed from `Pool`.
-
 <a id="ruby/pg/v1.0.0"></a>
 # [Aurora DSQL Connector for Ruby pg v1.0.0 (ruby/pg/v1.0.0)](https://github.com/awslabs/aurora-dsql-connectors/releases/tag/ruby/pg/v1.0.0)
 
@@ -17,7 +7,7 @@ Initial release of Aurora DSQL Ruby pg Connector
 - Automatic IAM token generation
 - Connection pooling via `connection_pool` gem with max_lifetime enforcement
 - Single connection support for simpler use cases
-- Automatic OCC retry with exponential backoff on `pool.with`
+- Opt-in OCC retry with exponential backoff on `pool.with`
 - Flexible host configuration (full endpoint or cluster ID)
 - Region auto-detection from endpoint hostname
 - Support for AWS profiles and custom credentials providers


### PR DESCRIPTION
## Summary
- Add `ruby-pg-release.yml` workflow following the established release
  pattern (wait-for-ci → publish to RubyGems → update changelog)
- Clean up `ruby/pg/CHANGELOG.md` for v1.0.0 initial release: fold
  unreleased section and correct OCC retry description to opt-in

## Test plan
- [ ] Verify workflow triggers on `ruby/pg/v*` tag push
- [ ] Confirm gem builds and publishes to RubyGems
- [ ] Confirm changelog update PR is created after publish