### PR TITLE
Remove unused gitleaks-action Dependabot ignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -99,5 +99,3 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "gitleaks/gitleaks-action"


### PR DESCRIPTION
## Summary
- Remove stale `gitleaks/gitleaks-action` ignore from Dependabot config

## Context
This repo uses `awslabs/git-secrets` via pre-commit for secret scanning, not `gitleaks-action`. The ignore entry was likely left over from a previous setup and is a no-op.

Flagged during appsec review of #212.