### PR TITLE
Fix Ruby integration tests: remove skips, use new pool config API

### DIFF
--- a/ruby/pg/example/test/alternatives/manual_token/example_test.rb
+++ b/ruby/pg/example/test/alternatives/manual_token/example_test.rb
@@ -6,9 +6,9 @@ require_relative "../../../src/alternatives/manual_token/example"
 
 RSpec.describe "manual_token example" do
   before(:all) do
-    skip "CLUSTER_ENDPOINT required for integration test" unless ENV["CLUSTER_ENDPOINT"]
-    skip "CLUSTER_USER required for integration test" unless ENV["CLUSTER_USER"]
-    skip "REGION required for integration test" unless ENV["REGION"]
+    raise "CLUSTER_ENDPOINT is required" unless ENV["CLUSTER_ENDPOINT"]
+    raise "CLUSTER_USER is required" unless ENV["CLUSTER_USER"]
+    raise "REGION is required" unless ENV["REGION"]
   end
 
   it "runs the manual token example without error" do

--- a/ruby/pg/example/test/example_preferred_test.rb
+++ b/ruby/pg/example/test/example_preferred_test.rb
@@ -6,7 +6,7 @@ require_relative "../src/example_preferred"
 
 RSpec.describe "example_preferred" do
   before(:all) do
-    skip "CLUSTER_ENDPOINT required for integration test" unless ENV["CLUSTER_ENDPOINT"]
+    raise "CLUSTER_ENDPOINT is required" unless ENV["CLUSTER_ENDPOINT"]
   end
 
   it "runs the preferred example without error" do

--- a/ruby/pg/test/integration/occ_retry_test.rb
+++ b/ruby/pg/test/integration/occ_retry_test.rb
@@ -8,15 +8,13 @@ TABLE_NAME = "occ_retry_test_#{Process.pid}"
 
 RSpec.describe "OCC retry integration", order: :defined do
   before(:all) do
-    skip "CLUSTER_ENDPOINT required for integration test" unless ENV["CLUSTER_ENDPOINT"]
-
     @pool = AuroraDsql::Pg.create_pool(
       host: ENV.fetch("CLUSTER_ENDPOINT"),
       user: ENV.fetch("CLUSTER_USER", "admin"),
       region: ENV.fetch("REGION", nil),
-      pool_size: 5,
       occ_max_retries: 3,
-      logger: Logger.new($stdout)
+      logger: Logger.new($stdout),
+      pool: { size: 5 }
     )
 
     # Retry initial connection to handle DNS propagation delay


### PR DESCRIPTION
## Summary
- Remove silent `skip` when `CLUSTER_ENDPOINT` is missing — `raise` instead so missing env vars cause a hard failure, not a silent pass
- Fix `pool_size:` kwarg to `pool: { size: 5 }` to match the new Config API from #270

## Test plan
- [ ] Ruby CI integration tests pass with the new pool config