### PR TITLE
Fix Maven Central publishing credentials in Java JDBC release

### DIFF
--- a/.github/workflows/java-jdbc-release.yml
+++ b/.github/workflows/java-jdbc-release.yml
@@ -49,11 +49,11 @@ jobs:
       - name: Get Maven Central Credentials
         run: |
           SECRET_JSON=$(aws secretsmanager get-secret-value \
-            --secret-id "prod/maven/account-credentials" \
+            --secret-id "prod/maven/publishing-credentials" \
             --query 'SecretString' \
             --output text)
-          USERNAME=$(echo "$SECRET_JSON" | jq -r '.username')
-          PASSWORD=$(echo "$SECRET_JSON" | jq -r '.password')
+          USERNAME=$(echo "$SECRET_JSON" | jq -r '.publish_username')
+          PASSWORD=$(echo "$SECRET_JSON" | jq -r '.publish_password')
           echo "::add-mask::$USERNAME"
           echo "::add-mask::$PASSWORD"
           echo "SONATYPE_USERNAME=$USERNAME" >> "$GITHUB_ENV"
@@ -93,7 +93,7 @@ jobs:
         run: |
           ./gradlew build
           ./gradlew publish
-          ./gradlew jreleaserDeploy --no-configuration-cache
+          ./gradlew jreleaserDeploy --no-configuration-cache --stacktrace
         env:
           JRELEASER_MAVENCENTRAL_STAGE: "UPLOAD"
           JRELEASER_GPG_PUBLIC_KEY: ${{ env.GPG_PUBLIC_KEY }}


### PR DESCRIPTION
## Summary
- Use correct Secrets Manager secret (`prod/maven/publishing-credentials`) with API token keys (`publish_username`/`publish_password`) instead of account login credentials
- Add `--stacktrace` to `jreleaserDeploy` for better error diagnostics

## Context
The v1.4.1 release workflow failed at the upload step with "Unexpected error" because `prod/maven/account-credentials` contained Sonatype login credentials, not the Central Portal API tokens needed by JReleaser.

## Test plan
- [ ] Re-tag `java/jdbc/v1.4.1` and verify the deploy workflow succeeds
- [ ] Confirm `MavenPublishGithubRole` has access to `prod/maven/publishing-credentials`