### PR TITLE
Add missing example READMEs and admin/non-admin support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ This monorepo contains database driver connectors for [Amazon Aurora DSQL](https
 
 ## Available Connectors
 
+### .NET
+
+| Package | Description | NuGet | License |
+|---------|-------------|-------|---------|
+| [Amazon.AuroraDsql.Npgsql](./dotnet/npgsql/) | Npgsql connector for Aurora DSQL | [![NuGet](https://img.shields.io/nuget/v/Amazon.AuroraDsql.Npgsql)](https://www.nuget.org/packages/Amazon.AuroraDsql.Npgsql) | ![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg) |
+
 ### Go
 
 | Package | Description | Module | License |
@@ -29,16 +35,22 @@ This monorepo contains database driver connectors for [Amazon Aurora DSQL](https
 |---------|-------------|------|---------|
 | [aurora-dsql-python-connector](./python/connector/) | Python connectors for Aurora DSQL (psycopg, psycopg2, asyncpg) | [![PyPI](https://img.shields.io/pypi/v/aurora-dsql-python-connector)](https://pypi.org/project/aurora-dsql-python-connector/) | ![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg) |
 
+### Ruby
+
+| Package | Description | RubyGems | License |
+|---------|-------------|----------|---------|
+| [aurora-dsql-ruby-pg](./ruby/pg/) | pg connector for Aurora DSQL | [![Gem Version](https://img.shields.io/gem/v/aurora-dsql-ruby-pg)](https://rubygems.org/gems/aurora-dsql-ruby-pg) | ![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg) |
+
 ## Installation
 
 Each connector is published as an independent package. Install the one you need:
 
 ```bash
-# Python (with psycopg support)
-pip install aurora-dsql-python-connector[psycopg]
+# .NET
+dotnet add package Amazon.AuroraDsql.Npgsql
 
-# Python (with asyncpg support)
-pip install aurora-dsql-python-connector[asyncpg]
+# Go
+go get github.com/awslabs/aurora-dsql-connectors/go/pgx
 
 # Node.js (node-postgres)
 npm install @aws/aurora-dsql-node-postgres-connector
@@ -46,8 +58,14 @@ npm install @aws/aurora-dsql-node-postgres-connector
 # Node.js (postgres.js)
 npm install @aws/aurora-dsql-postgresjs-connector
 
-# Go
-go get github.com/awslabs/aurora-dsql-connectors/go/pgx
+# Python (with psycopg support)
+pip install aurora-dsql-python-connector[psycopg]
+
+# Python (with asyncpg support)
+pip install aurora-dsql-python-connector[asyncpg]
+
+# Ruby
+gem install aurora-dsql-ruby-pg
 ```
 
 For Java connectors, see the [Java JDBC connector documentation](./java/jdbc/README.md) for Maven/Gradle installation instructions.
@@ -56,11 +74,13 @@ For Java connectors, see the [Java JDBC connector documentation](./java/jdbc/REA
 
 See the README in each connector's directory for detailed usage instructions:
 
+- [.NET Npgsql connector documentation](./dotnet/npgsql/README.md)
 - [Go pgx connector documentation](./go/pgx/README.md)
 - [Java JDBC connector documentation](./java/jdbc/README.md)
 - [Node.js node-postgres connector documentation](./node/node-postgres/README.md)
 - [Node.js postgres.js connector documentation](./node/postgres-js/README.md)
 - [Python connector documentation](./python/connector/README.md)
+- [Ruby pg connector documentation](./ruby/pg/README.md)
 
 ## Versioning
 

--- a/dotnet/npgsql/example/README.md
+++ b/dotnet/npgsql/example/README.md
@@ -1,0 +1,122 @@
+# Aurora DSQL with Npgsql
+
+## Overview
+
+This code example demonstrates how to use `Npgsql` with Amazon Aurora DSQL.
+The example shows you how to connect to an Aurora DSQL cluster and perform basic database operations.
+
+Aurora DSQL is a distributed SQL database service that provides high availability and scalability for
+your PostgreSQL-compatible applications. `Npgsql` is a popular PostgreSQL adapter for .NET that allows
+you to interact with PostgreSQL databases using C# code.
+
+This example uses the Aurora DSQL Npgsql Connector to handle IAM authentication automatically.
+
+## About the code example
+
+The example demonstrates a flexible connection approach that works for both admin and non-admin users:
+
+* When connecting as an **admin user**, the example uses the `public` schema.
+* When connecting as a **non-admin user**, the example uses a custom `myschema` schema.
+
+The code automatically detects the user type and adjusts its behavior accordingly.
+
+It creates a connection pool via `AuroraDsql.CreateDataSourceAsync`, runs multiple concurrent queries,
+and performs a transactional insert with automatic OCC retry.
+
+## ⚠️ Important
+
+* Running this code might result in charges to your AWS account.
+* We recommend that you grant your code least privilege. At most, grant only the
+  minimum permissions required to perform the task. For more information, see
+  [Grant least privilege](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#grant-least-privilege).
+* This code is not tested in every AWS Region. For more information, see
+  [AWS Regional Services](https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services).
+
+## TLS connection configuration
+
+This example uses direct TLS connections where supported, and verifies the server certificate is trusted. Verified SSL
+connections should be used where possible to ensure data security during transmission.
+
+* Driver versions following the release of PostgreSQL 17 support direct TLS connections, bypassing the traditional
+  PostgreSQL connection preamble
+* Direct TLS connections provide improved connection performance and enhanced security
+* Not all PostgreSQL drivers support direct TLS connections yet, or only in recent versions following PostgreSQL 17
+* Ensure your installed driver version supports direct TLS negotiation, or use a version that is at least as recent as
+  the one used in this sample
+* If your driver doesn't support direct TLS connections, you may need to use the traditional preamble connection instead
+
+## Run the example
+
+### Prerequisites
+
+* You must have an AWS account, and have your default credentials and AWS Region
+  configured as described in the
+  [Globally configuring AWS SDKs and tools](https://docs.aws.amazon.com/credref/latest/refdocs/creds-config-files.html)
+  guide.
+* .NET SDK: Ensure you have .NET 8.0+ installed.
+
+   _To verify .NET is installed, you can run_
+   ```bash
+   dotnet --version
+   ```
+
+* You must have an Aurora DSQL cluster. For information about creating an Aurora DSQL cluster, see the
+  [Getting started with Aurora DSQL](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/getting-started.html)
+  guide.
+* If connecting as a non-admin user, ensure the user is linked to an IAM role and is granted access to the `myschema`
+  schema. See the
+  [Using database roles with IAM roles](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/using-database-and-iam-roles.html)
+  guide.
+
+### Run the code
+
+The example demonstrates the following operations:
+
+- Opening a connection pool to an Aurora DSQL cluster
+- Running concurrent queries across multiple connections
+- Performing a transactional write with OCC retry
+- Cleaning up test data
+
+The example is designed to work with both admin and non-admin users:
+
+- When run as an admin user, it uses the `public` schema
+- When run as a non-admin user, it uses the `myschema` schema
+
+**Note:** running the example will use actual resources in your AWS account and may incur charges.
+
+Set environment variables for your cluster details:
+
+```bash
+# e.g. "admin"
+export CLUSTER_USER="<your user>"
+
+# e.g. "foo0bar1baz2quux3quuux4.dsql.us-east-1.on.aws"
+export CLUSTER_ENDPOINT="<your endpoint>"
+```
+
+Run the example:
+
+```bash
+dotnet test --filter "ExamplePreferredTest"
+```
+
+Run all examples (including alternatives):
+
+```bash
+dotnet test
+```
+
+The example contains comments explaining the code and the operations being performed.
+
+## Additional resources
+
+* [Amazon Aurora DSQL Documentation](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/what-is-aurora-dsql.html)
+* [Amazon Aurora DSQL Npgsql Connector](https://github.com/awslabs/aurora-dsql-connectors/tree/main/dotnet/npgsql)
+* [Npgsql Documentation](https://www.npgsql.org/doc/)
+* [AWS SDK for .NET Documentation](https://docs.aws.amazon.com/sdk-for-net/v3/developer-guide/welcome.html)
+
+---
+
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0

--- a/dotnet/npgsql/example/src/ExamplePreferred.cs
+++ b/dotnet/npgsql/example/src/ExamplePreferred.cs
@@ -9,20 +9,30 @@ namespace Amazon.AuroraDsql.Npgsql.Examples;
 /// <summary>
 /// Preferred example: demonstrates pool creation, concurrent reads,
 /// transactional writes, and cleanup using the DSQL connector.
+///
+/// Works with both admin and non-admin users:
+/// - Admin users operate in the default "public" schema
+/// - Non-admin users operate in a custom "myschema" schema
 /// </summary>
 public static class ExamplePreferred
 {
     private const int NumConcurrentQueries = 8;
 
-    public static async Task RunAsync(string clusterEndpoint)
+    public static async Task RunAsync(string clusterEndpoint, string clusterUser = "admin")
     {
+        // Determine schema based on user type
+        var schema = clusterUser == "admin" ? "public" : "myschema";
+
         // Create a connection pool via the connector
         await using var ds = await AuroraDsql.CreateDataSourceAsync(new DsqlConfig
         {
             Host = clusterEndpoint,
+            User = clusterUser,
             MaxPoolSize = 10,
             MinPoolSize = 2,
             OccMaxRetries = 3,
+            // Set search_path so all connections from the pool use the correct schema
+            ConfigureConnectionString = csb => csb.SearchPath = schema,
         });
 
         // Verify connectivity

--- a/dotnet/npgsql/example/test/ExamplePreferredTest.cs
+++ b/dotnet/npgsql/example/test/ExamplePreferredTest.cs
@@ -14,7 +14,8 @@ public class ExamplePreferredTest
     {
         var endpoint = Environment.GetEnvironmentVariable("CLUSTER_ENDPOINT")
             ?? throw new InvalidOperationException("CLUSTER_ENDPOINT environment variable is required.");
+        var user = Environment.GetEnvironmentVariable("CLUSTER_USER") ?? "admin";
 
-        await ExamplePreferred.RunAsync(endpoint);
+        await ExamplePreferred.RunAsync(endpoint, user);
     }
 }

--- a/go/pgx/example/README.md
+++ b/go/pgx/example/README.md
@@ -1,0 +1,131 @@
+# Aurora DSQL with pgx
+
+## Overview
+
+This code example demonstrates how to use `pgx` with Amazon Aurora DSQL.
+The example shows you how to connect to an Aurora DSQL cluster and perform basic database operations.
+
+Aurora DSQL is a distributed SQL database service that provides high availability and scalability for
+your PostgreSQL-compatible applications. `pgx` is a popular PostgreSQL driver for Go that allows
+you to interact with PostgreSQL databases using Go code.
+
+This example uses the Aurora DSQL pgx Connector to handle IAM authentication automatically.
+
+## About the code example
+
+The example demonstrates a flexible connection approach that works for both admin and non-admin users:
+
+* When connecting as an **admin user**, the example uses the `public` schema.
+* When connecting as a **non-admin user**, the example uses a custom `myschema` schema.
+
+The code automatically detects the user type and adjusts its behavior accordingly.
+
+It creates a connection pool via `dsql.NewPool`, verifies connectivity, and runs multiple
+concurrent workers that each execute queries through the pool.
+
+## ⚠️ Important
+
+* Running this code might result in charges to your AWS account.
+* We recommend that you grant your code least privilege. At most, grant only the
+  minimum permissions required to perform the task. For more information, see
+  [Grant least privilege](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#grant-least-privilege).
+* This code is not tested in every AWS Region. For more information, see
+  [AWS Regional Services](https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services).
+
+## TLS connection configuration
+
+This example uses direct TLS connections where supported, and verifies the server certificate is trusted. Verified SSL
+connections should be used where possible to ensure data security during transmission.
+
+* Driver versions following the release of PostgreSQL 17 support direct TLS connections, bypassing the traditional
+  PostgreSQL connection preamble
+* Direct TLS connections provide improved connection performance and enhanced security
+* Not all PostgreSQL drivers support direct TLS connections yet, or only in recent versions following PostgreSQL 17
+* Ensure your installed driver version supports direct TLS negotiation, or use a version that is at least as recent as
+  the one used in this sample
+* If your driver doesn't support direct TLS connections, you may need to use the traditional preamble connection instead
+
+## Run the example
+
+### Prerequisites
+
+* You must have an AWS account, and have your default credentials and AWS Region
+  configured as described in the
+  [Globally configuring AWS SDKs and tools](https://docs.aws.amazon.com/credref/latest/refdocs/creds-config-files.html)
+  guide.
+* Go: Ensure you have Go 1.24+ installed.
+
+   _To verify Go is installed, you can run_
+   ```bash
+   go version
+   ```
+
+* You must have an Aurora DSQL cluster. For information about creating an Aurora DSQL cluster, see the
+  [Getting started with Aurora DSQL](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/getting-started.html)
+  guide.
+* If connecting as a non-admin user, ensure the user is linked to an IAM role and is granted access to the `myschema`
+  schema. See the
+  [Using database roles with IAM roles](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/using-database-and-iam-roles.html)
+  guide.
+
+### Run the code
+
+The example demonstrates the following operations:
+
+- Opening a connection pool to an Aurora DSQL cluster
+- Verifying connectivity
+- Running concurrent queries across multiple goroutines
+
+The example is designed to work with both admin and non-admin users:
+
+- When run as an admin user, it uses the `public` schema
+- When run as a non-admin user, it uses the `myschema` schema
+
+**Note:** running the example will use actual resources in your AWS account and may incur charges.
+
+Set environment variables for your cluster details:
+
+```bash
+# e.g. "admin"
+export CLUSTER_USER="<your user>"
+
+# e.g. "foo0bar1baz2quux3quuux4.dsql.us-east-1.on.aws"
+export CLUSTER_ENDPOINT="<your endpoint>"
+```
+
+Run the tests:
+
+```bash
+go test ./test/... -v
+```
+
+Run a specific example test:
+
+```bash
+# Preferred example (concurrent pool queries)
+go test ./test/ -run TestExamplePreferred -v
+
+# Transaction example
+go test ./test/transaction/... -v
+
+# OCC retry example
+go test ./test/occ_retry/... -v
+
+# Connection string example
+go test ./test/connection_string/... -v
+```
+
+The example contains comments explaining the code and the operations being performed.
+
+## Additional resources
+
+* [Amazon Aurora DSQL Documentation](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/what-is-aurora-dsql.html)
+* [Amazon Aurora DSQL pgx Connector](https://github.com/awslabs/aurora-dsql-connectors/tree/main/go/pgx)
+* [pgx Documentation](https://pkg.go.dev/github.com/jackc/pgx/v5)
+* [AWS SDK for Go v2 Documentation](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2)
+
+---
+
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0

--- a/go/pgx/example/src/example_preferred.go
+++ b/go/pgx/example/src/example_preferred.go
@@ -4,6 +4,10 @@
  */
 
 // Package example_preferred demonstrates concurrent queries using the DSQL connector pool.
+//
+// Works with both admin and non-admin users:
+//   - Admin users operate in the default "public" schema
+//   - Non-admin users operate in a custom "myschema" schema
 package example_preferred
 
 import (
@@ -14,18 +18,35 @@ import (
 	"sync"
 
 	"github.com/awslabs/aurora-dsql-connectors/go/pgx/dsql"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 const numConcurrentQueries = 8
 
-func createPool(ctx context.Context, clusterEndpoint string) (*dsql.Pool, error) {
+func createPool(ctx context.Context, clusterEndpoint, clusterUser string) (*dsql.Pool, error) {
 	poolCfg, _ := pgxpool.ParseConfig("")
 	poolCfg.MaxConns = 10
 	poolCfg.MinConns = 2
 
+	// Set search_path on each new connection based on user type
+	var schema string
+	if clusterUser == "admin" {
+		schema = "public"
+	} else {
+		schema = "myschema"
+	}
+	poolCfg.AfterConnect = func(ctx context.Context, conn *pgx.Conn) error {
+		_, err := conn.Exec(ctx, fmt.Sprintf("SET search_path = %s", pgx.Identifier{schema}.Sanitize()))
+		if err != nil {
+			return fmt.Errorf("failed to set search_path to %s: %w", schema, err)
+		}
+		return nil
+	}
+
 	return dsql.NewPool(ctx, dsql.Config{
 		Host: clusterEndpoint,
+		User: clusterUser,
 	}, poolCfg)
 }
 
@@ -51,10 +72,14 @@ func Example() error {
 	if clusterEndpoint == "" {
 		return fmt.Errorf("CLUSTER_ENDPOINT environment variable is not set")
 	}
+	clusterUser := os.Getenv("CLUSTER_USER")
+	if clusterUser == "" {
+		clusterUser = "admin"
+	}
 
 	ctx := context.Background()
 
-	pool, err := createPool(ctx, clusterEndpoint)
+	pool, err := createPool(ctx, clusterEndpoint, clusterUser)
 	if err != nil {
 		return fmt.Errorf("failed to create pool: %w", err)
 	}

--- a/ruby/pg/example/README.md
+++ b/ruby/pg/example/README.md
@@ -1,0 +1,123 @@
+# Aurora DSQL with pg
+
+## Overview
+
+This code example demonstrates how to use the `pg` gem with Amazon Aurora DSQL.
+The example shows you how to connect to an Aurora DSQL cluster and perform basic database operations.
+
+Aurora DSQL is a distributed SQL database service that provides high availability and scalability for
+your PostgreSQL-compatible applications. `pg` is a popular PostgreSQL adapter for Ruby that allows
+you to interact with PostgreSQL databases using Ruby code.
+
+This example uses the Aurora DSQL Ruby pg Connector to handle IAM authentication automatically.
+
+## About the code example
+
+The example demonstrates a flexible connection approach that works for both admin and non-admin users:
+
+* When connecting as an **admin user**, the example uses the `public` schema.
+* When connecting as a **non-admin user**, the example uses a custom `myschema` schema.
+
+The code automatically detects the user type and adjusts its behavior accordingly.
+
+It creates a connection pool via `AuroraDsql::Pg.create_pool`, verifies connectivity, creates a table,
+inserts data, and runs multiple concurrent queries via threads.
+
+## ⚠️ Important
+
+* Running this code might result in charges to your AWS account.
+* We recommend that you grant your code least privilege. At most, grant only the
+  minimum permissions required to perform the task. For more information, see
+  [Grant least privilege](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#grant-least-privilege).
+* This code is not tested in every AWS Region. For more information, see
+  [AWS Regional Services](https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services).
+
+## TLS connection configuration
+
+This example uses direct TLS connections where supported (libpq 17+), and verifies the server certificate is trusted.
+Verified SSL connections should be used where possible to ensure data security during transmission.
+
+* Driver versions following the release of PostgreSQL 17 support direct TLS connections, bypassing the traditional
+  PostgreSQL connection preamble
+* Direct TLS connections provide improved connection performance and enhanced security
+* Not all PostgreSQL drivers support direct TLS connections yet, or only in recent versions following PostgreSQL 17
+* Ensure your installed driver version supports direct TLS negotiation, or use a version that is at least as recent as
+  the one used in this sample
+* If your driver doesn't support direct TLS connections, you may need to use the traditional preamble connection instead
+
+## Run the example
+
+### Prerequisites
+
+* You must have an AWS account, and have your default credentials and AWS Region
+  configured as described in the
+  [Globally configuring AWS SDKs and tools](https://docs.aws.amazon.com/credref/latest/refdocs/creds-config-files.html)
+  guide.
+* Ruby: Ensure you have Ruby 3.1+ installed.
+
+   _To verify Ruby is installed, you can run_
+   ```bash
+   ruby --version
+   ```
+
+* You must have an Aurora DSQL cluster. For information about creating an Aurora DSQL cluster, see the
+  [Getting started with Aurora DSQL](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/getting-started.html)
+  guide.
+* If connecting as a non-admin user, ensure the user is linked to an IAM role and is granted access to the `myschema`
+  schema. See the
+  [Using database roles with IAM roles](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/using-database-and-iam-roles.html)
+  guide.
+
+### Run the code
+
+The example demonstrates the following operations:
+
+- Opening a connection pool to an Aurora DSQL cluster
+- Creating a table
+- Performing a transactional insert with OCC retry
+- Running concurrent queries across multiple threads
+
+The example is designed to work with both admin and non-admin users:
+
+- When run as an admin user, it uses the `public` schema
+- When run as a non-admin user, it uses the `myschema` schema
+
+**Note:** running the example will use actual resources in your AWS account and may incur charges.
+
+Set environment variables for your cluster details:
+
+```bash
+# e.g. "admin"
+export CLUSTER_USER="<your user>"
+
+# e.g. "foo0bar1baz2quux3quuux4.dsql.us-east-1.on.aws"
+export CLUSTER_ENDPOINT="<your endpoint>"
+```
+
+Install dependencies and run the example:
+
+```bash
+bundle install
+ruby src/example_preferred.rb
+```
+
+Run the tests:
+
+```bash
+bundle exec rspec test/
+```
+
+The example contains comments explaining the code and the operations being performed.
+
+## Additional resources
+
+* [Amazon Aurora DSQL Documentation](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/what-is-aurora-dsql.html)
+* [Amazon Aurora DSQL Ruby pg Connector](https://github.com/awslabs/aurora-dsql-connectors/tree/main/ruby/pg)
+* [pg gem Documentation](https://deveiate.org/code/pg/)
+* [AWS SDK for Ruby Documentation](https://docs.aws.amazon.com/sdk-for-ruby/v3/api/)
+
+---
+
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0

--- a/ruby/pg/example/src/example_preferred.rb
+++ b/ruby/pg/example/src/example_preferred.rb
@@ -5,30 +5,49 @@ require "aurora_dsql_pg"
 
 NUM_CONCURRENT_QUERIES = 8
 
+# Works with both admin and non-admin users:
+# - Admin users operate in the default "public" schema
+# - Non-admin users operate in a custom "myschema" schema
 def example
   cluster_endpoint = ENV.fetch("CLUSTER_ENDPOINT") do
     raise "CLUSTER_ENDPOINT environment variable is not set"
   end
+  cluster_user = ENV.fetch("CLUSTER_USER", "admin")
+
+  # Determine schema based on user type
+  schema = cluster_user == "admin" ? "public" : "myschema"
 
   pool = AuroraDsql::Pg.create_pool(
     host: cluster_endpoint,
+    user: cluster_user,
     pool_size: 10,
     occ_max_retries: 3
   )
+
+  # Helper to set search_path on each connection checked out from the pool.
+  # Unlike Go's AfterConnect or .NET's ConfigureConnectionString, the Ruby
+  # connection pool does not have a per-connection setup hook, so we set
+  # search_path at the start of each checkout.
+  with_schema = proc do |&block|
+    pool.with do |conn|
+      conn.exec("SET search_path = #{conn.escape_identifier(schema)}")
+      block.call(conn)
+    end
+  end
 
   # Verify connection
   pool.with { |conn| conn.exec("SELECT 1") }
   puts "Connected to Aurora DSQL"
 
   # Create table
-  pool.with do |conn|
+  with_schema.call do |conn|
     conn.transaction do
       conn.exec("CREATE TABLE IF NOT EXISTS example_items (id UUID DEFAULT gen_random_uuid() PRIMARY KEY, name TEXT)")
     end
   end
 
   # Insert data (OCC retry enabled via occ_max_retries config)
-  pool.with do |conn|
+  with_schema.call do |conn|
     conn.transaction do
       conn.exec_params("INSERT INTO example_items (name) VALUES ($1)", ["test-item"])
     end
@@ -38,7 +57,7 @@ def example
   # Run concurrent queries
   threads = NUM_CONCURRENT_QUERIES.times.map do |i|
     Thread.new do
-      pool.with do |conn|
+      with_schema.call do |conn|
         result = conn.exec_params("SELECT $1::int AS worker_id", [i])
         puts "Worker #{i} result: #{result[0]['worker_id']}"
       end


### PR DESCRIPTION
## Summary

- Add example READMEs for dotnet/npgsql, go/pgx, and ruby/pg connectors matching the existing Java/Node.js format
- Add admin/non-admin user support to ExamplePreferred examples for dotnet, go, and ruby (non-admin users use `myschema` schema)
- Update top-level README with .NET and Ruby connector entries, install instructions, and documentation links

## Changes

**New files:**
- `dotnet/npgsql/example/README.md`
- `go/pgx/example/README.md`
- `ruby/pg/example/README.md`

**Modified examples (admin/non-admin schema switching):**
- `dotnet/npgsql/example/src/ExamplePreferred.cs` — pool-level via `ConfigureConnectionString` + `SearchPath`
- `go/pgx/example/src/example_preferred.go` — per-connection via `AfterConnect` callback
- `ruby/pg/example/src/example_preferred.rb` — per-checkout via `with_schema` helper proc
- `dotnet/npgsql/example/test/ExamplePreferredTest.cs` — passes `CLUSTER_USER` to example

**Modified README:**
- `README.md` — added .NET and Ruby sections (badges, install, docs)

## Test plan

- [ ] `dotnet build` passes in `dotnet/npgsql/example/`
- [ ] `go build ./...` and `go vet ./...` pass in `go/pgx/example/`
- [ ] `ruby -c` syntax check passes on `ruby/pg/example/src/example_preferred.rb`
- [ ] All internal links in top-level README resolve
- [ ] Run examples with `CLUSTER_USER=admin` (default behavior unchanged)
- [ ] Run examples with a non-admin `CLUSTER_USER` to verify `myschema` switching