### PR TITLE
Fix incorrect max token duration claim in Go connector

### DIFF
--- a/go/pgx/README.md
+++ b/go/pgx/README.md
@@ -50,7 +50,7 @@ go get github.com/awslabs/aurora-dsql-connectors/go/pgx/dsql
 | `Database` | `string` | `"postgres"` | Database name |
 | `Port` | `int` | `5432` | Database port |
 | `Profile` | `string` | `""` | AWS profile name for credentials |
-| `TokenDurationSecs` | `int` | `900` (15 min) | Token validity duration in seconds |
+| `TokenDurationSecs` | `int` | `900` (15 min) | Token validity duration in seconds (max 1 week) |
 | `CustomCredentialsProvider` | `aws.CredentialsProvider` | `nil` | Custom AWS credentials provider |
 | `MaxConns` | `int32` | `0` | Maximum pool connections (0 = pgxpool default) |
 | `MinConns` | `int32` | `0` | Minimum pool connections (0 = pgxpool default) |
@@ -215,7 +215,7 @@ The connector automatically generates IAM authentication tokens:
 
 For the `admin` user, the connector generates admin tokens using `GenerateDBConnectAdminAuthToken`. For other users, it generates standard tokens using `GenerateDbConnectAuthToken`.
 
-Token duration defaults to 15 minutes (the maximum allowed by Aurora DSQL).
+Token duration defaults to 15 minutes (recommended). The maximum allowed token lifetime is 1 week.
 
 ## Development
 

--- a/go/pgx/dsql/config.go
+++ b/go/pgx/dsql/config.go
@@ -39,7 +39,6 @@ const (
 	// DefaultMaxConnIdleTime is the default maximum idle time (10 minutes)
 	DefaultMaxConnIdleTime = 10 * time.Minute
 	// DefaultTokenDuration is the default token validity duration (15 minutes)
-	// This is the maximum allowed by Aurora DSQL
 	DefaultTokenDuration = 15 * time.Minute
 )
 

--- a/go/pgx/dsql/config_test.go
+++ b/go/pgx/dsql/config_test.go
@@ -38,7 +38,7 @@ func TestConfigDefaultTokenDuration(t *testing.T) {
 	resolved, err := cfg.resolve()
 	require.NoError(t, err)
 
-	// Should default to 15 minutes
+	// Should default to 15 minutes (recommended default)
 	assert.Equal(t, 15*time.Minute, resolved.TokenDuration)
 }
 


### PR DESCRIPTION
## Summary
- Removed incorrect comment claiming 15 minutes is the maximum token duration allowed by Aurora DSQL
- Clarified that 15 minutes is the recommended default, and the actual maximum token lifetime is 1 week (per ARC limits)
- Updated README documentation to reflect the correct limits

## Files changed
- `go/pgx/dsql/config.go` — removed misleading "maximum allowed by Aurora DSQL" comment
- `go/pgx/dsql/config_test.go` — clarified comment about default being recommended, not a max
- `go/pgx/README.md` — updated config table and token duration section with correct max (1 week)

## Test plan
- [ ] Verify Go unit tests still pass (`go test ./...` in `go/pgx/`)
- [ ] Review that no other references to 15-minute max remain