### PR TITLE
Harden CI config from appsec review

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -80,6 +80,20 @@ updates:
     schedule:
       interval: "weekly"
 
+  # Rust connector
+  - package-ecosystem: "cargo"
+    directory: "/rust/sqlx"
+    schedule:
+      interval: "weekly"
+
+  # .NET connector
+  - package-ecosystem: "nuget"
+    directories:
+      - "/dotnet/npgsql/src/Amazon.AuroraDsql.Npgsql"
+      - "/dotnet/npgsql/example"
+    schedule:
+      interval: "weekly"
+
   # GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -21,7 +21,7 @@ jobs:
       ruby-pg: ${{ steps.detect.outputs.ruby-pg }}
       dotnet-npgsql: ${{ steps.detect.outputs.dotnet-npgsql }}
     steps:
-      - uses: actions/github-script@v8
+      - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         id: detect
         with:
           script: |
@@ -148,7 +148,7 @@ jobs:
       - dotnet-npgsql
     if: always()
     steps:
-      - uses: actions/github-script@v8
+      - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             const needs = ${{ toJSON(needs) }};

--- a/.github/workflows/dotnet-npgsql-ci.yml
+++ b/.github/workflows/dotnet-npgsql-ci.yml
@@ -31,10 +31,10 @@ jobs:
       id-token: write # required by aws-actions/configure-aws-credentials
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
         with:
           dotnet-version: "8.0.x"
 
@@ -72,7 +72,7 @@ jobs:
         run: curl -o /tmp/global-bundle.pem https://www.amazontrust.com/repository/AmazonRootCA1.pem
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
           aws-region: ${{ needs.create-cluster.outputs.region }}

--- a/.github/workflows/dotnet-npgsql-release.yml
+++ b/.github/workflows/dotnet-npgsql-release.yml
@@ -31,15 +31,15 @@ jobs:
       id-token: write # required for requesting the JWT
       contents: read # required for actions/checkout
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
         with:
           dotnet-version: "8.0.x"
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6
         with:
           role-to-assume: ${{ secrets.NUGET_PUBLISH_IAM_ROLE }}
           role-session-name: dotnet-npgsql-nuget-publish

--- a/.github/workflows/dsql-cluster-create.yml
+++ b/.github/workflows/dsql-cluster-create.yml
@@ -42,7 +42,7 @@ jobs:
 
     steps:
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
           aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/dsql-cluster-delete.yml
+++ b/.github/workflows/dsql-cluster-delete.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
           aws-region: ${{ inputs.region }}

--- a/.github/workflows/go-pgx-ci.yml
+++ b/.github/workflows/go-pgx-ci.yml
@@ -31,15 +31,15 @@ jobs:
       GOPRIVATE: github.com/awslabs/aurora-dsql-connectors
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           go-version: "1.24"
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
           aws-region: ${{ needs.create-cluster.outputs.region }}

--- a/.github/workflows/java-jdbc-ci.yml
+++ b/.github/workflows/java-jdbc-ci.yml
@@ -29,10 +29,10 @@ jobs:
     needs: setup
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up JDK ${{ needs.setup.outputs.build-version }}
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           java-version: ${{ needs.setup.outputs.build-version }}
           distribution: "corretto"
@@ -43,7 +43,7 @@ jobs:
         run: ./gradlew build -x test
 
       - name: Upload integration test jar
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: integration-test-jar
           path: java/jdbc/integration-tests/build/libs/*-all.jar
@@ -53,10 +53,10 @@ jobs:
     needs: [setup, build]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up JDK ${{ needs.setup.outputs.build-version }}
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           java-version: ${{ needs.setup.outputs.build-version }}
           distribution: "corretto"
@@ -84,10 +84,10 @@ jobs:
       id-token: write # required by aws-actions/configure-aws-credentials
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up JDK ${{ needs.setup.outputs.build-version }}
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           java-version: ${{ needs.setup.outputs.build-version }}
           distribution: "corretto"
@@ -95,7 +95,7 @@ jobs:
           cache: gradle
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
           aws-region: ${{ needs.create-cluster.outputs.region }}
@@ -126,23 +126,23 @@ jobs:
         jvm-version: ${{ fromJson(needs.setup.outputs.target-versions) }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up JDK ${{ matrix.jvm-version }}
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           java-version: ${{ matrix.jvm-version }}
           distribution: "corretto"
           architecture: x64
 
       - name: Download integration test jar
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: integration-test-jar
           path: java/jdbc
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
           aws-region: ${{ needs.create-cluster.outputs.region }}

--- a/.github/workflows/java-jdbc-release.yml
+++ b/.github/workflows/java-jdbc-release.yml
@@ -28,10 +28,10 @@ jobs:
     runs-on: ubuntu-latest
     environment: maven
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up JDK 25
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           java-version: "25"
           distribution: "corretto"

--- a/.github/workflows/node-postgres-ci.yml
+++ b/.github/workflows/node-postgres-ci.yml
@@ -46,15 +46,15 @@ jobs:
         node-version: ${{ fromJson(needs.setup.outputs.target-versions) }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: ${{ matrix.node-version }}
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
           aws-region: ${{ needs.create-cluster.outputs.region }}

--- a/.github/workflows/node-postgres-release.yml
+++ b/.github/workflows/node-postgres-release.yml
@@ -30,9 +30,9 @@ jobs:
     permissions:
       id-token: write # required for trusted publishing
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: "25"
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/postgres-js-ci.yml
+++ b/.github/workflows/postgres-js-ci.yml
@@ -46,15 +46,15 @@ jobs:
         node-version: ${{ fromJson(needs.setup.outputs.target-versions) }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: ${{ matrix.node-version }}
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
           aws-region: ${{ needs.create-cluster.outputs.region }}

--- a/.github/workflows/postgres-js-release.yml
+++ b/.github/workflows/postgres-js-release.yml
@@ -30,9 +30,9 @@ jobs:
     permissions:
       id-token: write # required for trusted publishing
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: "25"
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -12,8 +12,8 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v7
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
       - run: uv sync --directory python/connector
       - name: Install git-secrets and register AWS patterns
         run: |

--- a/.github/workflows/python-connector-ci.yml
+++ b/.github/workflows/python-connector-ci.yml
@@ -35,16 +35,16 @@ jobs:
       id-token: write # required by aws-actions/configure-aws-credentials
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
           aws-region: ${{ needs.create-cluster.outputs.region }}
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/python-connector-release.yml
+++ b/.github/workflows/python-connector-release.yml
@@ -28,18 +28,18 @@ jobs:
     needs: wait-for-ci
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
 
       - name: Build distribution packages
         run: uv build
 
       - name: Store the distribution packages
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: python-package-distributions
           path: python/connector/dist/
@@ -56,12 +56,12 @@ jobs:
 
     steps:
       - name: Download all the dists
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: python-package-distributions
           path: dist/
       - name: Publish distribution package to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # release/v1
 
   update-changelog:
     needs: publish-to-pypi

--- a/.github/workflows/ruby-pg-ci.yml
+++ b/.github/workflows/ruby-pg-ci.yml
@@ -44,10 +44,10 @@ jobs:
         ruby-version: ${{ fromJson(needs.setup.outputs.target-versions) }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@dffb23f65a78bba8db45d387d5ea1bbd6be3ef18 # v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true
@@ -62,7 +62,7 @@ jobs:
           wget -q https://www.amazontrust.com/repository/AmazonRootCA1.pem -O ~/.postgresql/root.crt
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
           aws-region: ${{ needs.create-cluster.outputs.region }}

--- a/.github/workflows/ruby-pg-release.yml
+++ b/.github/workflows/ruby-pg-release.yml
@@ -28,10 +28,10 @@ jobs:
     runs-on: ubuntu-latest
     environment: ruby
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@dffb23f65a78bba8db45d387d5ea1bbd6be3ef18 # v1
         with:
           ruby-version: "3.3"
           working-directory: ruby/pg

--- a/.github/workflows/rust-sqlx-release.yml
+++ b/.github/workflows/rust-sqlx-release.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: rust
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install Rust toolchain
         run: rustup update stable && rustup default stable

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -23,7 +23,7 @@ jobs:
       contents: write # required by rhysd/changelog-from-release/action
       pull-requests: write # required by rhysd/changelog-from-release/action
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: main
 
@@ -35,7 +35,7 @@ jobs:
           echo "file=${PREFIX}/CHANGELOG.md" >> "$GITHUB_OUTPUT"
           echo "filter=^${PREFIX}/" >> "$GITHUB_OUTPUT"
 
-      - uses: rhysd/changelog-from-release/action@v3
+      - uses: rhysd/changelog-from-release/action@78b335bb7d059f35ad04c5428d50711726feee50 # v3
         with:
           file: ${{ steps.changelog.outputs.file }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,9 @@ obj/
 # IDE
 .idea/
 *.iml
+
+# Secrets & credentials
+.env
+*.pem
+*.key
+*.p12


### PR DESCRIPTION
## Summary
- Pin all 13 third-party GitHub Actions to commit SHAs across 19 workflow files (version tags kept as inline comments for readability and Dependabot compatibility)
- Add missing Dependabot entries for `cargo` (Rust) and `nuget` (.NET) ecosystems
- Add `.env`, `*.pem`, `*.key`, `*.p12` to `.gitignore` as defense-in-depth

## Context
Addresses findings from an appsec review of the repository:
- **Finding 4a/4b (Medium):** Rust and .NET ecosystems missing from Dependabot config
- **Finding 5a (Medium):** GitHub Actions pinned to mutable tags instead of commit SHAs
- **Minor:** `.gitignore` lacked credential file patterns

## Test plan
- [ ] Verify Dependabot picks up the new `cargo` and `nuget` entries
- [ ] Confirm CI workflows still pass with SHA-pinned actions
- [ ] Validate no YAML syntax issues in modified files