### PR TITLE
Add ExecWithRetry helper to Go OCC retry package

### DIFF
--- a/go/pgx/occretry/occretry.go
+++ b/go/pgx/occretry/occretry.go
@@ -149,6 +149,27 @@ func Retry(ctx context.Context, config Config, fn func() error) error {
 	return fmt.Errorf("max retries (%d) exceeded, last error: %w", config.MaxRetries, lastErr)
 }
 
+// Execer is an interface for types that can execute SQL statements.
+// *pgxpool.Pool and *pgx.Conn satisfy this interface.
+type Execer interface {
+	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
+}
+
+// ExecWithRetry executes a single SQL statement with automatic retry on OCC conflicts.
+// Unlike WithRetry, this does NOT wrap in an explicit transaction, making it suitable
+// for both DDL (CREATE TABLE, CREATE INDEX ASYNC, etc.) and single DML statements.
+//
+// Example:
+//
+//	err := occretry.ExecWithRetry(ctx, pool, occretry.DefaultConfig(),
+//	    "CREATE INDEX ASYNC ON users (email)")
+func ExecWithRetry(ctx context.Context, execer Execer, config Config, sql string, arguments ...any) error {
+	return Retry(ctx, config, func() error {
+		_, err := execer.Exec(ctx, sql, arguments...)
+		return err
+	})
+}
+
 // WithRetry executes a transactional function with automatic retry on OCC conflicts.
 // It begins a transaction, calls fn with the transaction, and commits on success.
 // If an OCC error occurs at any point, the transaction is rolled back and retried

--- a/go/pgx/occretry/occretry_test.go
+++ b/go/pgx/occretry/occretry_test.go
@@ -1,0 +1,124 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package occretry
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// mockExecer is a test double that records calls and returns preset results.
+type mockExecer struct {
+	calls     int
+	returnErr error
+	// errs, if set, is used instead of returnErr to return different errors per call.
+	errs []error
+}
+
+func (m *mockExecer) Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error) {
+	idx := m.calls
+	m.calls++
+	if m.errs != nil && idx < len(m.errs) {
+		return pgconn.CommandTag{}, m.errs[idx]
+	}
+	return pgconn.CommandTag{}, m.returnErr
+}
+
+func fastConfig() Config {
+	return Config{
+		MaxRetries:  3,
+		InitialWait: 1 * time.Millisecond,
+		MaxWait:     5 * time.Millisecond,
+		Multiplier:  2.0,
+	}
+}
+
+func TestExecWithRetry_Success(t *testing.T) {
+	mock := &mockExecer{}
+	err := ExecWithRetry(context.Background(), mock, fastConfig(), "INSERT INTO t VALUES ($1)", 1)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if mock.calls != 1 {
+		t.Fatalf("expected 1 call, got %d", mock.calls)
+	}
+}
+
+func TestExecWithRetry_OCCErrorTriggersRetry(t *testing.T) {
+	occErr := &pgconn.PgError{Code: "OC000", Message: "transaction conflict"}
+	mock := &mockExecer{
+		errs: []error{occErr, occErr, nil},
+	}
+	err := ExecWithRetry(context.Background(), mock, fastConfig(), "UPDATE t SET x = 1")
+	if err != nil {
+		t.Fatalf("expected nil error after retries, got %v", err)
+	}
+	if mock.calls != 3 {
+		t.Fatalf("expected 3 calls (2 failures + 1 success), got %d", mock.calls)
+	}
+}
+
+func TestExecWithRetry_NonOCCErrorReturnsImmediately(t *testing.T) {
+	nonOCCErr := errors.New("connection refused")
+	mock := &mockExecer{returnErr: nonOCCErr}
+	err := ExecWithRetry(context.Background(), mock, fastConfig(), "SELECT 1")
+	if !errors.Is(err, nonOCCErr) {
+		t.Fatalf("expected non-OCC error to be returned immediately, got %v", err)
+	}
+	if mock.calls != 1 {
+		t.Fatalf("expected 1 call (no retry for non-OCC error), got %d", mock.calls)
+	}
+}
+
+func TestExecWithRetry_ExhaustsRetries(t *testing.T) {
+	occErr := &pgconn.PgError{Code: "OC001", Message: "schema conflict"}
+	mock := &mockExecer{returnErr: occErr}
+	err := ExecWithRetry(context.Background(), mock, fastConfig(), "CREATE INDEX ASYNC ON t (col)")
+	if err == nil {
+		t.Fatal("expected error after exhausting retries, got nil")
+	}
+	// MaxRetries is 3, so we expect 1 initial + 3 retries = 4 calls
+	if mock.calls != 4 {
+		t.Fatalf("expected 4 calls (1 initial + 3 retries), got %d", mock.calls)
+	}
+}
+
+func TestExecWithRetry_PassesArguments(t *testing.T) {
+	var capturedSQL string
+	var capturedArgs []any
+	wrapper := &argCapturingExecer{
+		onExec: func(sql string, args []any) {
+			capturedSQL = sql
+			capturedArgs = args
+		},
+	}
+	err := ExecWithRetry(context.Background(), wrapper, fastConfig(),
+		"INSERT INTO t (a, b) VALUES ($1, $2)", "hello", 42)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if capturedSQL != "INSERT INTO t (a, b) VALUES ($1, $2)" {
+		t.Fatalf("unexpected sql: %s", capturedSQL)
+	}
+	if len(capturedArgs) != 2 || capturedArgs[0] != "hello" || capturedArgs[1] != 42 {
+		t.Fatalf("unexpected arguments: %v", capturedArgs)
+	}
+}
+
+type argCapturingExecer struct {
+	onExec func(sql string, args []any)
+}
+
+func (a *argCapturingExecer) Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error) {
+	if a.onExec != nil {
+		a.onExec(sql, arguments)
+	}
+	return pgconn.CommandTag{}, nil
+}


### PR DESCRIPTION
## Summary

- Add `Execer` interface and `ExecWithOCCRetry` function to the `occretry` package for retrying single SQL statements (DDL, single DML) with OCC conflict handling.

## Test plan

- [x] Unit tests included
- [ ] Go CI passes