### PR TITLE
fix(rust): Fix rust-sqlx release CI gate check name

### DIFF
--- a/.github/workflows/rust-sqlx-release.yml
+++ b/.github/workflows/rust-sqlx-release.yml
@@ -22,7 +22,7 @@ jobs:
           running-workflow-name: "Wait for CI to pass"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 30
-          check-regexp: "Analyze \\(rust\\)"
+          check-regexp: "^build$"
 
   publish:
     needs: wait-for-ci


### PR DESCRIPTION
The wait-for-ci step was matching "Analyze (rust)" which doesn't exist in this repo. Updated to match "^build$" which is the actual job name from rust-sqlx-ci.yml, consistent with Ruby, go-pgx and dotnet-npgsql release workflows.

*Issue #, if available:*
N/A

*Description of changes:*
Updated job name in rust release flow.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.