### PR TITLE
Migrate Java JDBC release secrets to AWS Secrets Manager

### DIFF
--- a/.github/workflows/java-jdbc-release.yml
+++ b/.github/workflows/java-jdbc-release.yml
@@ -27,6 +27,9 @@ jobs:
     needs: wait-for-ci
     runs-on: ubuntu-latest
     environment: maven
+    permissions:
+      id-token: write # required for requesting the JWT
+      contents: read # required for actions/checkout
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -35,6 +38,50 @@ jobs:
         with:
           java-version: "25"
           distribution: "corretto"
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6
+        with:
+          role-to-assume: ${{ secrets.MAVEN_PUBLISH_IAM_ROLE }}
+          role-session-name: java-jdbc-maven-publish
+          aws-region: us-east-1
+
+      - name: Get Maven Central Credentials
+        run: |
+          SECRET_JSON=$(aws secretsmanager get-secret-value \
+            --secret-id "prod/maven/account-credentials" \
+            --query 'SecretString' \
+            --output text)
+          USERNAME=$(echo "$SECRET_JSON" | jq -r '.username')
+          PASSWORD=$(echo "$SECRET_JSON" | jq -r '.password')
+          echo "::add-mask::$USERNAME"
+          echo "::add-mask::$PASSWORD"
+          echo "SONATYPE_USERNAME=$USERNAME" >> "$GITHUB_ENV"
+          echo "SONATYPE_PASSWORD=$PASSWORD" >> "$GITHUB_ENV"
+
+      - name: Get GPG Signing Key
+        run: |
+          SECRET_JSON=$(aws secretsmanager get-secret-value \
+            --secret-id "prod/maven/gpg-signing-key" \
+            --query 'SecretString' \
+            --output text)
+          GPG_PASSPHRASE=$(echo "$SECRET_JSON" | jq -r '.gpg_passphrase')
+          GPG_PUBLIC_KEY=$(echo "$SECRET_JSON" | jq -r '.gpg_public_key')
+          GPG_SECRET_KEY=$(echo "$SECRET_JSON" | jq -r '.gpg_secret_key')
+
+          echo "::add-mask::$GPG_PASSPHRASE"
+          echo "$GPG_PUBLIC_KEY" | while IFS= read -r line; do echo "::add-mask::$line"; done
+          echo "$GPG_SECRET_KEY" | while IFS= read -r line; do echo "::add-mask::$line"; done
+
+          {
+            echo "GPG_PASSPHRASE=$GPG_PASSPHRASE"
+            echo "GPG_PUBLIC_KEY<<GPGPUBEOF"
+            echo "$GPG_PUBLIC_KEY"
+            echo "GPGPUBEOF"
+            echo "GPG_SECRET_KEY<<GPGSECEOF"
+            echo "$GPG_SECRET_KEY"
+            echo "GPGSECEOF"
+          } >> "$GITHUB_ENV"
 
       - name: Extract version from tag
         run: |
@@ -49,11 +96,11 @@ jobs:
           ./gradlew jreleaserDeploy --no-configuration-cache
         env:
           JRELEASER_MAVENCENTRAL_STAGE: "UPLOAD"
-          JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.GPG_PUBLIC_KEY }}
-          JRELEASER_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-          JRELEASER_GPG_SECRET_KEY: ${{ secrets.GPG_SECRET_KEY }}
-          JRELEASER_MAVENCENTRAL_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-          JRELEASER_MAVENCENTRAL_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          JRELEASER_GPG_PUBLIC_KEY: ${{ env.GPG_PUBLIC_KEY }}
+          JRELEASER_GPG_PASSPHRASE: ${{ env.GPG_PASSPHRASE }}
+          JRELEASER_GPG_SECRET_KEY: ${{ env.GPG_SECRET_KEY }}
+          JRELEASER_MAVENCENTRAL_USERNAME: ${{ env.SONATYPE_USERNAME }}
+          JRELEASER_MAVENCENTRAL_PASSWORD: ${{ env.SONATYPE_PASSWORD }}
 
   update-changelog:
     needs: deploy


### PR DESCRIPTION
## Summary
- Replace direct GitHub secrets with AWS Secrets Manager lookups in the Java JDBC release workflow
- Sonatype credentials fetched from `prod/maven/account-credentials`
- GPG signing keys fetched from `prod/maven/gpg-signing-key`
- Uses OIDC role assumption via `MAVEN_PUBLISH_IAM_ROLE`, consistent with the dotnet release workflow pattern

## Prerequisites
- [x] IAM role `MavenPublishGithubRole` created with OIDC trust policy scoped to `environment:maven` and `refs/tags/java/jdbc/*`
- [x] Secrets Manager secrets created (`prod/maven/account-credentials`, `prod/maven/gpg-signing-key`)
- [x] GitHub secret `MAVEN_PUBLISH_IAM_ROLE` configured with role ARN

## Test plan
- [ ] Trigger a test release with a `java/jdbc/v*` tag and verify the workflow succeeds
- [ ] Verify secrets are masked in workflow logs
- [ ] Remove old GitHub secrets (GPG_PUBLIC_KEY, GPG_PASSPHRASE, GPG_SECRET_KEY, SONATYPE_USERNAME, SONATYPE_PASSWORD) after successful release