### PR TITLE
Parse JSON secret for NuGet API key

### DIFF
--- a/.github/workflows/dotnet-npgsql-release.yml
+++ b/.github/workflows/dotnet-npgsql-release.yml
@@ -47,10 +47,11 @@ jobs:
 
       - name: Get NuGet API Key
         run: |
-          NUGET_API_KEY=$(aws secretsmanager get-secret-value \
+          SECRET_JSON=$(aws secretsmanager get-secret-value \
             --secret-id "production/build/AuroraDsql-nuget-api-key" \
             --query 'SecretString' \
             --output text)
+          NUGET_API_KEY=$(echo "$SECRET_JSON" | jq -r '.Key')
           echo "::add-mask::$NUGET_API_KEY"
           echo "NUGET_API_KEY=$NUGET_API_KEY" >> "$GITHUB_ENV"
 


### PR DESCRIPTION
## Summary
- The NuGet API key in Secrets Manager is stored as JSON `{"Key":"..."}`, not a plain string
- Extract the `Key` field with `jq` before passing to `dotnet nuget push`

## Context
OIDC + Secrets Manager flow is working. The publish step got a 403 because it was passing the raw JSON as the API key instead of the extracted value.