### PR TITLE
feature(rust): Add trait-based OCC retry for SQLx connector

### DIFF
--- a/rust/sqlx/src/lib.rs
+++ b/rust/sqlx/src/lib.rs
@@ -8,8 +8,12 @@ pub mod connection;
 mod error;
 #[cfg(feature = "occ")]
 mod occ_retry;
+#[cfg(feature = "occ")]
+mod occ_trait;
 #[cfg(feature = "pool")]
 pub mod pool;
+#[cfg(feature = "occ")]
+mod retry_query;
 mod token;
 pub(crate) mod util;
 
@@ -18,3 +22,7 @@ pub use config::{DsqlConnectOptions, DsqlConnectOptionsBuilder};
 pub use error::{DsqlError, Result};
 #[cfg(feature = "occ")]
 pub use occ_retry::{is_occ_error, retry_on_occ, OCCRetryConfig, OCCRetryConfigBuilder};
+#[cfg(feature = "occ")]
+pub use occ_trait::{RetryExecutor, RetryPool};
+#[cfg(feature = "occ")]
+pub use retry_query::RetryQuery;

--- a/rust/sqlx/src/occ_retry.rs
+++ b/rust/sqlx/src/occ_retry.rs
@@ -18,6 +18,28 @@ pub struct OCCRetryConfig {
     jitter_factor: f64,
 }
 
+impl OCCRetryConfig {
+    /// Maximum number of retry attempts.
+    pub fn max_attempts(&self) -> u32 {
+        self.max_attempts
+    }
+
+    /// Base delay in milliseconds for exponential backoff.
+    pub fn base_delay_ms(&self) -> u64 {
+        self.base_delay_ms
+    }
+
+    /// Maximum delay in milliseconds.
+    pub fn max_delay_ms(&self) -> u64 {
+        self.max_delay_ms
+    }
+
+    /// Jitter factor (0.0 to 1.0) applied to backoff delays.
+    pub fn jitter_factor(&self) -> f64 {
+        self.jitter_factor
+    }
+}
+
 impl OCCRetryConfigBuilder {
     fn validate(&self) -> std::result::Result<(), String> {
         if let Some(0) = self.max_attempts {
@@ -44,7 +66,7 @@ pub fn is_occ_error(err: &sqlx::Error) -> bool {
     }
 }
 
-pub(crate) fn calculate_backoff(config: &OCCRetryConfig, attempt: u32) -> Duration {
+fn calculate_backoff(config: &OCCRetryConfig, attempt: u32) -> Duration {
     let base = config.base_delay_ms as f64;
     let delay = (base * 2_f64.powi((attempt - 1) as i32)).min(config.max_delay_ms as f64);
     let jitter = delay * rand::random::<f64>() * config.jitter_factor;
@@ -67,9 +89,9 @@ pub(crate) fn calculate_backoff(config: &OCCRetryConfig, attempt: u32) -> Durati
 ///
 /// Returns `DsqlError::OCCRetryExhausted` with the last OCC error
 /// preserved as the cause when max attempts are exceeded.
-pub async fn retry_on_occ<F, Fut, T>(config: &OCCRetryConfig, mut f: F) -> Result<T>
+pub async fn retry_on_occ<F, Fut, T>(config: &OCCRetryConfig, f: F) -> Result<T>
 where
-    F: FnMut() -> Fut,
+    F: Fn() -> Fut,
     Fut: std::future::Future<Output = std::result::Result<T, sqlx::Error>>,
 {
     let max_attempts = config.max_attempts;

--- a/rust/sqlx/src/occ_trait.rs
+++ b/rust/sqlx/src/occ_trait.rs
@@ -1,0 +1,145 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Trait-based OCC retry with automatic query retry.
+
+use crate::occ_retry::OCCRetryConfig;
+use crate::retry_query::RetryQuery;
+use crate::{DsqlError, Result};
+use sqlx::pool::PoolConnection;
+use sqlx::postgres::{PgPool, Postgres};
+use sqlx::Transaction;
+
+/// Trait for executing queries with automatic OCC retry.
+///
+/// Implemented for `PgPool` with default configuration. For custom retry
+/// configuration, use `pool::connect_with_retry()` to get a `RetryPool<PgPool>`.
+pub trait RetryExecutor: Clone + Send + Sync {
+    /// Override to customize retry behavior.
+    fn retry_config(&self) -> OCCRetryConfig {
+        OCCRetryConfig::default()
+    }
+
+    /// Create a query with automatic OCC retry.
+    fn query<'q>(&self, sql: &'q str) -> RetryQuery<'q, Self> {
+        RetryQuery::new(sql, self.clone(), self.retry_config())
+    }
+}
+
+/// Built-in implementation for sqlx PgPool with default retry configuration.
+impl RetryExecutor for PgPool {}
+
+/// Pool wrapper with automatic OCC retry via `RetryExecutor`.
+///
+/// Create via `pool::connect_with_retry()` to specify custom retry configuration.
+/// Use `.query()` for automatic retry, or `.begin()`/`.acquire()` for transactions.
+
+#[derive(Clone)]
+#[non_exhaustive]
+pub struct RetryPool<P> {
+    inner: P,
+    config: OCCRetryConfig,
+}
+
+impl<P> RetryPool<P> {
+    /// Create a new RetryPool wrapping an executor with a retry configuration.
+    pub fn new(pool: P, config: OCCRetryConfig) -> Self {
+        Self {
+            inner: pool,
+            config,
+        }
+    }
+
+    /// Get a reference to the inner pool.
+    pub fn inner(&self) -> &P {
+        &self.inner
+    }
+
+    /// Get a reference to the retry configuration.
+    pub fn config(&self) -> &OCCRetryConfig {
+        &self.config
+    }
+}
+
+impl<P: RetryExecutor> RetryExecutor for RetryPool<P> {
+    fn retry_config(&self) -> OCCRetryConfig {
+        self.config.clone()
+    }
+}
+
+/// Convenience methods for `RetryPool<PgPool>` to delegate common operations.
+impl RetryPool<PgPool> {
+    /// Create a query with automatic OCC retry using this pool's custom configuration.
+    ///
+    /// This shadows the trait default to ensure the executor passed to `RetryQuery`
+    /// is the inner `PgPool` (which satisfies the `Executor` bound), not the wrapper.
+    pub fn query<'q>(&self, sql: &'q str) -> RetryQuery<'q, PgPool> {
+        RetryQuery::new(sql, self.inner.clone(), self.retry_config())
+    }
+
+    /// Begin a transaction. Use `.query()` for automatic retry on single statements.
+    ///
+    /// Note: Transactions should wrap retry logic at the transaction level using
+    /// `retry_on_occ()` rather than retrying individual statements within a transaction.
+    pub async fn begin(&self) -> Result<Transaction<'_, Postgres>> {
+        self.inner.begin().await.map_err(DsqlError::DatabaseError)
+    }
+
+    /// Acquire a connection from the pool.
+    pub async fn acquire(&self) -> Result<PoolConnection<Postgres>> {
+        self.inner.acquire().await.map_err(DsqlError::DatabaseError)
+    }
+
+    /// Close the underlying pool and stop the background token refresh task.
+    ///
+    /// This will wait for all connections to be returned to the pool and then
+    /// close them. The background task that refreshes IAM tokens will also be stopped.
+    pub async fn close(&self) {
+        self.inner.close().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_retry_pool_stores_config() {
+        let pool = PgPool::connect_lazy("postgres://localhost/test").unwrap();
+        let config = OCCRetryConfig::default();
+        let retry_pool = RetryPool::new(pool, config.clone());
+
+        assert_eq!(retry_pool.config().max_attempts(), config.max_attempts());
+    }
+
+    #[tokio::test]
+    async fn test_retry_pool_implements_retry_executor() {
+        let pool = PgPool::connect_lazy("postgres://localhost/test").unwrap();
+        let config = OCCRetryConfig::default();
+        let retry_pool = RetryPool::new(pool, config);
+
+        // Should be able to call .query() via trait
+        let _query = retry_pool.query("SELECT 1");
+    }
+
+    #[tokio::test]
+    async fn test_retry_pool_clone() {
+        let pool = PgPool::connect_lazy("postgres://localhost/test").unwrap();
+        let config = OCCRetryConfig::default();
+        let retry_pool = RetryPool::new(pool, config);
+
+        let cloned = retry_pool.clone();
+        assert_eq!(
+            cloned.config().max_attempts(),
+            retry_pool.config().max_attempts()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_pgpool_implements_retry_executor() {
+        let pool = PgPool::connect_lazy("postgres://localhost/test").unwrap();
+
+        // Should be able to call .query() via trait
+        let _query = pool.query("SELECT 1");
+    }
+}

--- a/rust/sqlx/src/pool.rs
+++ b/rust/sqlx/src/pool.rs
@@ -75,3 +75,26 @@ async fn refresh_token(
     pool.set_connect_options(config.build_connect_options(sdk_config, &token)?);
     Ok(())
 }
+
+/// Parse a connection string, create a PgPool with retry, verify connectivity,
+/// and spawn a background token refresh task.
+#[cfg(feature = "occ")]
+pub async fn connect_with_retry(
+    url: &str,
+    retry_config: crate::occ_retry::OCCRetryConfig,
+) -> Result<crate::occ_trait::RetryPool<PgPool>> {
+    let config = DsqlConnectOptions::from_connection_string(url)?;
+    connect_with_retry_opts(&config, PgPoolOptions::new(), retry_config).await
+}
+
+/// Create a PgPool with retry from pre-built options, verify connectivity,
+/// and spawn a background token refresh task.
+#[cfg(feature = "occ")]
+pub async fn connect_with_retry_opts(
+    config: &DsqlConnectOptions,
+    pool_options: PgPoolOptions,
+    retry_config: crate::occ_retry::OCCRetryConfig,
+) -> Result<crate::occ_trait::RetryPool<PgPool>> {
+    let pool = connect_with(config, pool_options).await?;
+    Ok(crate::occ_trait::RetryPool::new(pool, retry_config))
+}

--- a/rust/sqlx/src/retry_query.rs
+++ b/rust/sqlx/src/retry_query.rs
@@ -1,0 +1,170 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Query builder with automatic OCC retry.
+
+use crate::occ_retry::{retry_on_occ, OCCRetryConfig};
+use crate::Result;
+use sqlx::postgres::{PgArguments, PgQueryResult, PgRow};
+use sqlx::query::Query;
+use sqlx::{Encode, Executor, Postgres, Type};
+
+/// Type-erased parameter storage for replay on retry.
+trait BoundParameter: Send + Sync {
+    fn bind_to<'q>(
+        &self,
+        query: Query<'q, Postgres, PgArguments>,
+    ) -> Query<'q, Postgres, PgArguments>;
+}
+struct TypedParameter<T> {
+    value: T,
+}
+
+impl<T> BoundParameter for TypedParameter<T>
+where
+    T: for<'q> Encode<'q, Postgres> + Type<Postgres> + Send + Sync + Clone + 'static,
+{
+    fn bind_to<'q>(
+        &self,
+        query: Query<'q, Postgres, PgArguments>,
+    ) -> Query<'q, Postgres, PgArguments> {
+        query.bind(self.value.clone())
+    }
+}
+
+/// Query builder with automatic OCC retry.
+///
+/// Created via `executor.query()`. Most useful for single-statement writes.
+/// Multi-statement transactions should use `retry_on_occ` instead
+pub struct RetryQuery<'q, E> {
+    sql: &'q str,
+    params: Vec<Box<dyn BoundParameter>>,
+    executor: E,
+    config: OCCRetryConfig,
+    retry_enabled: bool,
+}
+
+impl<'q, E> RetryQuery<'q, E> {
+    pub(crate) fn new(sql: &'q str, executor: E, config: OCCRetryConfig) -> Self {
+        Self {
+            sql,
+            params: Vec::new(),
+            executor,
+            config,
+            retry_enabled: true,
+        }
+    }
+
+    /// Bind a parameter. Stores value for replay on retry.
+    pub fn bind<T>(mut self, value: T) -> Self
+    where
+        T: for<'e> Encode<'e, Postgres> + Type<Postgres> + Send + Sync + Clone + 'static,
+    {
+        self.params.push(Box::new(TypedParameter { value }));
+        self
+    }
+
+    /// Disable retry for this query.
+    pub fn without_retry(mut self) -> Self {
+        self.retry_enabled = false;
+        self
+    }
+
+    fn build_query(&self) -> Query<'q, Postgres, PgArguments> {
+        let mut query = sqlx::query(self.sql);
+        for param in &self.params {
+            query = param.bind_to(query);
+        }
+        query
+    }
+}
+
+/// Implement fetch methods with optional retry.
+macro_rules! impl_fetch_method {
+    ($method:ident, $ret:ty, $doc:expr) => {
+        #[doc = $doc]
+        pub async fn $method(self) -> Result<$ret>
+        where
+            for<'e> &'e E: Executor<'e, Database = Postgres>,
+        {
+            if !self.retry_enabled {
+                return self
+                    .build_query()
+                    .$method(&self.executor)
+                    .await
+                    .map_err(crate::DsqlError::DatabaseError);
+            }
+
+            retry_on_occ(&self.config, || async {
+                self.build_query().$method(&self.executor).await
+            })
+            .await
+        }
+    };
+}
+
+impl<'q, E> RetryQuery<'q, E> {
+    impl_fetch_method!(
+        execute,
+        PgQueryResult,
+        "Execute the query, returning the number of rows affected."
+    );
+    impl_fetch_method!(
+        fetch_one,
+        PgRow,
+        "Fetch a single row, returning an error if no rows or multiple rows are returned."
+    );
+    impl_fetch_method!(
+        fetch_all,
+        Vec<PgRow>,
+        "Fetch all rows returned by the query."
+    );
+    impl_fetch_method!(
+        fetch_optional,
+        Option<PgRow>,
+        "Fetch a single row if present, or None if no rows are returned."
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_bind_stores_parameters() {
+        let config = OCCRetryConfig::default();
+        let query = RetryQuery::new("SELECT $1, $2", (), config)
+            .bind(1_i32)
+            .bind("test");
+
+        assert_eq!(query.params.len(), 2);
+        assert_eq!(query.sql, "SELECT $1, $2");
+    }
+
+    #[test]
+    fn test_without_retry_disables_retry() {
+        let config = OCCRetryConfig::default();
+        let query = RetryQuery::new("SELECT 1", (), config).without_retry();
+
+        assert!(!query.retry_enabled);
+    }
+
+    #[test]
+    fn test_retry_enabled_by_default() {
+        let config = OCCRetryConfig::default();
+        let query = RetryQuery::new("SELECT 1", (), config);
+
+        assert!(query.retry_enabled);
+    }
+
+    #[test]
+    fn test_bind_chainable() {
+        let config = OCCRetryConfig::default();
+        let query = RetryQuery::new("SELECT $1, $2, $3", (), config)
+            .bind(1_i32)
+            .bind("test")
+            .bind(vec![1u8, 2u8, 3u8]);
+
+        assert_eq!(query.params.len(), 3);
+    }
+}

--- a/rust/sqlx/tests/integration/mod.rs
+++ b/rust/sqlx/tests/integration/mod.rs
@@ -5,4 +5,6 @@ mod test_util;
 
 mod connection_integration_test;
 #[cfg(all(feature = "pool", feature = "occ"))]
+mod occ_trait_integration_test;
+#[cfg(all(feature = "pool", feature = "occ"))]
 mod pool_integration_test;

--- a/rust/sqlx/tests/integration/occ_trait_integration_test.rs
+++ b/rust/sqlx/tests/integration/occ_trait_integration_test.rs
@@ -1,0 +1,642 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Integration tests for trait-based OCC retry.
+//!
+//! These tests require a running Aurora DSQL cluster with credentials configured.
+//! Set CLUSTER_ENDPOINT environment variable to run these tests.
+
+use aurora_dsql_sqlx_connector::{
+    is_occ_error, pool, retry_on_occ, OCCRetryConfig, OCCRetryConfigBuilder, Result, RetryExecutor,
+};
+use sqlx::{Acquire, Row};
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::Arc;
+
+use super::test_util::build_conn_str;
+
+#[tokio::test]
+async fn test_journey_1_default_config_pgpool() -> Result<()> {
+    // Journey 1: sqlx pool + default config (simplest)
+    let url = build_conn_str();
+    let table_name = format!("test_j1_{}", std::process::id());
+
+    let pool = pool::connect(&url).await?;
+
+    let occ_config = OCCRetryConfigBuilder::default()
+        .max_attempts(10)
+        .base_delay_ms(100)
+        .build()
+        .unwrap();
+
+    // Create test table with OCC retry in transaction (handles schema propagation delays)
+    retry_on_occ(&occ_config, || {
+        let pool = pool.clone();
+        let t = table_name.clone();
+        async move {
+            let mut conn = pool.acquire().await?;
+            let mut tx = conn.begin().await?;
+            sqlx::query(&format!(
+                "CREATE TABLE IF NOT EXISTS {} (id INTEGER PRIMARY KEY, value TEXT)",
+                t
+            ))
+            .execute(&mut *tx)
+            .await?;
+            tx.commit().await?;
+            Ok(())
+        }
+    })
+    .await?;
+
+    // Insert with automatic retry using trait
+    pool.query(&format!(
+        "INSERT INTO {} (id, value) VALUES ($1, $2)",
+        table_name
+    ))
+    .bind(1)
+    .bind("alice")
+    .execute()
+    .await?;
+
+    // Fetch with automatic retry
+    let row = pool
+        .query(&format!("SELECT value FROM {} WHERE id = $1", table_name))
+        .bind(1)
+        .fetch_one()
+        .await?;
+
+    let value: String = row.get("value");
+    assert_eq!(value, "alice");
+
+    // Cleanup
+    pool.query(&format!("DROP TABLE {}", table_name))
+        .execute()
+        .await?;
+
+    pool.close().await;
+    Ok(())
+}
+
+#[tokio::test]
+
+async fn test_journey_2_custom_config_retry_pool() -> Result<()> {
+    // Journey 2: sqlx pool + custom config
+    let url = build_conn_str();
+    let table_name = format!("test_j2_{}", std::process::id());
+
+    let config = OCCRetryConfigBuilder::default()
+        .max_attempts(10)
+        .base_delay_ms(100)
+        .max_delay_ms(2000)
+        .build()
+        .unwrap();
+
+    let pool = pool::connect_with_retry(&url, config.clone()).await?;
+
+    // Verify config is stored
+    assert_eq!(pool.config().max_attempts(), 10);
+    assert_eq!(pool.config().base_delay_ms(), 100);
+
+    // Create test table with OCC retry in transaction
+    retry_on_occ(&config, || {
+        let inner_pool = pool.inner().clone();
+        let t = table_name.clone();
+        async move {
+            let mut conn = inner_pool.acquire().await?;
+            let mut tx = conn.begin().await?;
+            sqlx::query(&format!(
+                "CREATE TABLE IF NOT EXISTS {} (id INTEGER PRIMARY KEY, balance INTEGER)",
+                t
+            ))
+            .execute(&mut *tx)
+            .await?;
+            tx.commit().await?;
+            Ok(())
+        }
+    })
+    .await?;
+
+    pool.query(&format!(
+        "INSERT INTO {} (id, balance) VALUES (1, 1000)",
+        table_name
+    ))
+    .execute()
+    .await?;
+
+    // Update with custom retry config
+    pool.query(&format!(
+        "UPDATE {} SET balance = balance - $1 WHERE id = $2",
+        table_name
+    ))
+    .bind(100)
+    .bind(1)
+    .execute()
+    .await?;
+
+    // Verify result
+    let row = pool
+        .query(&format!("SELECT balance FROM {} WHERE id = 1", table_name))
+        .fetch_one()
+        .await?;
+
+    let balance: i32 = row.get("balance");
+    assert_eq!(balance, 900);
+
+    // Test .begin() delegation with retry wrapper for schema propagation
+    retry_on_occ(&config, || {
+        let inner_pool = pool.inner().clone();
+        let t = table_name.clone();
+        async move {
+            let mut conn = inner_pool.acquire().await?;
+            let mut tx = conn.begin().await?;
+            sqlx::query(&format!("INSERT INTO {} (id, balance) VALUES (2, 500)", t))
+                .execute(&mut *tx)
+                .await?;
+            tx.commit().await
+        }
+    })
+    .await?;
+
+    // Cleanup
+    pool.query(&format!("DROP TABLE {}", table_name))
+        .execute()
+        .await?;
+
+    pool.close().await;
+    Ok(())
+}
+
+#[tokio::test]
+
+async fn test_journey_3_per_query_opt_out() -> Result<()> {
+    // Journey 3: Per-query opt-out
+    let url = build_conn_str();
+    let table_name = format!("test_j3_{}", std::process::id());
+
+    let pool = pool::connect(&url).await?;
+
+    let occ_config = OCCRetryConfigBuilder::default()
+        .max_attempts(10)
+        .base_delay_ms(100)
+        .build()
+        .unwrap();
+
+    // Create test table with OCC retry in transaction
+    retry_on_occ(&occ_config, || {
+        let pool = pool.clone();
+        let t = table_name.clone();
+        async move {
+            let mut conn = pool.acquire().await?;
+            let mut tx = conn.begin().await?;
+            sqlx::query(&format!(
+                "CREATE TABLE IF NOT EXISTS {} (id INTEGER PRIMARY KEY, data TEXT)",
+                t
+            ))
+            .execute(&mut *tx)
+            .await?;
+            tx.commit().await?;
+            Ok(())
+        }
+    })
+    .await?;
+
+    // Write with retry (default)
+    pool.query(&format!(
+        "INSERT INTO {} (id, data) VALUES ($1, $2)",
+        table_name
+    ))
+    .bind(1)
+    .bind("event_data")
+    .execute()
+    .await?;
+
+    // Read without retry (opt-out)
+    let row = pool
+        .query(&format!("SELECT COUNT(*) as total FROM {}", table_name))
+        .without_retry()
+        .fetch_one()
+        .await?;
+
+    let count: i64 = row.get("total");
+    assert_eq!(count, 1);
+
+    // Cleanup
+    pool.query(&format!("DROP TABLE {}", table_name))
+        .execute()
+        .await?;
+
+    pool.close().await;
+    Ok(())
+}
+
+#[tokio::test]
+
+async fn test_journey_5_single_connection_with_retry_on_occ() -> Result<()> {
+    // Journey 5: Single connection with retry_on_occ
+    let url = build_conn_str();
+
+    let config = OCCRetryConfig::default();
+
+    // Create table outside retry closure
+    let pool = pool::connect(&url).await?;
+    pool.query("DROP TABLE IF EXISTS test_journey_5")
+        .execute()
+        .await
+        .ok();
+    pool.query("CREATE TABLE test_journey_5 (id INTEGER PRIMARY KEY, value TEXT)")
+        .execute()
+        .await?;
+    pool.close().await;
+
+    // Use retry_on_occ with connection::connect
+    retry_on_occ(&config, || async {
+        let mut conn = aurora_dsql_sqlx_connector::connection::connect(&url)
+            .await
+            .map_err(|e| match e {
+                aurora_dsql_sqlx_connector::DsqlError::ConnectionError(sqlx_err) => sqlx_err,
+                other => sqlx::Error::Protocol(other.to_string().into()),
+            })?;
+
+        sqlx::query("INSERT INTO test_journey_5 (id, value) VALUES ($1, $2)")
+            .bind(1)
+            .bind("test")
+            .execute(&mut conn)
+            .await
+    })
+    .await?;
+
+    // Verify insertion
+    let pool2 = pool::connect(&url).await?;
+    let row = pool2
+        .query("SELECT value FROM test_journey_5 WHERE id = 1")
+        .fetch_one()
+        .await?;
+
+    let value: String = row.get("value");
+    assert_eq!(value, "test");
+
+    // Cleanup
+    pool2.query("DROP TABLE test_journey_5").execute().await?;
+    pool2.close().await;
+    Ok(())
+}
+
+#[tokio::test]
+
+async fn test_parameter_replay_across_retries() -> Result<()> {
+    let url = build_conn_str();
+    let table_name = format!("test_params_{}", std::process::id());
+
+    let occ_config = OCCRetryConfigBuilder::default()
+        .max_attempts(10)
+        .base_delay_ms(100)
+        .build()
+        .unwrap();
+
+    let pool = pool::connect_with_retry(&url, occ_config.clone()).await?;
+
+    // Create test table with OCC retry in transaction
+    retry_on_occ(&occ_config, || {
+        let inner_pool = pool.inner().clone();
+        let t = table_name.clone();
+        async move {
+            let mut conn = inner_pool.acquire().await?;
+            let mut tx = conn.begin().await?;
+            sqlx::query(&format!(
+                "CREATE TABLE IF NOT EXISTS {} (id INTEGER PRIMARY KEY, name TEXT, age INTEGER)",
+                t
+            ))
+            .execute(&mut *tx)
+            .await?;
+            tx.commit().await?;
+            Ok(())
+        }
+    })
+    .await?;
+
+    // Insert with multiple parameters using automatic retry
+    pool.query(&format!(
+        "INSERT INTO {} (id, name, age) VALUES ($1, $2, $3)",
+        table_name
+    ))
+    .bind(1)
+    .bind("alice")
+    .bind(30)
+    .execute()
+    .await?;
+
+    // Verify all parameters were correctly bound
+    let row = pool
+        .query(&format!(
+            "SELECT name, age FROM {} WHERE id = 1",
+            table_name
+        ))
+        .fetch_one()
+        .await?;
+
+    let name: String = row.get("name");
+    let age: i32 = row.get("age");
+    assert_eq!(name, "alice");
+    assert_eq!(age, 30);
+
+    // Cleanup
+    pool.query(&format!("DROP TABLE {}", table_name))
+        .execute()
+        .await?;
+
+    pool.close().await;
+    Ok(())
+}
+
+#[tokio::test]
+
+async fn test_fetch_all_with_retry() -> Result<()> {
+    let url = build_conn_str();
+    let table_name = format!("test_fetch_all_{}", std::process::id());
+
+    let occ_config = OCCRetryConfigBuilder::default()
+        .max_attempts(10)
+        .base_delay_ms(100)
+        .build()
+        .unwrap();
+
+    let pool = pool::connect_with_retry(&url, occ_config.clone()).await?;
+
+    // Create test table with OCC retry in transaction
+    retry_on_occ(&occ_config, || {
+        let pool = pool.clone();
+        let t = table_name.clone();
+        async move {
+            let mut conn = pool.acquire().await?;
+            let mut tx = conn.begin().await?;
+            sqlx::query(&format!(
+                "CREATE TABLE IF NOT EXISTS {} (id INTEGER PRIMARY KEY, value TEXT)",
+                t
+            ))
+            .execute(&mut *tx)
+            .await?;
+            tx.commit().await?;
+            Ok(())
+        }
+    })
+    .await?;
+
+    // Insert multiple rows
+    for i in 1..=5 {
+        pool.query(&format!(
+            "INSERT INTO {} (id, value) VALUES ($1, $2)",
+            table_name
+        ))
+        .bind(i)
+        .bind(format!("value_{}", i))
+        .execute()
+        .await?;
+    }
+
+    // Fetch all rows
+    let rows = pool
+        .query(&format!("SELECT id, value FROM {} ORDER BY id", table_name))
+        .fetch_all()
+        .await?;
+
+    assert_eq!(rows.len(), 5);
+    for (idx, row) in rows.iter().enumerate() {
+        let id: i32 = row.get("id");
+        let value: String = row.get("value");
+        assert_eq!(id, (idx + 1) as i32);
+        assert_eq!(value, format!("value_{}", idx + 1));
+    }
+
+    // Cleanup
+    pool.query(&format!("DROP TABLE {}", table_name))
+        .execute()
+        .await?;
+
+    pool.close().await;
+    Ok(())
+}
+
+#[tokio::test]
+
+async fn test_fetch_optional_with_retry() -> Result<()> {
+    let url = build_conn_str();
+    let table_name = format!("test_fetch_opt_{}", std::process::id());
+
+    let pool = pool::connect(&url).await?;
+
+    let occ_config = OCCRetryConfigBuilder::default()
+        .max_attempts(10)
+        .base_delay_ms(100)
+        .build()
+        .unwrap();
+
+    // Create test table with OCC retry in transaction
+    retry_on_occ(&occ_config, || {
+        let pool = pool.clone();
+        let t = table_name.clone();
+        async move {
+            let mut conn = pool.acquire().await?;
+            let mut tx = conn.begin().await?;
+            sqlx::query(&format!(
+                "CREATE TABLE IF NOT EXISTS {} (id INTEGER PRIMARY KEY, value TEXT)",
+                t
+            ))
+            .execute(&mut *tx)
+            .await?;
+            tx.commit().await?;
+            Ok(())
+        }
+    })
+    .await?;
+
+    // Fetch from empty table (should return None)
+    let result = pool
+        .query(&format!("SELECT value FROM {} WHERE id = 1", table_name))
+        .fetch_optional()
+        .await?;
+
+    assert!(result.is_none());
+
+    // Insert a row
+    pool.query(&format!(
+        "INSERT INTO {} (id, value) VALUES (1, 'exists')",
+        table_name
+    ))
+    .execute()
+    .await?;
+
+    // Fetch again (should return Some)
+    let result = pool
+        .query(&format!("SELECT value FROM {} WHERE id = 1", table_name))
+        .fetch_optional()
+        .await?;
+
+    assert!(result.is_some());
+    let row = result.unwrap();
+    let value: String = row.get("value");
+    assert_eq!(value, "exists");
+
+    // Cleanup
+    pool.query(&format!("DROP TABLE {}", table_name))
+        .execute()
+        .await?;
+
+    pool.close().await;
+    Ok(())
+}
+
+#[tokio::test]
+
+async fn test_actual_occ_retry() -> Result<()> {
+    // This test simulates an actual OCC conflict and verifies retry behavior.
+    // NOTE: Creating reliable OCC conflicts in tests is challenging.
+    // This test uses a counter to verify retry logic is invoked.
+
+    let url = build_conn_str();
+    let table_name = format!("test_occ_{}", std::process::id());
+
+    let occ_config = OCCRetryConfigBuilder::default()
+        .max_attempts(10)
+        .base_delay_ms(100)
+        .build()
+        .unwrap();
+
+    let pool = pool::connect_with_retry(&url, occ_config.clone()).await?;
+
+    // Create test table with OCC retry in transaction
+    retry_on_occ(&occ_config, || {
+        let pool = pool.clone();
+        let t = table_name.clone();
+        async move {
+            let mut conn = pool.acquire().await?;
+            let mut tx = conn.begin().await?;
+            sqlx::query(&format!(
+                "CREATE TABLE IF NOT EXISTS {} (id INTEGER PRIMARY KEY, counter INTEGER)",
+                t
+            ))
+            .execute(&mut *tx)
+            .await?;
+            tx.commit().await?;
+            Ok(())
+        }
+    })
+    .await?;
+
+    retry_on_occ(&occ_config, || {
+        let pool = pool.clone();
+        let t = table_name.clone();
+        async move {
+            let mut conn = pool.acquire().await?;
+            let mut tx = conn.begin().await?;
+            sqlx::query(&format!("INSERT INTO {} (id, counter) VALUES (1, 0)", t))
+                .execute(&mut *tx)
+                .await?;
+            tx.commit().await?;
+            Ok(())
+        }
+    })
+    .await?;
+
+    // Simulate OCC conflict with concurrent transactions
+    let counter = Arc::new(AtomicU32::new(0));
+    let counter_clone = counter.clone();
+
+    let config = OCCRetryConfigBuilder::default()
+        .max_attempts(5)
+        .base_delay_ms(10)
+        .build()
+        .unwrap();
+
+    // Use retry_on_occ to wrap a transaction that might conflict
+    let result = retry_on_occ(&config, || {
+        let counter = counter_clone.clone();
+        let pool = pool.clone();
+        let t = table_name.clone();
+        async move {
+            counter.fetch_add(1, Ordering::SeqCst);
+
+            let mut tx = pool.begin().await?;
+            sqlx::query(&format!(
+                "UPDATE {} SET counter = counter + 1 WHERE id = 1",
+                t
+            ))
+            .execute(&mut *tx)
+            .await?;
+            tx.commit().await
+        }
+    })
+    .await;
+
+    // Should either succeed or exhaust retries with OCC error
+    // (Parallel test execution can cause real OCC conflicts)
+    match result {
+        Ok(_) => {
+            // Success - verify at least one attempt was made
+            assert!(counter.load(Ordering::SeqCst) >= 1);
+        }
+        Err(aurora_dsql_sqlx_connector::DsqlError::OCCRetryExhausted { attempts, .. }) => {
+            // OCC retry exhausted - verify we tried the configured number of times
+            assert_eq!(attempts, 5);
+            assert_eq!(counter.load(Ordering::SeqCst), 5);
+        }
+        Err(e) => panic!("Unexpected error: {:?}", e),
+    }
+
+    // Cleanup
+    pool.query(&format!("DROP TABLE {}", table_name))
+        .execute()
+        .await?;
+
+    pool.close().await;
+    Ok(())
+}
+
+#[tokio::test]
+
+async fn test_is_occ_error_detection() -> Result<()> {
+    // Test that is_occ_error correctly identifies OCC errors
+    // This is more of a unit test but included for completeness
+
+    let url = build_conn_str();
+
+    let pool = pool::connect(&url).await?;
+
+    // Create test table with constraint to trigger non-OCC error
+    pool.query("DROP TABLE IF EXISTS test_error_detection")
+        .execute()
+        .await
+        .ok();
+
+    pool.query("CREATE TABLE test_error_detection (id INTEGER PRIMARY KEY)")
+        .execute()
+        .await?;
+
+    pool.query("INSERT INTO test_error_detection (id) VALUES (1)")
+        .execute()
+        .await?;
+
+    // Try to insert duplicate - should get unique violation, not OCC error
+    let result = pool
+        .query("INSERT INTO test_error_detection (id) VALUES (1)")
+        .execute()
+        .await;
+
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+
+    // This should NOT be an OCC error (it's a unique constraint violation)
+    match err {
+        aurora_dsql_sqlx_connector::DsqlError::DatabaseError(sqlx_err) => {
+            assert!(!is_occ_error(&sqlx_err));
+        }
+        _ => panic!("Expected DatabaseError"),
+    }
+
+    // Cleanup
+    pool.query("DROP TABLE test_error_detection")
+        .execute()
+        .await?;
+
+    pool.close().await;
+    Ok(())
+}

--- a/rust/sqlx/tests/integration/pool_integration_test.rs
+++ b/rust/sqlx/tests/integration/pool_integration_test.rs
@@ -1,9 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use aurora_dsql_sqlx_connector::{DsqlConnectOptions, DsqlError, OCCRetryConfig, Result};
+use aurora_dsql_sqlx_connector::{DsqlConnectOptions, DsqlError, OCCRetryConfigBuilder, Result};
 use sqlx::postgres::PgPoolOptions;
-use sqlx::{Connection, Row};
+use sqlx::{Acquire, Row};
 use std::time::Duration;
 
 use super::test_util::build_conn_str;
@@ -16,7 +16,11 @@ async fn test_pool_transactional_write() -> Result<()> {
     let opts = DsqlConnectOptions::from_connection_string(&conn_str)?;
     let pool = aurora_dsql_sqlx_connector::pool::connect_with(&opts, PgPoolOptions::new()).await?;
 
-    let occ_config = OCCRetryConfig::default();
+    let occ_config = OCCRetryConfigBuilder::default()
+        .max_attempts(10)
+        .base_delay_ms(100)
+        .build()
+        .unwrap();
 
     // Setup: create table with OCC retry
     aurora_dsql_sqlx_connector::retry_on_occ(&occ_config, || {


### PR DESCRIPTION
Implement pool-agnostic retry system with trait pattern allowing pool-level opt-in and per-query opt-out. Includes type-erased parameter storage for replay on OCC conflicts.

Core changes:
- Add RetryExecutor trait with default impl for PgPool
- Add RetryPool wrapper for custom retry config
- Add RetryQuery builder with automatic parameter replay
- Add pool::connect_with_retry() for custom config
- Update retry_on_occ to use Fn (idempotency enforcement)
- Add getter methods to OCCRetryConfig

Integration tests updated to handle DSQL schema propagation delays using transactions with retry for DDL operations.

*Issue #, if available:*
N/A

*Description of changes:*
Implemented Automatic OCC retry trait for Rust connector

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
