### PR TITLE
Add Gemfile.lock for Ruby example project

### DIFF
--- a/ruby/pg/.gitignore
+++ b/ruby/pg/.gitignore
@@ -7,5 +7,5 @@
 /pkg/
 /spec/reports/
 /tmp/
-Gemfile.lock
+/Gemfile.lock
 .rspec_status

--- a/ruby/pg/example/Gemfile.lock
+++ b/ruby/pg/example/Gemfile.lock
@@ -1,0 +1,68 @@
+PATH
+  remote: ..
+  specs:
+    aurora-dsql-ruby-pg (1.0.0)
+      aws-sdk-dsql (~> 1.6)
+      connection_pool (>= 2.4, < 4.0)
+      pg (~> 1.5)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    aws-eventstream (1.4.0)
+    aws-partitions (1.1227.0)
+    aws-sdk-core (3.243.0)
+      aws-eventstream (~> 1, >= 1.3.0)
+      aws-partitions (~> 1, >= 1.992.0)
+      aws-sigv4 (~> 1.9)
+      base64
+      bigdecimal
+      jmespath (~> 1, >= 1.6.1)
+      logger
+    aws-sdk-dsql (1.25.0)
+      aws-sdk-core (~> 3, >= 3.241.4)
+      aws-sigv4 (~> 1.5)
+    aws-sigv4 (1.12.1)
+      aws-eventstream (~> 1, >= 1.0.2)
+    base64 (0.3.0)
+    bigdecimal (4.0.1)
+    connection_pool (3.0.2)
+    diff-lcs (1.6.2)
+    jmespath (1.6.2)
+    logger (1.7.0)
+    pg (1.6.3)
+    pg (1.6.3-aarch64-linux)
+    pg (1.6.3-aarch64-linux-musl)
+    pg (1.6.3-arm64-darwin)
+    pg (1.6.3-x86_64-darwin)
+    pg (1.6.3-x86_64-linux)
+    pg (1.6.3-x86_64-linux-musl)
+    rspec (3.13.2)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.6)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.5)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.8)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.7)
+
+PLATFORMS
+  aarch64-linux
+  aarch64-linux-musl
+  arm64-darwin
+  ruby
+  x86_64-darwin
+  x86_64-linux
+  x86_64-linux-musl
+
+DEPENDENCIES
+  aurora-dsql-ruby-pg!
+  aws-sdk-dsql (~> 1.6)
+  pg (~> 1.5)
+  rspec (~> 3.13)
+


### PR DESCRIPTION
## Summary
- Add `Gemfile.lock` for `ruby/pg/example/` to pin dependency versions
- Scope `ruby/pg/.gitignore` to only ignore the library root lockfile (`/Gemfile.lock`), allowing the example's lockfile to be tracked

## Context
The example directory is an application (not a library), so committing a lockfile ensures reproducible builds. The library root correctly omits its lockfile per Ruby gem conventions.