### PR TITLE
Fix release workflow check-regexp for Go and .NET

### DIFF
--- a/.github/workflows/dotnet-npgsql-release.yml
+++ b/.github/workflows/dotnet-npgsql-release.yml
@@ -22,7 +22,7 @@ jobs:
           running-workflow-name: "Wait for CI to pass"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 30
-          check-regexp: "^build$"
+          check-regexp: "build"
 
   publish:
     needs: wait-for-ci

--- a/.github/workflows/go-pgx-release.yml
+++ b/.github/workflows/go-pgx-release.yml
@@ -18,7 +18,7 @@ jobs:
           running-workflow-name: "Wait for CI to pass"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 30
-          check-regexp: "^build$"
+          check-regexp: "build"
 
   update-changelog:
     needs: wait-for-ci


### PR DESCRIPTION
## Summary

- Relax `check-regexp` from `^build$` to `build` in go-pgx and dotnet-npgsql release workflows
- `^build$` fails when CI runs through `ci-gate.yml` because the check name becomes `go-pgx / build` (or `dotnet-npgsql / build`) instead of bare `build`
- This caused the `go/pgx/v0.4.0` release to fail: https://github.com/awslabs/aurora-dsql-connectors/actions/runs/23766161282

## Test plan

- [ ] Merge this PR, then re-run the `go/pgx/v0.4.0` release workflow