### PR TITLE
Use OIDC + Secrets Manager for NuGet API key

### DIFF
--- a/.github/workflows/dotnet-npgsql-release.yml
+++ b/.github/workflows/dotnet-npgsql-release.yml
@@ -27,6 +27,9 @@ jobs:
     needs: wait-for-ci
     runs-on: ubuntu-latest
     environment: .NET
+    permissions:
+      id-token: write # required for requesting the JWT
+      contents: read # required for actions/checkout
     steps:
       - uses: actions/checkout@v6
 
@@ -34,6 +37,22 @@ jobs:
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: "8.0.x"
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.NUGET_PUBLISH_IAM_ROLE }}
+          role-session-name: dotnet-npgsql-nuget-publish
+          aws-region: us-west-2
+
+      - name: Get NuGet API Key
+        run: |
+          NUGET_API_KEY=$(aws secretsmanager get-secret-value \
+            --secret-id "production/build/AuroraDsql-nuget-api-key" \
+            --query 'SecretString' \
+            --output text)
+          echo "::add-mask::$NUGET_API_KEY"
+          echo "NUGET_API_KEY=$NUGET_API_KEY" >> "$GITHUB_ENV"
 
       - name: Set version from tag
         run: |
@@ -45,7 +64,7 @@ jobs:
         run: dotnet pack -c Release -o ./nupkg
 
       - name: Publish to NuGet
-        run: dotnet nuget push ./nupkg/*.nupkg --api-key ${{ secrets.NU_GET_API_KEY }} --source https://api.nuget.org/v3/index.json
+        run: dotnet nuget push ./nupkg/*.nupkg --api-key ${{ env.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
 
   update-changelog:
     needs: publish


### PR DESCRIPTION
# Details
- Replace direct `NU_GET_API_KEY` GitHub secret with AWS OIDC flow for NuGet publishing
- The `Amazon.*` namespace on NuGet is protected and requires a special API key stored in AWS Secrets Manager
- Workflow now assumes an IAM role via GitHub OIDC, fetches the key from Secrets Manager, and uses it to publish

Note I followed https://docs.github.com/en/actions/how-tos/secure-your-work/security-harden-deployments/oidc-in-aws#updating-your-github-actions-workflow

# Env
- GitHub secret `NUGET_PUBLISH_IAM_ROLE` was added
- IAM role trust policy must allow GitHub OIDC for this repo

## Test plan
- [ ] Tag a release `dotnet/npgsql/v0.0.1` and verify the workflow succeeds
- [ ] Confirm package appears on nuget.org under `Amazon.AuroraDsql.Npgsql`