### PR TITLE
Migrate Ruby RubyGems release secrets to AWS Secrets Manager

### DIFF
--- a/.github/workflows/ruby-pg-release.yml
+++ b/.github/workflows/ruby-pg-release.yml
@@ -28,6 +28,9 @@ jobs:
     needs: wait-for-ci
     runs-on: ubuntu-latest
     environment: ruby
+    permissions:
+      id-token: write # required for requesting the JWT
+      contents: read # required for actions/checkout
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -36,6 +39,23 @@ jobs:
         with:
           ruby-version: "3.3"
           working-directory: ruby/pg
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6
+        with:
+          role-to-assume: ${{ secrets.RUBYGEMS_PUBLISH_IAM_ROLE }}
+          role-session-name: ruby-pg-rubygems-publish
+          aws-region: us-east-1
+
+      - name: Get RubyGems API Key
+        run: |
+          SECRET_JSON=$(aws secretsmanager get-secret-value \
+            --secret-id "prod/rubygems/account-credentials" \
+            --query 'SecretString' \
+            --output text)
+          RUBYGEMS_API_KEY=$(echo "$SECRET_JSON" | jq -r '.["API Key for Github Publish"]')
+          echo "::add-mask::$RUBYGEMS_API_KEY"
+          echo "GEM_HOST_API_KEY=$RUBYGEMS_API_KEY" >> "$GITHUB_ENV"
 
       - name: Set version from tag
         run: |
@@ -48,8 +68,6 @@ jobs:
 
       - name: Publish to RubyGems
         run: gem push aurora-dsql-ruby-pg-*.gem
-        env:
-          GEM_HOST_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
 
   update-changelog:
     needs: publish


### PR DESCRIPTION
## Summary
- Replace direct `RUBYGEMS_API_KEY` GitHub secret with IAM role-based authentication via GitHub OIDC
- Workflow now assumes `RUBYGEMS_PUBLISH_IAM_ROLE` and fetches the API key from AWS Secrets Manager (`prod/rubygems/account-credentials`) at publish time
- Matches the pattern used by Rust (#259) and .NET release workflows

## Changes
- Added `id-token: write` permission for OIDC token request
- Added `Configure AWS Credentials` step using `aws-actions/configure-aws-credentials@v6`
- Added `Get RubyGems API Key` step to fetch from Secrets Manager
- Removed direct `secrets.RUBYGEMS_API_KEY` reference

## Test plan
- [ ] Verify IAM role `RubyPublishGithubRole` has correct trust policy for `repo:awslabs/aurora-dsql-connectors:environment:ruby`
- [ ] Verify `RUBYGEMS_PUBLISH_IAM_ROLE` secret is set in the `ruby` GitHub environment
- [ ] Trigger a test release to confirm end-to-end publish works
- [ ] Remove old `RUBYGEMS_API_KEY` secret from GitHub after successful publish