### PR TITLE
Allow dirty working tree for Rust crate publish

### DIFF
--- a/.github/workflows/rust-sqlx-release.yml
+++ b/.github/workflows/rust-sqlx-release.yml
@@ -61,7 +61,7 @@ jobs:
           sed -i "s/^version = .*/version = \"$VERSION\"/" Cargo.toml
 
       - name: Publish to crates.io
-        run: cargo publish
+        run: cargo publish --allow-dirty
         env:
           CARGO_REGISTRY_TOKEN: ${{ env.CRATES_IO_KEY }}
 


### PR DESCRIPTION
## Summary
- Add `--allow-dirty` to `cargo publish` in the Rust release workflow

## Context
The release workflow sets the crate version from the git tag by modifying `Cargo.toml` via `sed`. This leaves an uncommitted change, causing `cargo publish` to fail with:

```
error: 1 files in the working directory contain changes that were not yet committed into git
```

## Test plan
- [ ] Merge, delete and re-create `rust/sqlx/v0.1.0` tag, verify publish succeeds