### PR TITLE
Add missing permissions to update-changelog in Java release

### DIFF
--- a/.github/workflows/java-jdbc-release.yml
+++ b/.github/workflows/java-jdbc-release.yml
@@ -104,6 +104,9 @@ jobs:
 
   update-changelog:
     needs: deploy
+    permissions:
+      contents: write
+      pull-requests: write
     uses: ./.github/workflows/update-changelog.yml
     with:
       tag: ${{ github.ref_name }}


### PR DESCRIPTION
## Summary
- Add `contents: write` and `pull-requests: write` permissions to the `update-changelog` job in the Java JDBC release workflow
- This was missing before and likely caused the `startup_failure` on the `v1.4.1` release
- Matches the dotnet release workflow pattern

## Test plan
- [ ] Merge and re-tag `java/jdbc/v1.4.1` to verify the release succeeds