### PR TITLE
Migrate Rust crates.io release secrets to AWS Secrets Manager

### DIFF
--- a/.github/workflows/rust-sqlx-release.yml
+++ b/.github/workflows/rust-sqlx-release.yml
@@ -27,11 +27,31 @@ jobs:
     needs: wait-for-ci
     runs-on: ubuntu-latest
     environment: rust
+    permissions:
+      id-token: write # required for requesting the JWT
+      contents: read # required for actions/checkout
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install Rust toolchain
         run: rustup update stable && rustup default stable
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6
+        with:
+          role-to-assume: ${{ secrets.CRATES_PUBLISH_IAM_ROLE }}
+          role-session-name: rust-sqlx-crates-publish
+          aws-region: us-east-1
+
+      - name: Get crates.io API Key
+        run: |
+          SECRET_JSON=$(aws secretsmanager get-secret-value \
+            --secret-id "prod/cratesio/account-credentials" \
+            --query 'SecretString' \
+            --output text)
+          CRATES_IO_KEY=$(echo "$SECRET_JSON" | jq -r '.["Github API Key"]')
+          echo "::add-mask::$CRATES_IO_KEY"
+          echo "CRATES_IO_KEY=$CRATES_IO_KEY" >> "$GITHUB_ENV"
 
       - name: Set version from tag
         run: |
@@ -42,7 +62,7 @@ jobs:
       - name: Publish to crates.io
         run: cargo publish
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_KEY }}
+          CARGO_REGISTRY_TOKEN: ${{ env.CRATES_IO_KEY }}
 
   update-changelog:
     needs: publish


### PR DESCRIPTION
## Summary
- Replace direct GitHub secret `CRATES_IO_KEY` with AWS Secrets Manager lookup in the Rust SQLx release workflow
- API key fetched from `prod/cratesio/account-credentials` in us-east-1
- Uses OIDC role assumption via `CRATES_PUBLISH_IAM_ROLE`, consistent with existing release workflows

## Prerequisites
- [x] IAM role `CratesPublishGithubRole` created with OIDC trust policy scoped to `environment:rust` and `refs/tags/rust/sqlx/*`
- [x] Secrets Manager secret created (`prod/cratesio/account-credentials`)
- [x] GitHub secret `CRATES_PUBLISH_IAM_ROLE` configured with role ARN

## Test plan
- [ ] Trigger a test release with a `rust/sqlx/v*` tag and verify the workflow succeeds
- [ ] Verify secret is masked in workflow logs
- [ ] Remove old GitHub secret `CRATES_IO_KEY` after successful release