### PR TITLE
Pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -15,7 +15,7 @@ jobs:
       pull-requests: write # required to approve PR
       contents: write # required to enable auto-merge
     steps:
-      - uses: dependabot/fetch-metadata@v2
+      - uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2
 
       - name: Approve and enable auto-merge
         env:

--- a/.github/workflows/dotnet-npgsql-release.yml
+++ b/.github/workflows/dotnet-npgsql-release.yml
@@ -16,7 +16,7 @@ jobs:
     name: Wait for CI to pass
     runs-on: ubuntu-latest
     steps:
-      - uses: lewagon/wait-on-check-action@v1.5.0
+      - uses: lewagon/wait-on-check-action@74049309dfeff245fe8009a0137eacf28136cb3c # v1.5.0
         with:
           ref: ${{ github.sha }}
           running-workflow-name: "Wait for CI to pass"

--- a/.github/workflows/go-pgx-release.yml
+++ b/.github/workflows/go-pgx-release.yml
@@ -12,7 +12,7 @@ jobs:
     name: Wait for CI to pass
     runs-on: ubuntu-latest
     steps:
-      - uses: lewagon/wait-on-check-action@v1.5.0
+      - uses: lewagon/wait-on-check-action@74049309dfeff245fe8009a0137eacf28136cb3c # v1.5.0
         with:
           ref: ${{ github.sha }}
           running-workflow-name: "Wait for CI to pass"

--- a/.github/workflows/java-jdbc-release.yml
+++ b/.github/workflows/java-jdbc-release.yml
@@ -16,7 +16,7 @@ jobs:
     name: Wait for CI to pass
     runs-on: ubuntu-latest
     steps:
-      - uses: lewagon/wait-on-check-action@v1.5.0
+      - uses: lewagon/wait-on-check-action@74049309dfeff245fe8009a0137eacf28136cb3c # v1.5.0
         with:
           ref: ${{ github.sha }}
           running-workflow-name: "Wait for CI to pass"

--- a/.github/workflows/node-postgres-release.yml
+++ b/.github/workflows/node-postgres-release.yml
@@ -16,7 +16,7 @@ jobs:
     name: Wait for CI to pass
     runs-on: ubuntu-latest
     steps:
-      - uses: lewagon/wait-on-check-action@v1.5.0
+      - uses: lewagon/wait-on-check-action@74049309dfeff245fe8009a0137eacf28136cb3c # v1.5.0
         with:
           ref: ${{ github.sha }}
           running-workflow-name: "Wait for CI to pass"

--- a/.github/workflows/postgres-js-release.yml
+++ b/.github/workflows/postgres-js-release.yml
@@ -16,7 +16,7 @@ jobs:
     name: Wait for CI to pass
     runs-on: ubuntu-latest
     steps:
-      - uses: lewagon/wait-on-check-action@v1.5.0
+      - uses: lewagon/wait-on-check-action@74049309dfeff245fe8009a0137eacf28136cb3c # v1.5.0
         with:
           ref: ${{ github.sha }}
           running-workflow-name: "Wait for CI to pass"

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -20,4 +20,4 @@ jobs:
           git clone https://github.com/awslabs/git-secrets.git /tmp/git-secrets
           cd /tmp/git-secrets && sudo make install
           git secrets --register-aws
-      - uses: pre-commit/action@v3.0.1
+      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/.github/workflows/python-connector-release.yml
+++ b/.github/workflows/python-connector-release.yml
@@ -16,7 +16,7 @@ jobs:
     name: Wait for CI to pass
     runs-on: ubuntu-latest
     steps:
-      - uses: lewagon/wait-on-check-action@v1.5.0
+      - uses: lewagon/wait-on-check-action@74049309dfeff245fe8009a0137eacf28136cb3c # v1.5.0
         with:
           ref: ${{ github.sha }}
           running-workflow-name: "Wait for CI to pass"

--- a/.github/workflows/ruby-pg-release.yml
+++ b/.github/workflows/ruby-pg-release.yml
@@ -16,7 +16,7 @@ jobs:
     name: Wait for CI to pass
     runs-on: ubuntu-latest
     steps:
-      - uses: lewagon/wait-on-check-action@v1.5.0
+      - uses: lewagon/wait-on-check-action@74049309dfeff245fe8009a0137eacf28136cb3c # v1.5.0
         with:
           ref: ${{ github.sha }}
           running-workflow-name: "Wait for CI to pass"

--- a/.github/workflows/rust-sqlx-release.yml
+++ b/.github/workflows/rust-sqlx-release.yml
@@ -16,7 +16,7 @@ jobs:
     name: Wait for CI to pass
     runs-on: ubuntu-latest
     steps:
-      - uses: lewagon/wait-on-check-action@v1.5.0
+      - uses: lewagon/wait-on-check-action@74049309dfeff245fe8009a0137eacf28136cb3c # v1.5.0
         with:
           ref: ${{ github.sha }}
           running-workflow-name: "Wait for CI to pass"


### PR DESCRIPTION
## Summary
Pin third-party GitHub Actions to commit SHAs to prevent supply chain attacks via tag mutation. Version tags are kept as inline comments for readability.

## Actions pinned

| Action | Version | Commit SHA | Files |
|--------|---------|------------|-------|
| `lewagon/wait-on-check-action` | v1.5.0 | `74049309dfeff245fe8009a0137eacf28136cb3c` | 8 release workflows |
| `dependabot/fetch-metadata` | v2 | `21025c705c08248db411dc16f3619e6b5f9ea21a` | dependabot-automerge.yml |
| `pre-commit/action` | v3.0.1 | `2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd` | pre-commit.yml |

## Verification
Each SHA was resolved from the corresponding version tag via the GitHub Git refs API, with annotated tags dereferenced to their target commit.