### PR TITLE
Rename example() to run_queries() in ruby manual_token

### DIFF
--- a/ruby/pg/example/src/alternatives/manual_token/example.rb
+++ b/ruby/pg/example/src/alternatives/manual_token/example.rb
@@ -41,7 +41,7 @@ def create_connection(cluster_user, cluster_endpoint, region)
   PG.connect(conn_params)
 end
 
-def example(conn)
+def run_queries(conn)
   # Create table
   conn.transaction do
     conn.exec('CREATE TABLE IF NOT EXISTS owner (
@@ -82,7 +82,7 @@ def main()
     if cluster_user != 'admin'
       conn.exec("SET search_path = myschema")
     end
-    example(conn)
+    run_queries(conn)
     puts "Ruby test passed"
   rescue => error
     puts error.full_message


### PR DESCRIPTION
## Summary

- Rename `example(conn)` → `run_queries(conn)` in `ruby/pg/example/src/alternatives/manual_token/example.rb`
- Both `example_preferred.rb` and `manual_token/example.rb` defined top-level `def example` with different signatures (0 args vs 1 arg)
- When RSpec loads both test files in the same process, the second definition overwrites the first on `Object`, causing `ArgumentError: wrong number of arguments`
- This broke the `ruby-pg` CI on the samples repo sync PR (aws-samples/aurora-dsql-samples#404)

## Test plan

- [ ] Verify `ruby-pg` integ tests pass (both preferred and manual_token tests in same RSpec process)
- [ ] Trigger sync workflow on samples repo and verify CI passes