### PR TITLE
Add Dependabot coverage for Java example project

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,7 +44,9 @@ updates:
 
   # Java connector
   - package-ecosystem: "gradle"
-    directory: "/java/jdbc"
+    directories:
+      - "/java/jdbc"
+      - "/java/jdbc/examples/pgjdbc"
     schedule:
       interval: "weekly"
     ignore:


### PR DESCRIPTION
## Summary
- Switch Java Dependabot entry from `directory` to `directories` to also cover `/java/jdbc/examples/pgjdbc`

## Context
The example project has its own `build.gradle.kts` with independent dependencies (HikariCP, JUnit) that were not receiving automated update PRs.

The existing `ignore` rules for JUnit 6.x and JGit 7.x carry over to both directories.