### PR TITLE
Accept pgxpool.Config directly in NewPool

### DIFF
--- a/go/pgx/README.md
+++ b/go/pgx/README.md
@@ -52,11 +52,8 @@ go get github.com/awslabs/aurora-dsql-connectors/go/pgx/dsql
 | `Profile` | `string` | `""` | AWS profile name for credentials |
 | `TokenDurationSecs` | `int` | `900` (15 min) | Token validity duration in seconds (max 1 week) |
 | `CustomCredentialsProvider` | `aws.CredentialsProvider` | `nil` | Custom AWS credentials provider |
-| `MaxConns` | `int32` | `0` | Maximum pool connections (0 = pgxpool default) |
-| `MinConns` | `int32` | `0` | Minimum pool connections (0 = pgxpool default) |
-| `MaxConnLifetime` | `time.Duration` | `55 minutes` | Maximum connection lifetime (aligns with DSQL characteristics) |
-| `MaxConnIdleTime` | `time.Duration` | `10 minutes` | Maximum idle time before connection is closed |
-| `HealthCheckPeriod` | `time.Duration` | `0` | Interval between health checks |
+
+Pool configuration is passed directly via `*pgxpool.Config` as a separate parameter to `NewPool`. See [Pool Configuration Tuning](#pool-configuration-tuning) for details.
 
 ## Quick Start
 
@@ -164,18 +161,31 @@ pool, err := dsql.NewPool(ctx, dsql.Config{
 
 ### Pool Configuration Tuning
 
-Configure the connection pool for your workload:
+Pool settings are configured via an optional `*pgxpool.Config` parameter to `NewPool`.
+When omitted, the connector applies DSQL-specific defaults:
+- `MaxConnLifetime`: 55 minutes (connections timeout after 60 minutes)
+- `MaxConnIdleTime`: 10 minutes
+
+All other fields use pgxpool defaults. To customize, create a config via
+`pgxpool.ParseConfig` and override the fields you need:
 
 ```go
+poolCfg, _ := pgxpool.ParseConfig("")
+poolCfg.MaxConns = 20
+poolCfg.MinConns = 5
+poolCfg.MaxConnLifetime = time.Hour
+poolCfg.MaxConnIdleTime = 30 * time.Minute
+poolCfg.MaxConnLifetimeJitter = 5 * time.Minute
+poolCfg.HealthCheckPeriod = time.Minute
+
 pool, err := dsql.NewPool(ctx, dsql.Config{
-    Host:              "your-cluster.dsql.us-east-1.on.aws",
-    MaxConns:          20,
-    MinConns:          5,
-    MaxConnLifetime:   time.Hour,
-    MaxConnIdleTime:   30 * time.Minute,
-    HealthCheckPeriod: time.Minute,
-})
+    Host: "your-cluster.dsql.us-east-1.on.aws",
+}, poolCfg)
 ```
+
+Setting `MaxConnLifetimeJitter` is recommended to prevent all connections from expiring simultaneously, which can cause a thundering herd of reconnections.
+
+See [pgxpool.Config](https://pkg.go.dev/github.com/jackc/pgx/v5/pgxpool#Config) for all available options.
 
 ### Single Connection Usage
 
@@ -287,7 +297,7 @@ When using this connector with Aurora DSQL, follow these practices:
 3. **No Foreign Keys**: DSQL doesn't support foreign key constraints - enforce relationships in your application
 4. **Async Indexes**: Use `CREATE INDEX ASYNC` for index creation
 5. **Transaction Limits**: Transactions are limited to 3,000 rows, 10 MiB, and 5 minutes
-6. **Connection Limits**: Connections timeout after 60 minutes; configure pool `MaxConnLifetime` accordingly
+6. **Connection Limits**: Connections timeout after 60 minutes; configure `MaxConnLifetime` on your `pgxpool.Config` accordingly
 7. **No SAVEPOINT**: Partial rollbacks via SAVEPOINT are not supported
 
 ## Additional Resources

--- a/go/pgx/dsql/config.go
+++ b/go/pgx/dsql/config.go
@@ -67,13 +67,6 @@ type Config struct {
 
 	// CustomCredentialsProvider is a custom AWS credentials provider. Optional.
 	CustomCredentialsProvider aws.CredentialsProvider
-
-	// Pool configuration options (passed through to pgxpool)
-	MaxConns          int32
-	MinConns          int32
-	MaxConnLifetime   time.Duration
-	MaxConnIdleTime   time.Duration
-	HealthCheckPeriod time.Duration
 }
 
 // resolvedConfig holds the validated and resolved configuration with all
@@ -87,11 +80,6 @@ type resolvedConfig struct {
 	Profile                   string
 	TokenDuration             time.Duration
 	CustomCredentialsProvider aws.CredentialsProvider
-	MaxConns                  int32
-	MinConns                  int32
-	MaxConnLifetime           time.Duration
-	MaxConnIdleTime           time.Duration
-	HealthCheckPeriod         time.Duration
 }
 
 // resolve validates the configuration, applies defaults, and resolves the
@@ -109,11 +97,6 @@ func (c *Config) resolve() (*resolvedConfig, error) {
 		Port:                      c.Port,
 		Profile:                   c.Profile,
 		CustomCredentialsProvider: c.CustomCredentialsProvider,
-		MaxConns:                  c.MaxConns,
-		MinConns:                  c.MinConns,
-		MaxConnLifetime:           c.MaxConnLifetime,
-		MaxConnIdleTime:           c.MaxConnIdleTime,
-		HealthCheckPeriod:         c.HealthCheckPeriod,
 	}
 
 	// Apply defaults
@@ -128,12 +111,6 @@ func (c *Config) resolve() (*resolvedConfig, error) {
 	}
 	if resolved.Port < 1 || resolved.Port > 65535 {
 		return nil, fmt.Errorf("port must be between 1 and 65535, got %d", resolved.Port)
-	}
-	if resolved.MaxConnLifetime == 0 {
-		resolved.MaxConnLifetime = DefaultMaxConnLifetime
-	}
-	if resolved.MaxConnIdleTime == 0 {
-		resolved.MaxConnIdleTime = DefaultMaxConnIdleTime
 	}
 
 	// Convert token duration with default

--- a/go/pgx/dsql/pool.go
+++ b/go/pgx/dsql/pool.go
@@ -20,8 +20,15 @@ type Pool struct {
 }
 
 // NewPool creates a new connection pool to Aurora DSQL.
+//
 // The config parameter can be a Config struct, *Config, or a connection string.
-func NewPool(ctx context.Context, config any) (*Pool, error) {
+//
+// The optional poolConfig parameter allows direct configuration of the underlying pgxpool.
+// It must be created via [pgxpool.ParseConfig]. If omitted, sensible defaults are applied
+// (MaxConnLifetime: 55min, MaxConnIdleTime: 10min). Any BeforeConnect callback set on
+// poolConfig will be chained with the connector's IAM token generation (user callback
+// runs first).
+func NewPool(ctx context.Context, config any, poolConfig ...*pgxpool.Config) (*Pool, error) {
 	var cfg *Config
 
 	switch c := config.(type) {
@@ -47,45 +54,56 @@ func NewPool(ctx context.Context, config any) (*Pool, error) {
 		return nil, err
 	}
 
-	return newPoolFromResolved(ctx, resolved)
+	var pc *pgxpool.Config
+	if len(poolConfig) > 0 {
+		pc = poolConfig[0]
+	}
+
+	return newPoolFromResolved(ctx, resolved, pc)
 }
 
-func newPoolFromResolved(ctx context.Context, resolved *resolvedConfig) (*Pool, error) {
+func newPoolFromResolved(ctx context.Context, resolved *resolvedConfig, poolConfig *pgxpool.Config) (*Pool, error) {
 	credentialsProvider, err := resolveCredentialsProvider(ctx, resolved)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve credentials provider: %w", err)
 	}
 
-	poolConfig, err := pgxpool.ParseConfig("")
-	if err != nil {
-		return nil, fmt.Errorf("unable to create pool config: %w", err)
+	applyDSQLDefaults := poolConfig == nil
+	if poolConfig == nil {
+		poolConfig, err = pgxpool.ParseConfig("")
+		if err != nil {
+			return nil, fmt.Errorf("unable to create pool config: %w", err)
+		}
 	}
 
 	resolved.configureConnConfig(poolConfig.ConnConfig)
+
+	// Apply DSQL-optimized defaults. When no pool config was provided,
+	// always override pgxpool defaults. When the user provides their own
+	// config, only fill in zero values so that users who don't explicitly
+	// set lifetimes still get safe connection recycling on DSQL (where
+	// connections timeout server-side after 60 minutes).
+	if applyDSQLDefaults || poolConfig.MaxConnLifetime == 0 {
+		poolConfig.MaxConnLifetime = DefaultMaxConnLifetime
+	}
+	if applyDSQLDefaults || poolConfig.MaxConnIdleTime == 0 {
+		poolConfig.MaxConnIdleTime = DefaultMaxConnIdleTime
+	}
+
+	// Chain with any user-provided BeforeConnect callback
+	userBeforeConnect := poolConfig.BeforeConnect
 	poolConfig.BeforeConnect = func(ctx context.Context, cfg *pgx.ConnConfig) error {
+		if userBeforeConnect != nil {
+			if err := userBeforeConnect(ctx, cfg); err != nil {
+				return err
+			}
+		}
 		token, err := GenerateToken(ctx, resolved.Host, resolved.Region, resolved.User, credentialsProvider, resolved.TokenDuration)
 		if err != nil {
 			return err
 		}
 		cfg.Password = token
 		return nil
-	}
-
-	// Apply pool configuration
-	if resolved.MaxConns > 0 {
-		poolConfig.MaxConns = resolved.MaxConns
-	}
-	if resolved.MinConns > 0 {
-		poolConfig.MinConns = resolved.MinConns
-	}
-	if resolved.MaxConnLifetime > 0 {
-		poolConfig.MaxConnLifetime = resolved.MaxConnLifetime
-	}
-	if resolved.MaxConnIdleTime > 0 {
-		poolConfig.MaxConnIdleTime = resolved.MaxConnIdleTime
-	}
-	if resolved.HealthCheckPeriod > 0 {
-		poolConfig.HealthCheckPeriod = resolved.HealthCheckPeriod
 	}
 
 	pool, err := pgxpool.NewWithConfig(ctx, poolConfig)

--- a/go/pgx/dsql/pool_test.go
+++ b/go/pgx/dsql/pool_test.go
@@ -9,7 +9,9 @@ import (
 	"context"
 	"os"
 	"testing"
+	"time"
 
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -84,7 +86,34 @@ func TestPoolQuery(t *testing.T) {
 	assert.Equal(t, 1, result)
 }
 
-func TestPoolWithCustomConfig(t *testing.T) {
+func TestPoolWithCustomPoolConfig(t *testing.T) {
+	endpoint := os.Getenv("CLUSTER_ENDPOINT")
+	region := os.Getenv("REGION")
+	if endpoint == "" || region == "" {
+		t.Skip("CLUSTER_ENDPOINT and REGION required for pool test")
+	}
+
+	ctx := context.Background()
+
+	poolCfg, err := pgxpool.ParseConfig("")
+	require.NoError(t, err)
+	poolCfg.MaxConns = 5
+	poolCfg.MinConns = 1
+
+	pool, err := NewPool(ctx, Config{
+		Host:   endpoint,
+		Region: region,
+	}, poolCfg)
+	require.NoError(t, err)
+	defer pool.Close()
+
+	// Verify pool config
+	actualCfg := pool.Config()
+	assert.Equal(t, int32(5), actualCfg.MaxConns)
+	assert.Equal(t, int32(1), actualCfg.MinConns)
+}
+
+func TestPoolDefaultsApplied(t *testing.T) {
 	endpoint := os.Getenv("CLUSTER_ENDPOINT")
 	region := os.Getenv("REGION")
 	if endpoint == "" || region == "" {
@@ -94,16 +123,43 @@ func TestPoolWithCustomConfig(t *testing.T) {
 	ctx := context.Background()
 
 	pool, err := NewPool(ctx, Config{
-		Host:     endpoint,
-		Region:   region,
-		MaxConns: 5,
-		MinConns: 1,
+		Host:   endpoint,
+		Region: region,
 	})
 	require.NoError(t, err)
 	defer pool.Close()
 
-	// Verify pool config
-	poolConfig := pool.Config()
-	assert.Equal(t, int32(5), poolConfig.MaxConns)
-	assert.Equal(t, int32(1), poolConfig.MinConns)
+	// Verify DSQL defaults are applied
+	actualCfg := pool.Config()
+	assert.Equal(t, 55*time.Minute, actualCfg.MaxConnLifetime)
+	assert.Equal(t, 10*time.Minute, actualCfg.MaxConnIdleTime)
+}
+
+func TestPoolUserConfigPreserved(t *testing.T) {
+	endpoint := os.Getenv("CLUSTER_ENDPOINT")
+	region := os.Getenv("REGION")
+	if endpoint == "" || region == "" {
+		t.Skip("CLUSTER_ENDPOINT and REGION required for pool test")
+	}
+
+	ctx := context.Background()
+
+	poolCfg, err := pgxpool.ParseConfig("")
+	require.NoError(t, err)
+	poolCfg.MaxConnLifetime = 30 * time.Minute
+	poolCfg.MaxConnIdleTime = 5 * time.Minute
+	poolCfg.MaxConnLifetimeJitter = 3 * time.Minute
+
+	pool, err := NewPool(ctx, Config{
+		Host:   endpoint,
+		Region: region,
+	}, poolCfg)
+	require.NoError(t, err)
+	defer pool.Close()
+
+	// Verify user-provided values are preserved, not overwritten by defaults
+	actualCfg := pool.Config()
+	assert.Equal(t, 30*time.Minute, actualCfg.MaxConnLifetime)
+	assert.Equal(t, 5*time.Minute, actualCfg.MaxConnIdleTime)
+	assert.Equal(t, 3*time.Minute, actualCfg.MaxConnLifetimeJitter)
 }

--- a/go/pgx/example/src/example_preferred.go
+++ b/go/pgx/example/src/example_preferred.go
@@ -14,16 +14,19 @@ import (
 	"sync"
 
 	"github.com/awslabs/aurora-dsql-connectors/go/pgx/dsql"
+	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 const numConcurrentQueries = 8
 
 func createPool(ctx context.Context, clusterEndpoint string) (*dsql.Pool, error) {
+	poolCfg, _ := pgxpool.ParseConfig("")
+	poolCfg.MaxConns = 10
+	poolCfg.MinConns = 2
+
 	return dsql.NewPool(ctx, dsql.Config{
-		Host:     clusterEndpoint,
-		MaxConns: 10,
-		MinConns: 2,
-	})
+		Host: clusterEndpoint,
+	}, poolCfg)
 }
 
 // workerResult holds either a successful result or an error from a worker.

--- a/go/pgx/example/src/occ_retry/example.go
+++ b/go/pgx/example/src/occ_retry/example.go
@@ -23,6 +23,7 @@ import (
 	"github.com/awslabs/aurora-dsql-connectors/go/pgx/dsql"
 	"github.com/awslabs/aurora-dsql-connectors/go/pgx/occretry"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 // Counter represents a simple counter entity.
@@ -114,10 +115,12 @@ func Example() error {
 
 	ctx := context.Background()
 
+	poolCfg, _ := pgxpool.ParseConfig("")
+	poolCfg.MaxConns = 10
+
 	pool, err := dsql.NewPool(ctx, dsql.Config{
-		Host:     clusterEndpoint,
-		MaxConns: 10,
-	})
+		Host: clusterEndpoint,
+	}, poolCfg)
 	if err != nil {
 		return fmt.Errorf("failed to create pool: %w", err)
 	}

--- a/go/pgx/example/src/transaction/example.go
+++ b/go/pgx/example/src/transaction/example.go
@@ -28,6 +28,7 @@ import (
 	"github.com/awslabs/aurora-dsql-connectors/go/pgx/dsql"
 	"github.com/awslabs/aurora-dsql-connectors/go/pgx/occretry"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 // Account represents a bank account for the transfer demo.
@@ -167,10 +168,12 @@ func Example() error {
 
 	ctx := context.Background()
 
+	poolCfg, _ := pgxpool.ParseConfig("")
+	poolCfg.MaxConns = 5
+
 	pool, err := dsql.NewPool(ctx, dsql.Config{
-		Host:     clusterEndpoint,
-		MaxConns: 5,
-	})
+		Host: clusterEndpoint,
+	}, poolCfg)
 	if err != nil {
 		return fmt.Errorf("create pool: %w", err)
 	}


### PR DESCRIPTION
## Summary

- Remove pool configuration fields from `dsql.Config` (`MaxConns`, `MinConns`, `MaxConnLifetime`, `MaxConnIdleTime`, `HealthCheckPeriod`)
- `NewPool` now accepts an optional `*pgxpool.Config` variadic parameter, exposing the full pgxpool configuration surface directly
- This enables `MaxConnLifetimeJitter`, `MinIdleConns`, `PingTimeout`, and all pgxpool callbacks without the connector needing to mirror every field

## Motivation

Without connection lifetime jitter (`MaxConnLifetimeJitter`), all pool connections created around the same time expire simultaneously, causing a thundering herd of reconnections — each requiring IAM token generation. The connector previously had no way to configure this.

Rather than adding fields one-by-one, this accepts `*pgxpool.Config` directly so all current and future pgxpool options are available.

## Behavior

- `NewPool(ctx, config)` — DSQL defaults applied (55min lifetime, 10min idle)
- `NewPool(ctx, config, poolCfg)` — user owns all pool settings
- `BeforeConnect` callbacks are chained (user's runs first, then IAM token injection)

## Breaking change

`dsql.Config` no longer has pool fields. Callers setting `MaxConns`, `MinConns`, etc. must pass a `*pgxpool.Config` instead:

```go
// Before
dsql.NewPool(ctx, dsql.Config{Host: "...", MaxConns: 10})

// After
dsql.NewPool(ctx, dsql.Config{Host: "..."}, &pgxpool.Config{MaxConns: 10})
```

No public use: https://pkg.go.dev/github.com/awslabs/aurora-dsql-connectors/go/pgx/dsql

Also for V1 connector breaking changes are "okay" (obviously not ideal) but better to get it right early on.

## Test plan

- [ ] Verify CI build passes
- [ ] Run integration tests with `CLUSTER_ENDPOINT` set
- [ ] `TestPoolDefaultsApplied` — verifies DSQL defaults with no pool config
- [ ] `TestPoolUserConfigPreserved` — verifies user settings (including `MaxConnLifetimeJitter`) aren't overwritten
- [ ] `TestPoolWithCustomPoolConfig` — verifies pool config passthrough