### PR TITLE
Add OCCRetryExt trait for automatic OCC retry on PgPool

### DIFF
--- a/rust/sqlx/Cargo.toml
+++ b/rust/sqlx/Cargo.toml
@@ -14,7 +14,9 @@ categories = ["database", "authentication"]
 [features]
 default = []
 pool = ["dep:tokio", "tokio/rt", "tokio/time", "tokio/macros"]
-occ = ["dep:rand", "dep:tokio", "tokio/time"]
+occ = ["dep:rand", "dep:tokio", "tokio/time", "dep:async-trait"]
+tracing = ["dep:tracing"]
+occ-tracing = ["occ", "tracing"]
 
 [dependencies]
 sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "tls-rustls-ring"] }
@@ -25,8 +27,9 @@ thiserror = "2.0"
 url = "2.5"
 rand = { version = "0.10.0", optional = true }
 regex = "1"
-tracing = "0.1"
+tracing = { version = "0.1", optional = true }
 derive_builder = "0.20"
+async-trait = { version = "0.1", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt"] }

--- a/rust/sqlx/Cargo.toml
+++ b/rust/sqlx/Cargo.toml
@@ -15,8 +15,6 @@ categories = ["database", "authentication"]
 default = []
 pool = ["dep:tokio", "tokio/rt", "tokio/time", "tokio/macros"]
 occ = ["dep:rand", "dep:tokio", "tokio/time", "dep:async-trait"]
-tracing = ["dep:tracing"]
-occ-tracing = ["occ", "tracing"]
 
 [dependencies]
 sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "tls-rustls-ring"] }
@@ -27,7 +25,7 @@ thiserror = "2.0"
 url = "2.5"
 rand = { version = "0.10.0", optional = true }
 regex = "1"
-tracing = { version = "0.1", optional = true }
+log = "0.4"
 derive_builder = "0.20"
 async-trait = { version = "0.1", optional = true }
 

--- a/rust/sqlx/README.md
+++ b/rust/sqlx/README.md
@@ -44,7 +44,7 @@ aurora-dsql-sqlx-connector = "0.1.2"
 
 | Feature | Default | Description |
 |---------|---------|-------------|
-| `occ` | No | OCC retry helpers (`retry_on_occ`, `is_occ_error`, `OCCRetryExt` trait) |
+| `occ` | No | OCC retry helpers (`retry_on_occ`, `is_occ_error`); `OCCRetryExt` trait requires both `occ` and `pool` |
 | `pool` | No | sqlx pool helper with background token refresh |
 | `occ-tracing` | No | Optional logging for OCC retry attempts (requires `occ`) |
 

--- a/rust/sqlx/README.md
+++ b/rust/sqlx/README.md
@@ -44,14 +44,23 @@ aurora-dsql-sqlx-connector = "0.1.2"
 
 | Feature | Default | Description |
 |---------|---------|-------------|
-| `occ` | No | OCC retry helpers (`retry_on_occ`, `is_occ_error`) |
+| `occ` | No | OCC retry helpers (`retry_on_occ`, `is_occ_error`, `OCCRetryExt` trait) |
 | `pool` | No | sqlx pool helper with background token refresh |
+| `occ-tracing` | No | Optional logging for OCC retry attempts (requires `occ`) |
 
 For most applications, enable both features:
 
 ```toml
 [dependencies]
 aurora-dsql-sqlx-connector = { version = "0.1.2", features = ["pool", "occ"] }
+```
+
+Enable `occ-tracing` for debugging retry behavior:
+
+```toml
+[dependencies]
+aurora-dsql-sqlx-connector = { version = "0.1.2", features = ["pool", "occ", "occ-tracing"] }
+tracing-subscriber = "0.3"
 ```
 
 ## Configuration Options
@@ -239,34 +248,117 @@ Token duration defaults to 900 seconds. This can be customized via `tokenDuratio
 
 ## OCC Retry
 
-Aurora DSQL uses optimistic concurrency control. The connector provides helpers to detect and handle OCC errors (enable the `occ` feature):
+Aurora DSQL uses optimistic concurrency control (OCC). Transactions may fail with OCC errors when concurrent modifications conflict. The connector provides helpers to automatically detect and retry these operations (enable the `occ` feature).
+
+### Using the Extension Trait (Recommended)
+
+Import `OCCRetryExt` to add retry methods directly to `PgPool`:
 
 ```rust
-use aurora_dsql_sqlx_connector::{retry_on_occ, OCCRetryConfig};
+use aurora_dsql_sqlx_connector::OCCRetryExt;
 
-let config = OCCRetryConfig::default(); // max_attempts: 3, exponential backoff
-
-retry_on_occ(&config, || async {
-    let mut tx = pool.begin().await?;
-
+// With default config (3 attempts, exponential backoff)
+pool.transaction_with_retry(None, |tx| Box::pin(async move {
     sqlx::query("UPDATE accounts SET balance = balance - 100 WHERE id = $1")
         .bind(account_id)
-        .execute(&mut *tx)
+        .execute(&mut **tx)
         .await?;
+    Ok(())
+})).await?;
 
+// With custom config
+use aurora_dsql_sqlx_connector::OCCRetryConfigBuilder;
+
+let config = OCCRetryConfigBuilder::default()
+    .max_attempts(5u32)
+    .base_delay_ms(200u64)
+    .build()?;
+
+pool.transaction_with_retry(Some(&config), |tx| Box::pin(async move {
+    sqlx::query("INSERT INTO users VALUES ($1, $2)")
+        .bind(1)
+        .bind("alice")
+        .execute(&mut **tx)
+        .await?;
+    Ok(())
+})).await?;
+```
+
+**Opting Out:** For operations that don't need retry, use sqlx directly:
+
+```rust
+// Direct pool usage - no OCC retry
+let mut tx = pool.begin().await?;
+sqlx::query("SELECT * FROM users").execute(&mut *tx).await?;
+tx.commit().await?;
+```
+
+### Manual Retry (Advanced)
+
+For non-pool operations or custom retry logic:
+
+```rust
+use aurora_dsql_sqlx_connector::retry_on_occ;
+
+let config = OCCRetryConfig::default();
+retry_on_occ(&config, || async {
+    let mut conn = pool.acquire().await?;
+    let mut tx = conn.begin().await?;
+    // Custom logic with full control
     tx.commit().await?;
     Ok(())
 }).await?;
 ```
 
-**OCC Error Detection:**
-- SQLSTATE `40001` (serialization failure)
-- Error codes `OC000` (data conflict) and `OC001` (schema conflict)
+### Configuration
+
+Customize retry behavior with `OCCRetryConfigBuilder`:
+
+```rust
+use aurora_dsql_sqlx_connector::OCCRetryConfigBuilder;
+
+let config = OCCRetryConfigBuilder::default()
+    .max_attempts(5u32)          // Default: 3
+    .base_delay_ms(200u64)       // Default: 100ms
+    .max_delay_ms(10000u64)      // Default: 5000ms
+    .jitter_factor(0.25)         // Default: 0.25 (25%)
+    .build()?;
+```
 
 **Backoff Strategy:**
-- Exponential backoff: `base_delay * 2^(attempt-1)`
-- Additive jitter: 0-25% of delay
-- Max delay: 5000ms
+- Exponential: `delay = base_delay * 2^(attempt-1)`
+- Additive jitter: `jitter = delay * random(0..1) * jitter_factor`
+- Capped at `max_delay_ms`
+
+### Optional Retry Logging
+
+Enable the `occ-tracing` feature to log retry attempts:
+
+```toml
+[dependencies]
+aurora-dsql-sqlx-connector = { version = "0.1", features = ["pool", "occ", "occ-tracing"] }
+tracing-subscriber = "0.3"
+```
+
+Configure tracing in your application:
+
+```rust
+tracing_subscriber::fmt()
+    .with_env_filter("info,aurora_dsql_sqlx_connector=warn")
+    .init();
+```
+
+**Log Levels:**
+- `warn`: OCC conflict detected, retrying
+- `info`: Operation succeeded after retry
+- `error`: Max retry attempts exhausted
+
+### OCC Error Detection
+
+Automatically detects these error codes:
+- `40001`: SQLSTATE serialization failure
+- `OC000`: Data conflict
+- `OC001`: Schema conflict
 
 ## Examples
 

--- a/rust/sqlx/README.md
+++ b/rust/sqlx/README.md
@@ -45,7 +45,9 @@ aurora-dsql-sqlx-connector = "0.1.2"
 | Feature | Default | Description |
 |---------|---------|-------------|
 | `occ` | No | OCC retry helpers (`retry_on_occ`, `is_occ_error`, `OCCType`, `OCCRetryExt` trait for `PgConnection`) |
-| `pool` | No | sqlx pool helper with background token refresh; enables `OCCRetryExt` for `PgPool` (requires both `occ` and `pool`) |
+| `pool` | No | sqlx pool helper with background token refresh |
+
+**Note:** To use `OCCRetryExt` on `PgPool`, enable both `occ` and `pool` features.
 
 For most applications, enable both features:
 
@@ -280,7 +282,8 @@ use aurora_dsql_sqlx_connector::OCCRetryConfigBuilder;
 
 let config = OCCRetryConfigBuilder::default()
     .max_attempts(5u32)
-    .base_delay_ms(200u64)
+    .base_delay_ms(10u64)
+    .max_delay_ms(50u64)
     .build()?;
 
 pool.transaction_with_retry(Some(&config), |tx| Box::pin(async move {
@@ -343,8 +346,8 @@ use aurora_dsql_sqlx_connector::OCCRetryConfigBuilder;
 
 let config = OCCRetryConfigBuilder::default()
     .max_attempts(5u32)          // Default: 3
-    .base_delay_ms(200u64)       // Default: 100ms
-    .max_delay_ms(10000u64)      // Default: 5000ms
+    .base_delay_ms(10u64)        // Default: 1ms
+    .max_delay_ms(50u64)         // Default: 100ms
     .jitter_factor(0.25)         // Default: 0.25 (25%)
     .build()?;
 ```
@@ -357,12 +360,6 @@ let config = OCCRetryConfigBuilder::default()
 ### Retry Logging
 
 The connector uses the `log` crate for retry logging. If your application uses any log implementation (e.g., `env_logger`, `tracing-subscriber`), the connector's logs will be captured automatically.
-
-**Log Levels:**
-- `warn`: OCC conflict detected (includes type: Data/Schema/Unknown), retrying
-- `info`: Operation succeeded after retry (includes type)
-- `error`: Max retry attempts exhausted (includes type)
-- `debug`: Internal details (commit failures, rollback events)
 
 ### OCC Error Types
 

--- a/rust/sqlx/README.md
+++ b/rust/sqlx/README.md
@@ -369,9 +369,9 @@ The connector classifies OCC errors by type for better observability:
 |----------|---------|-------------|
 | `OC000` | `Data` | Data conflict - concurrent modification of same rows |
 | `OC001` | `Schema` | Schema conflict - DDL changes during transaction |
-| `40001` | `Unknown` | Generic serialization failure |
+| `40001` | `Unknown` | Generic serialization failure (parsed for embedded OC000/OC001) |
 
-Use `is_occ_error()` to detect and classify errors, or check logs for conflict types.
+Use `is_occ_error()` to detect and classify errors, or check logs for conflict types. Error codes are included in all retry log messages for better observability.
 
 ## Examples
 

--- a/rust/sqlx/README.md
+++ b/rust/sqlx/README.md
@@ -44,23 +44,14 @@ aurora-dsql-sqlx-connector = "0.1.2"
 
 | Feature | Default | Description |
 |---------|---------|-------------|
-| `occ` | No | OCC retry helpers (`retry_on_occ`, `is_occ_error`); `OCCRetryExt` trait requires both `occ` and `pool` |
-| `pool` | No | sqlx pool helper with background token refresh |
-| `occ-tracing` | No | Optional logging for OCC retry attempts (requires `occ`) |
+| `occ` | No | OCC retry helpers (`retry_on_occ`, `is_occ_error`, `OCCType`, `OCCRetryExt` trait for `PgConnection`) |
+| `pool` | No | sqlx pool helper with background token refresh; enables `OCCRetryExt` for `PgPool` (requires both `occ` and `pool`) |
 
 For most applications, enable both features:
 
 ```toml
 [dependencies]
 aurora-dsql-sqlx-connector = { version = "0.1.2", features = ["pool", "occ"] }
-```
-
-Enable `occ-tracing` for debugging retry behavior:
-
-```toml
-[dependencies]
-aurora-dsql-sqlx-connector = { version = "0.1.2", features = ["pool", "occ", "occ-tracing"] }
-tracing-subscriber = "0.3"
 ```
 
 ## Configuration Options
@@ -252,15 +243,33 @@ Aurora DSQL uses optimistic concurrency control (OCC). Transactions may fail wit
 
 ### Using the Extension Trait (Recommended)
 
-Import `OCCRetryExt` to add retry methods directly to `PgPool`:
+Import `OCCRetryExt` to add retry methods to `PgPool` or `PgConnection`:
 
 ```rust
 use aurora_dsql_sqlx_connector::OCCRetryExt;
 
-// With default config (3 attempts, exponential backoff)
+// With connection pool
+let mut pool = aurora_dsql_sqlx_connector::pool::connect(
+    "postgres://admin@cluster.dsql.us-east-1.on.aws/postgres"
+).await?;
+
 pool.transaction_with_retry(None, |tx| Box::pin(async move {
     sqlx::query("UPDATE accounts SET balance = balance - 100 WHERE id = $1")
         .bind(account_id)
+        .execute(&mut **tx)
+        .await?;
+    Ok(())
+})).await?;
+
+// With single connection
+let mut conn = aurora_dsql_sqlx_connector::connection::connect(
+    "postgres://admin@cluster.dsql.us-east-1.on.aws/postgres"
+).await?;
+
+conn.transaction_with_retry(None, |tx| Box::pin(async move {
+    sqlx::query("INSERT INTO users VALUES ($1, $2)")
+        .bind(1)
+        .bind("alice")
         .execute(&mut **tx)
         .await?;
     Ok(())
@@ -275,6 +284,21 @@ let config = OCCRetryConfigBuilder::default()
     .build()?;
 
 pool.transaction_with_retry(Some(&config), |tx| Box::pin(async move {
+    sqlx::query("INSERT INTO products VALUES ($1, $2)")
+        .bind(1)
+        .bind("Widget")
+        .execute(&mut **tx)
+        .await?;
+    Ok(())
+})).await?;
+```
+
+**Simplifying with `txn!` macro:** Hide `Box::pin` boilerplate:
+
+```rust
+use aurora_dsql_sqlx_connector::{txn, OCCRetryExt};
+
+pool.transaction_with_retry(None, |tx| txn!({
     sqlx::query("INSERT INTO users VALUES ($1, $2)")
         .bind(1)
         .bind("alice")
@@ -295,7 +319,7 @@ tx.commit().await?;
 
 ### Manual Retry (Advanced)
 
-For non-pool operations or custom retry logic:
+For custom retry logic or operations that need explicit transaction control:
 
 ```rust
 use aurora_dsql_sqlx_connector::retry_on_occ;
@@ -330,35 +354,27 @@ let config = OCCRetryConfigBuilder::default()
 - Additive jitter: `jitter = delay * random(0..1) * jitter_factor`
 - Capped at `max_delay_ms`
 
-### Optional Retry Logging
+### Retry Logging
 
-Enable the `occ-tracing` feature to log retry attempts:
-
-```toml
-[dependencies]
-aurora-dsql-sqlx-connector = { version = "0.1", features = ["pool", "occ", "occ-tracing"] }
-tracing-subscriber = "0.3"
-```
-
-Configure tracing in your application:
-
-```rust
-tracing_subscriber::fmt()
-    .with_env_filter("info,aurora_dsql_sqlx_connector=warn")
-    .init();
-```
+The connector uses the `log` crate for retry logging. If your application uses any log implementation (e.g., `env_logger`, `tracing-subscriber`), the connector's logs will be captured automatically.
 
 **Log Levels:**
-- `warn`: OCC conflict detected, retrying
-- `info`: Operation succeeded after retry
-- `error`: Max retry attempts exhausted
+- `warn`: OCC conflict detected (includes type: Data/Schema/Unknown), retrying
+- `info`: Operation succeeded after retry (includes type)
+- `error`: Max retry attempts exhausted (includes type)
+- `debug`: Internal details (commit failures, rollback events)
 
-### OCC Error Detection
+### OCC Error Types
 
-Automatically detects these error codes:
-- `40001`: SQLSTATE serialization failure
-- `OC000`: Data conflict
-- `OC001`: Schema conflict
+The connector classifies OCC errors by type for better observability:
+
+| SQLSTATE | OCCType | Description |
+|----------|---------|-------------|
+| `OC000` | `Data` | Data conflict - concurrent modification of same rows |
+| `OC001` | `Schema` | Schema conflict - DDL changes during transaction |
+| `40001` | `Unknown` | Generic serialization failure |
+
+Use `is_occ_error()` to detect and classify errors, or check logs for conflict types.
 
 ## Examples
 

--- a/rust/sqlx/example/README.md
+++ b/rust/sqlx/example/README.md
@@ -72,7 +72,7 @@ The **preferred example** demonstrates the following operations:
 
 - Opening a connection pool to an Aurora DSQL cluster
 - Creating a table
-- Performing a transactional insert with OCC retry using the `OCCRetryExt` trait ⚠️ transactions must be idempotent
+- Performing a transactional insert with OCC retry using the `OCCRetryExt` trait transactions must be idempotent
 - Opting out of OCC retry for operations that don't need it
 - Running concurrent queries across multiple tokio tasks
 

--- a/rust/sqlx/example/README.md
+++ b/rust/sqlx/example/README.md
@@ -72,7 +72,8 @@ The **preferred example** demonstrates the following operations:
 
 - Opening a connection pool to an Aurora DSQL cluster
 - Creating a table
-- Performing a transactional insert with OCC retry
+- Performing a transactional insert with OCC retry using the `OCCRetryExt` trait
+- Opting out of OCC retry for operations that don't need it
 - Running concurrent queries across multiple tokio tasks
 
 The preferred example is designed to work with both admin and non-admin users:

--- a/rust/sqlx/example/README.md
+++ b/rust/sqlx/example/README.md
@@ -72,7 +72,7 @@ The **preferred example** demonstrates the following operations:
 
 - Opening a connection pool to an Aurora DSQL cluster
 - Creating a table
-- Performing a transactional insert with OCC retry using the `OCCRetryExt` trait
+- Performing a transactional insert with OCC retry using the `OCCRetryExt` trait ⚠️ transactions must be idempotent
 - Opting out of OCC retry for operations that don't need it
 - Running concurrent queries across multiple tokio tasks
 

--- a/rust/sqlx/example/src/alternatives/README.md
+++ b/rust/sqlx/example/src/alternatives/README.md
@@ -1,20 +1,24 @@
 # Alternative Examples
 
-The recommended approach is `example_preferred.rs` in the parent directory, which uses a connection pool with background token refresh via the Aurora DSQL SQLx Connector.
+The recommended approach is `example_preferred.rs` in the parent directory, which uses a connection pool with background token refresh and automatic OCC retry via the Aurora DSQL SQLx Connector.
 
 ## Why Connection Pooling with the Connector?
 
 Aurora DSQL has specific connection characteristics:
 - **60-minute max connection lifetime** — connections are terminated after 1 hour
 - **IAM auth token expiry** — tokens can be valid for up to 7 days, but a 15-minute default is recommended for security best practices
+- **Optimistic concurrency control (OCC)** — transactions may conflict and require retry
 - **Optimized for concurrency** — more concurrent connections with smaller batches yields better throughput
 
-The connector pool helper (`aurora_dsql_sqlx_connector::pool::connect`) handles this automatically:
+The connector pool helper (`aurora_dsql_sqlx_connector::pool::connect`) with `OCCRetryExt` trait handles this automatically:
 - Refreshes IAM tokens in the background before they expire
+- Automatically retries transactions on OCC conflicts
 - Works with sqlx's standard `PgPool` for connection lifecycle management
 
 ## Alternatives
 
 ### `no_connection_pool/`
-Single connection without pooling:
+Single connection without pooling or automatic OCC retry:
 - `example_no_connection_pool.rs` — Direct connection using `connection::connect()`
+- Best for simple scripts or cases where pooling overhead isn't needed
+- Does not include automatic OCC retry (use `retry_on_occ` manually if needed)

--- a/rust/sqlx/example/src/alternatives/README.md
+++ b/rust/sqlx/example/src/alternatives/README.md
@@ -18,7 +18,8 @@ The connector pool helper (`aurora_dsql_sqlx_connector::pool::connect`) with `OC
 ## Alternatives
 
 ### `no_connection_pool/`
-Single connection without pooling or automatic OCC retry:
-- `example_no_connection_pool.rs` — Direct connection using `connection::connect()`
+Single connection without pooling:
+- `example_no_connection_pool.rs` — Direct connection using `connection::connect()` with `OCCRetryExt` for transactional retry
 - Best for simple scripts or cases where pooling overhead isn't needed
-- Does not include automatic OCC retry (use `retry_on_occ` manually if needed)
+- Supports automatic OCC retry via `OCCRetryExt` trait on `PgConnection`
+- Does not include background token refresh (connections are valid for token duration only)

--- a/rust/sqlx/example/src/alternatives/no_connection_pool/example_no_connection_pool.rs
+++ b/rust/sqlx/example/src/alternatives/no_connection_pool/example_no_connection_pool.rs
@@ -25,14 +25,16 @@ async fn main() -> anyhow::Result<()> {
     .await?;
 
     // -- Transactional write WITH OCC retry --
-    conn.transaction_with_retry(None, |tx| txn!({
-        sqlx::query("INSERT INTO owner(name, city) VALUES($1, $2)")
-            .bind("John Doe")
-            .bind("Anytown")
-            .execute(&mut **tx)
-            .await?;
-        Ok(())
-    }))
+    conn.transaction_with_retry(None, |tx| {
+        txn!({
+            sqlx::query("INSERT INTO owner(name, city) VALUES($1, $2)")
+                .bind("John Doe")
+                .bind("Anytown")
+                .execute(&mut **tx)
+                .await?;
+            Ok(())
+        })
+    })
     .await?;
 
     // Query it back

--- a/rust/sqlx/example/src/alternatives/no_connection_pool/example_no_connection_pool.rs
+++ b/rust/sqlx/example/src/alternatives/no_connection_pool/example_no_connection_pool.rs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use aurora_dsql_sqlx_connector::{txn, OCCRetryExt};
 use sqlx::{Executor, Row};
 
 #[tokio::main]
@@ -23,9 +24,16 @@ async fn main() -> anyhow::Result<()> {
     )
     .await?;
 
-    // Insert a row
-    conn.execute("INSERT INTO owner(name, city) VALUES('John Doe', 'Anytown')")
-        .await?;
+    // -- Transactional write WITH OCC retry --
+    conn.transaction_with_retry(None, |tx| txn!({
+        sqlx::query("INSERT INTO owner(name, city) VALUES($1, $2)")
+            .bind("John Doe")
+            .bind("Anytown")
+            .execute(&mut **tx)
+            .await?;
+        Ok(())
+    }))
+    .await?;
 
     // Query it back
     let row = sqlx::query("SELECT * FROM owner WHERE name = $1")

--- a/rust/sqlx/example/src/example_preferred.rs
+++ b/rust/sqlx/example/src/example_preferred.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use aurora_dsql_sqlx_connector::{DsqlConnectOptions, OCCRetryExt};
+use aurora_dsql_sqlx_connector::{txn, DsqlConnectOptions, OCCRetryExt};
 use sqlx::postgres::PgPoolOptions;
 use sqlx::{Executor, Row};
 
@@ -25,7 +25,7 @@ async fn main() -> anyhow::Result<()> {
     // connect_with() verifies connectivity and spawns a background token refresh task.
     let config = DsqlConnectOptions::from_connection_string(&conn_str)?;
     let schema_owned = schema.to_string();
-    let pool = aurora_dsql_sqlx_connector::pool::connect_with(
+    let mut pool = aurora_dsql_sqlx_connector::pool::connect_with(
         &config,
         PgPoolOptions::new()
             .max_connections(10)
@@ -70,17 +70,15 @@ async fn main() -> anyhow::Result<()> {
     )
     .await?;
 
-    // -- Transactional write WITH OCC retry (using trait) --
-    pool.transaction_with_retry(None, |tx| {
-        Box::pin(async move {
-            sqlx::query("INSERT INTO owner(name, city) VALUES($1, $2)")
-                .bind("John Doe")
-                .bind("Anytown")
-                .execute(&mut **tx)
-                .await?;
-            Ok(())
-        })
-    })
+    // -- Transactional write WITH OCC retry (using trait and txn! macro) --
+    pool.transaction_with_retry(None, |tx| txn!({
+        sqlx::query("INSERT INTO owner(name, city) VALUES($1, $2)")
+            .bind("John Doe")
+            .bind("Anytown")
+            .execute(&mut **tx)
+            .await?;
+        Ok(())
+    }))
     .await?;
 
     // Verify the write

--- a/rust/sqlx/example/src/example_preferred.rs
+++ b/rust/sqlx/example/src/example_preferred.rs
@@ -71,14 +71,16 @@ async fn main() -> anyhow::Result<()> {
     .await?;
 
     // -- Transactional write WITH OCC retry (using trait and txn! macro) --
-    pool.transaction_with_retry(None, |tx| txn!({
-        sqlx::query("INSERT INTO owner(name, city) VALUES($1, $2)")
-            .bind("John Doe")
-            .bind("Anytown")
-            .execute(&mut **tx)
-            .await?;
-        Ok(())
-    }))
+    pool.transaction_with_retry(None, |tx| {
+        txn!({
+            sqlx::query("INSERT INTO owner(name, city) VALUES($1, $2)")
+                .bind("John Doe")
+                .bind("Anytown")
+                .execute(&mut **tx)
+                .await?;
+            Ok(())
+        })
+    })
     .await?;
 
     // Verify the write

--- a/rust/sqlx/example/src/example_preferred.rs
+++ b/rust/sqlx/example/src/example_preferred.rs
@@ -1,9 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use aurora_dsql_sqlx_connector::{retry_on_occ, DsqlConnectOptions, OCCRetryConfig};
+use aurora_dsql_sqlx_connector::{DsqlConnectOptions, OCCRetryExt};
 use sqlx::postgres::PgPoolOptions;
-use sqlx::{Connection, Executor, Row};
+use sqlx::{Executor, Row};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -70,20 +70,16 @@ async fn main() -> anyhow::Result<()> {
     )
     .await?;
 
-    // -- Transactional write with OCC retry --
-    let occ_config = OCCRetryConfig::default();
-    retry_on_occ(&occ_config, || async {
-        let mut conn = pool.acquire().await?;
-        let mut tx = conn.begin().await?;
-
-        sqlx::query("INSERT INTO owner(name, city) VALUES($1, $2)")
-            .bind("John Doe")
-            .bind("Anytown")
-            .execute(&mut *tx)
-            .await?;
-
-        tx.commit().await?;
-        Ok(())
+    // -- Transactional write WITH OCC retry (using trait) --
+    pool.transaction_with_retry(None, |tx| {
+        Box::pin(async move {
+            sqlx::query("INSERT INTO owner(name, city) VALUES($1, $2)")
+                .bind("John Doe")
+                .bind("Anytown")
+                .execute(&mut **tx)
+                .await?;
+            Ok(())
+        })
     })
     .await?;
 
@@ -97,11 +93,14 @@ async fn main() -> anyhow::Result<()> {
     let city: &str = row.get("city");
     println!("Inserted: name={}, city={}", name, city);
 
-    // Clean up
+    // -- Transactional write WITHOUT OCC retry (opt-out) --
+    // For operations that don't need retry, use sqlx directly
+    let mut tx = pool.begin().await?;
     sqlx::query("DELETE FROM owner WHERE name = $1")
         .bind("John Doe")
-        .execute(&pool)
+        .execute(&mut *tx)
         .await?;
+    tx.commit().await?;
 
     println!("Transactional write completed successfully");
 

--- a/rust/sqlx/src/config.rs
+++ b/rust/sqlx/src/config.rs
@@ -101,10 +101,13 @@ impl DsqlConnectOptions {
                 }
                 "ormPrefix" => orm_prefix = Some(value.to_string()),
                 other => {
+                    #[cfg(feature = "tracing")]
                     tracing::warn!(
                         param = other,
                         "aurora-dsql: ignoring unrecognized connection parameter"
                     );
+                    #[cfg(not(feature = "tracing"))]
+                    let _ = other;
                 }
             }
         }

--- a/rust/sqlx/src/config.rs
+++ b/rust/sqlx/src/config.rs
@@ -101,13 +101,10 @@ impl DsqlConnectOptions {
                 }
                 "ormPrefix" => orm_prefix = Some(value.to_string()),
                 other => {
-                    #[cfg(feature = "tracing")]
-                    tracing::warn!(
-                        param = other,
-                        "aurora-dsql: ignoring unrecognized connection parameter"
+                    log::debug!(
+                        "aurora-dsql: ignoring unrecognized connection parameter: {}",
+                        other
                     );
-                    #[cfg(not(feature = "tracing"))]
-                    let _ = other;
                 }
             }
         }

--- a/rust/sqlx/src/error.rs
+++ b/rust/sqlx/src/error.rs
@@ -27,3 +27,10 @@ pub enum DsqlError {
         source: Box<DsqlError>,
     },
 }
+
+#[cfg(feature = "occ")]
+impl From<crate::occ_retry::OCCRetryConfigBuilderError> for DsqlError {
+    fn from(err: crate::occ_retry::OCCRetryConfigBuilderError) -> Self {
+        DsqlError::ConfigError(Box::new(err))
+    }
+}

--- a/rust/sqlx/src/error.rs
+++ b/rust/sqlx/src/error.rs
@@ -3,6 +3,9 @@
 
 use thiserror::Error;
 
+#[cfg(feature = "occ")]
+use crate::occ_retry::OCCType;
+
 pub type Result<T> = std::result::Result<T, DsqlError>;
 
 #[derive(Error, Debug)]
@@ -24,7 +27,7 @@ pub enum DsqlError {
     #[error("OCC retry exhausted after {attempts} attempts (type: {occ_type:?}): {source}")]
     OCCRetryExhausted {
         attempts: u32,
-        occ_type: crate::occ_retry::OCCType,
+        occ_type: OCCType,
         #[source]
         source: Box<DsqlError>,
     },

--- a/rust/sqlx/src/error.rs
+++ b/rust/sqlx/src/error.rs
@@ -20,9 +20,11 @@ pub enum DsqlError {
     #[error("database error: {0}")]
     DatabaseError(#[source] sqlx::Error),
 
-    #[error("OCC retry exhausted after {attempts} attempts: {source}")]
+    #[cfg(feature = "occ")]
+    #[error("OCC retry exhausted after {attempts} attempts (type: {occ_type:?}): {source}")]
     OCCRetryExhausted {
         attempts: u32,
+        occ_type: crate::occ_retry::OCCType,
         #[source]
         source: Box<DsqlError>,
     },

--- a/rust/sqlx/src/lib.rs
+++ b/rust/sqlx/src/lib.rs
@@ -16,5 +16,7 @@ pub(crate) mod util;
 pub use aws_config::Region;
 pub use config::{DsqlConnectOptions, DsqlConnectOptionsBuilder};
 pub use error::{DsqlError, Result};
+#[cfg(all(feature = "occ", feature = "pool"))]
+pub use occ_retry::OCCRetryExt;
 #[cfg(feature = "occ")]
 pub use occ_retry::{is_occ_error, retry_on_occ, OCCRetryConfig, OCCRetryConfigBuilder};

--- a/rust/sqlx/src/lib.rs
+++ b/rust/sqlx/src/lib.rs
@@ -16,7 +16,7 @@ pub(crate) mod util;
 pub use aws_config::Region;
 pub use config::{DsqlConnectOptions, DsqlConnectOptionsBuilder};
 pub use error::{DsqlError, Result};
-#[cfg(all(feature = "occ", feature = "pool"))]
-pub use occ_retry::OCCRetryExt;
 #[cfg(feature = "occ")]
-pub use occ_retry::{is_occ_error, retry_on_occ, OCCRetryConfig, OCCRetryConfigBuilder};
+pub use occ_retry::{
+    is_occ_error, retry_on_occ, OCCRetryConfig, OCCRetryConfigBuilder, OCCRetryExt, OCCType,
+};

--- a/rust/sqlx/src/occ_retry.rs
+++ b/rust/sqlx/src/occ_retry.rs
@@ -81,18 +81,27 @@ impl Default for OCCRetryConfig {
     }
 }
 
-/// Detect and classify OCC errors. Returns `Some(OCCType)` for OCC errors, `None` otherwise.
-pub fn is_occ_error(err: &sqlx::Error) -> Option<OCCType> {
+/// Detect and classify OCC errors. Returns `Some((OCCType, code))` for OCC errors, `None` otherwise.
+pub fn is_occ_error(err: &sqlx::Error) -> Option<(OCCType, &'static str)> {
     if let sqlx::Error::Database(db_err) = err {
         match db_err.code().as_deref() {
-            Some("OC000") => Some(OCCType::Data),
-            Some("OC001") => Some(OCCType::Schema),
-            Some("40001") => Some(OCCType::Unknown),
-            _ => None,
+            Some("OC000") => return Some((OCCType::Data, "OC000")),
+            Some("OC001") => return Some((OCCType::Schema, "OC001")),
+            Some("40001") => {
+                // Fallback: parse message for embedded OCC type
+                let message = db_err.message();
+                if message.contains("(OC000)") {
+                    return Some((OCCType::Data, "OC000"));
+                } else if message.contains("(OC001)") {
+                    return Some((OCCType::Schema, "OC001"));
+                } else {
+                    return Some((OCCType::Unknown, "40001"));
+                }
+            }
+            _ => return None,
         }
-    } else {
-        None
     }
+    None
 }
 
 pub(crate) fn calculate_backoff(config: &OCCRetryConfig, attempt: u32) -> Duration {
@@ -133,14 +142,15 @@ where
                 return Ok(val);
             }
             Err(e) => {
-                let Some(occ_type) = is_occ_error(&e) else {
+                let Some((occ_type, occ_code)) = is_occ_error(&e) else {
                     return Err(DsqlError::DatabaseError(e));
                 };
 
                 if attempt == max_attempts {
                     log::error!(
-                        "OCC transaction retry exhausted, type={:?}, attempts={}",
+                        "OCC transaction retry exhausted, type={:?}, code={}, attempts={}",
                         occ_type,
+                        occ_code,
                         max_attempts
                     );
                     return Err(DsqlError::OCCRetryExhausted {
@@ -153,8 +163,8 @@ where
                 let delay = calculate_backoff(config, attempt);
 
                 log::debug!(
-                    "OCC conflict detected, type={:?}, retrying after backoff, attempt={}/{}, delay_ms={}",
-                    occ_type, attempt + 1, max_attempts, delay.as_millis()
+                    "OCC conflict detected, type={:?}, code={}, retrying after backoff, attempt={}/{}, delay_ms={}",
+                    occ_type, occ_code, attempt + 1, max_attempts, delay.as_millis()
                 );
 
                 tokio::time::sleep(delay).await;
@@ -246,14 +256,14 @@ impl OCCRetryExt for sqlx::postgres::PgPool {
                                 attempt < max_attempts
                             );
 
-                            let Some(occ_type) = is_occ_error(&e) else {
+                            let Some((occ_type, occ_code)) = is_occ_error(&e) else {
                                 return Err(DsqlError::DatabaseError(e));
                             };
 
                             if attempt == max_attempts {
                                 log::error!(
-                                    "OCC transaction retry exhausted on commit, type={:?}, attempts={}",
-                                    occ_type, max_attempts
+                                    "OCC transaction retry exhausted on commit, type={:?}, code={}, attempts={}",
+                                    occ_type, occ_code, max_attempts
                                 );
                                 return Err(DsqlError::OCCRetryExhausted {
                                     attempts: max_attempts,
@@ -265,8 +275,8 @@ impl OCCRetryExt for sqlx::postgres::PgPool {
                             let delay = calculate_backoff(&config, attempt);
 
                             log::debug!(
-                                "OCC conflict on commit, type={:?}, retrying after backoff, attempt={}/{}, delay_ms={}",
-                                occ_type, attempt + 1, max_attempts, delay.as_millis()
+                                "OCC conflict on commit, type={:?}, code={}, retrying after backoff, attempt={}/{}, delay_ms={}",
+                                occ_type, occ_code, attempt + 1, max_attempts, delay.as_millis()
                             );
 
                             tokio::time::sleep(delay).await;
@@ -287,14 +297,14 @@ impl OCCRetryExt for sqlx::postgres::PgPool {
                     }
 
                     // Check if this is an OCC error from the closure execution
-                    let Some(occ_type) = is_occ_error(&e) else {
+                    let Some((occ_type, occ_code)) = is_occ_error(&e) else {
                         return Err(DsqlError::DatabaseError(e));
                     };
 
                     if attempt == max_attempts {
                         log::error!(
-                            "OCC transaction retry exhausted during execution, type={:?}, attempts={}",
-                            occ_type, max_attempts
+                            "OCC transaction retry exhausted during execution, type={:?}, code={}, attempts={}",
+                            occ_type, occ_code, max_attempts
                         );
                         return Err(DsqlError::OCCRetryExhausted {
                             attempts: max_attempts,
@@ -306,8 +316,8 @@ impl OCCRetryExt for sqlx::postgres::PgPool {
                     let delay = calculate_backoff(&config, attempt);
 
                     log::debug!(
-                        "OCC conflict during execution, type={:?}, retrying after backoff, attempt={}/{}, delay_ms={}",
-                        occ_type, attempt + 1, max_attempts, delay.as_millis()
+                        "OCC conflict during execution, type={:?}, code={}, retrying after backoff, attempt={}/{}, delay_ms={}",
+                        occ_type, occ_code, attempt + 1, max_attempts, delay.as_millis()
                     );
 
                     tokio::time::sleep(delay).await;
@@ -362,14 +372,14 @@ impl OCCRetryExt for sqlx::PgConnection {
                                 attempt < max_attempts
                             );
 
-                            let Some(occ_type) = is_occ_error(&e) else {
+                            let Some((occ_type, occ_code)) = is_occ_error(&e) else {
                                 return Err(DsqlError::DatabaseError(e));
                             };
 
                             if attempt == max_attempts {
                                 log::error!(
-                                    "OCC transaction retry exhausted on commit, type={:?}, attempts={}",
-                                    occ_type, max_attempts
+                                    "OCC transaction retry exhausted on commit, type={:?}, code={}, attempts={}",
+                                    occ_type, occ_code, max_attempts
                                 );
                                 return Err(DsqlError::OCCRetryExhausted {
                                     attempts: max_attempts,
@@ -381,8 +391,8 @@ impl OCCRetryExt for sqlx::PgConnection {
                             let delay = calculate_backoff(&config, attempt);
 
                             log::debug!(
-                                "OCC conflict on commit, type={:?}, retrying after backoff, attempt={}/{}, delay_ms={}",
-                                occ_type, attempt + 1, max_attempts, delay.as_millis()
+                                "OCC conflict on commit, type={:?}, code={}, retrying after backoff, attempt={}/{}, delay_ms={}",
+                                occ_type, occ_code, attempt + 1, max_attempts, delay.as_millis()
                             );
 
                             tokio::time::sleep(delay).await;
@@ -403,14 +413,14 @@ impl OCCRetryExt for sqlx::PgConnection {
                     }
 
                     // Check if this is an OCC error from the closure execution
-                    let Some(occ_type) = is_occ_error(&e) else {
+                    let Some((occ_type, occ_code)) = is_occ_error(&e) else {
                         return Err(DsqlError::DatabaseError(e));
                     };
 
                     if attempt == max_attempts {
                         log::error!(
-                            "OCC transaction retry exhausted during execution, type={:?}, attempts={}",
-                            occ_type, max_attempts
+                            "OCC transaction retry exhausted during execution, type={:?}, code={}, attempts={}",
+                            occ_type, occ_code, max_attempts
                         );
                         return Err(DsqlError::OCCRetryExhausted {
                             attempts: max_attempts,
@@ -422,8 +432,8 @@ impl OCCRetryExt for sqlx::PgConnection {
                     let delay = calculate_backoff(&config, attempt);
 
                     log::debug!(
-                        "OCC conflict during execution, type={:?}, retrying after backoff, attempt={}/{}, delay_ms={}",
-                        occ_type, attempt + 1, max_attempts, delay.as_millis()
+                        "OCC conflict during execution, type={:?}, code={}, retrying after backoff, attempt={}/{}, delay_ms={}",
+                        occ_type, occ_code, attempt + 1, max_attempts, delay.as_millis()
                     );
 
                     tokio::time::sleep(delay).await;
@@ -507,12 +517,28 @@ mod tests {
 
     #[test]
     fn test_occ_error_detection_sqlstate() {
+        // 40001 without embedded code -> Unknown
         let err = sqlx::Error::Database(Box::new(MockDbError {
             code: Some("40001".to_string()),
             message: "serialization failure".to_string(),
         }));
+        assert_eq!(is_occ_error(&err), Some((OCCType::Unknown, "40001")));
 
-        assert_eq!(is_occ_error(&err), Some(OCCType::Unknown));
+        // 40001 with embedded (OC000) -> Data
+        let err = sqlx::Error::Database(Box::new(MockDbError {
+            code: Some("40001".to_string()),
+            message: "data has been updated by another transaction, please retry: (OC000)"
+                .to_string(),
+        }));
+        assert_eq!(is_occ_error(&err), Some((OCCType::Data, "OC000")));
+
+        // 40001 with embedded (OC001) -> Schema
+        let err = sqlx::Error::Database(Box::new(MockDbError {
+            code: Some("40001".to_string()),
+            message: "schema has been updated by another transaction, please retry: (OC001)"
+                .to_string(),
+        }));
+        assert_eq!(is_occ_error(&err), Some((OCCType::Schema, "OC001")));
     }
 
     #[test]
@@ -522,7 +548,7 @@ mod tests {
             message: "optimistic concurrency failure".to_string(),
         }));
 
-        assert_eq!(is_occ_error(&err), Some(OCCType::Data));
+        assert_eq!(is_occ_error(&err), Some((OCCType::Data, "OC000")));
     }
 
     #[test]
@@ -532,7 +558,7 @@ mod tests {
             message: "transaction conflict".to_string(),
         }));
 
-        assert_eq!(is_occ_error(&err), Some(OCCType::Schema));
+        assert_eq!(is_occ_error(&err), Some((OCCType::Schema, "OC001")));
     }
 
     #[test]
@@ -805,8 +831,8 @@ mod tests {
     fn test_builder_accepts_valid_config() {
         let result = OCCRetryConfigBuilder::default()
             .max_attempts(5u32)
-            .base_delay_ms(100u64)
-            .max_delay_ms(5000u64)
+            .base_delay_ms(10u64)
+            .max_delay_ms(50u64)
             .jitter_factor(0.25)
             .build();
 

--- a/rust/sqlx/src/occ_retry.rs
+++ b/rust/sqlx/src/occ_retry.rs
@@ -27,9 +27,9 @@ pub enum OCCType {
 pub struct OCCRetryConfig {
     #[builder(default = "3")]
     max_attempts: u32,
-    #[builder(default = "100")]
+    #[builder(default = "1")]
     base_delay_ms: u64,
-    #[builder(default = "5000")]
+    #[builder(default = "100")]
     max_delay_ms: u64,
     #[builder(default = "0.25")]
     jitter_factor: f64,
@@ -52,8 +52,8 @@ impl OCCRetryConfigBuilder {
         }
 
         if let Some(max) = self.max_delay_ms {
-            if max > 60_000 {
-                return Err("max_delay_ms exceeds 60 seconds".into());
+            if max > 100 {
+                return Err("max_delay_ms exceeds 100ms".into());
             }
         }
 
@@ -126,25 +126,16 @@ where
 {
     let max_attempts = config.max_attempts;
     let mut attempt = 1;
-    let mut last_occ_type: Option<OCCType> = None;
 
     loop {
         match f().await {
             Ok(val) => {
-                if attempt > 1 {
-                    log::info!(
-                        "OCC transaction succeeded after retry, type={:?}, attempt={}, max_attempts={}",
-                        last_occ_type, attempt, max_attempts
-                    );
-                }
                 return Ok(val);
             }
             Err(e) => {
                 let Some(occ_type) = is_occ_error(&e) else {
                     return Err(DsqlError::DatabaseError(e));
                 };
-
-                last_occ_type = Some(occ_type);
 
                 if attempt == max_attempts {
                     log::error!(
@@ -161,135 +152,13 @@ where
 
                 let delay = calculate_backoff(config, attempt);
 
-                log::warn!(
+                log::debug!(
                     "OCC conflict detected, type={:?}, retrying after backoff, attempt={}/{}, delay_ms={}",
                     occ_type, attempt + 1, max_attempts, delay.as_millis()
                 );
 
                 tokio::time::sleep(delay).await;
 
-                attempt += 1;
-            }
-        }
-    }
-}
-
-/// Helper for single-connection retry (reuses same connection).
-async fn transaction_with_retry_impl<F, T>(
-    conn: &mut sqlx::PgConnection,
-    config: Option<&OCCRetryConfig>,
-    f: F,
-) -> Result<T>
-where
-    F: for<'a> Fn(
-            &'a mut sqlx::Transaction<'_, sqlx::Postgres>,
-        ) -> std::pin::Pin<
-            Box<dyn std::future::Future<Output = std::result::Result<T, sqlx::Error>> + Send + 'a>,
-        > + Send,
-    T: Send,
-{
-    let config = config.cloned().unwrap_or_default();
-    let max_attempts = config.max_attempts;
-    let mut attempt = 1;
-    let mut last_occ_type: Option<OCCType> = None;
-
-    loop {
-        let mut tx = conn.begin().await.map_err(DsqlError::DatabaseError)?;
-
-        // OCC errors may occur during execution or at commit; both are retried.
-        match f(&mut tx).await {
-            Ok(val) => {
-                // Attempt commit - OCC errors occur at commit time
-                match tx.commit().await {
-                    Ok(_) => {
-                        if attempt > 1 {
-                            log::info!(
-                                "OCC transaction succeeded after retry, type={:?}, attempt={}, max_attempts={}",
-                                last_occ_type, attempt, max_attempts
-                            );
-                        }
-                        return Ok(val);
-                    }
-                    Err(e) => {
-                        log::debug!(
-                            "Commit failed: error={}, attempt={}/{}, will_retry={}",
-                            e,
-                            attempt,
-                            max_attempts,
-                            attempt < max_attempts
-                        );
-
-                        let Some(occ_type) = is_occ_error(&e) else {
-                            return Err(DsqlError::DatabaseError(e));
-                        };
-
-                        last_occ_type = Some(occ_type);
-
-                        if attempt == max_attempts {
-                            log::error!(
-                                "OCC transaction retry exhausted on commit, type={:?}, attempts={}",
-                                occ_type,
-                                max_attempts
-                            );
-                            return Err(DsqlError::OCCRetryExhausted {
-                                attempts: max_attempts,
-                                occ_type,
-                                source: Box::new(DsqlError::DatabaseError(e)),
-                            });
-                        }
-
-                        let delay = calculate_backoff(&config, attempt);
-
-                        log::warn!(
-                            "OCC conflict on commit, type={:?}, retrying after backoff, attempt={}/{}, delay_ms={}",
-                            occ_type, attempt + 1, max_attempts, delay.as_millis()
-                        );
-
-                        tokio::time::sleep(delay).await;
-                        attempt += 1;
-                    }
-                }
-            }
-            Err(e) => {
-                // Explicitly rollback before handling the error
-                if let Err(rollback_err) = tx.rollback().await {
-                    log::warn!(
-                        "Rollback failed: original_error={}, rollback_error={}, attempt={}/{}",
-                        e,
-                        rollback_err,
-                        attempt,
-                        max_attempts
-                    );
-                }
-
-                // Check if this is an OCC error from the closure execution
-                let Some(occ_type) = is_occ_error(&e) else {
-                    return Err(DsqlError::DatabaseError(e));
-                };
-
-                last_occ_type = Some(occ_type);
-
-                if attempt == max_attempts {
-                    log::error!(
-                        "OCC transaction retry exhausted during execution, type={:?}, attempts={}",
-                        occ_type,
-                        max_attempts
-                    );
-                    return Err(DsqlError::OCCRetryExhausted {
-                        attempts: max_attempts,
-                        occ_type,
-                        source: Box::new(DsqlError::DatabaseError(e)),
-                    });
-                }
-
-                let delay = calculate_backoff(&config, attempt);
-
-                log::warn!(
-                    "OCC conflict during execution, type={:?}, retrying after backoff, attempt={}/{}, delay_ms={}",
-                    occ_type, attempt + 1, max_attempts, delay.as_millis()
-                );
-
-                tokio::time::sleep(delay).await;
                 attempt += 1;
             }
         }
@@ -356,7 +225,6 @@ impl OCCRetryExt for sqlx::postgres::PgPool {
         let config = config.cloned().unwrap_or_default();
         let max_attempts = config.max_attempts;
         let mut attempt = 1;
-        let mut last_occ_type: Option<OCCType> = None;
 
         loop {
             // Get fresh connection from pool on each retry
@@ -367,12 +235,6 @@ impl OCCRetryExt for sqlx::postgres::PgPool {
                     // Attempt commit - OCC errors occur at commit time
                     match tx.commit().await {
                         Ok(_) => {
-                            if attempt > 1 {
-                                log::info!(
-                                    "OCC transaction succeeded after retry, type={:?}, attempt={}, max_attempts={}",
-                                    last_occ_type, attempt, max_attempts
-                                );
-                            }
                             return Ok(val);
                         }
                         Err(e) => {
@@ -388,8 +250,6 @@ impl OCCRetryExt for sqlx::postgres::PgPool {
                                 return Err(DsqlError::DatabaseError(e));
                             };
 
-                            last_occ_type = Some(occ_type);
-
                             if attempt == max_attempts {
                                 log::error!(
                                     "OCC transaction retry exhausted on commit, type={:?}, attempts={}",
@@ -404,7 +264,7 @@ impl OCCRetryExt for sqlx::postgres::PgPool {
 
                             let delay = calculate_backoff(&config, attempt);
 
-                            log::warn!(
+                            log::debug!(
                                 "OCC conflict on commit, type={:?}, retrying after backoff, attempt={}/{}, delay_ms={}",
                                 occ_type, attempt + 1, max_attempts, delay.as_millis()
                             );
@@ -417,15 +277,19 @@ impl OCCRetryExt for sqlx::postgres::PgPool {
                 Err(e) => {
                     // Explicitly rollback before handling the error
                     if let Err(rollback_err) = tx.rollback().await {
-                        log::warn!("Rollback failed during error handling: {}", rollback_err);
+                        log::debug!(
+                            "Rollback failed: original_error={}, rollback_error={}, attempt={}/{}",
+                            e,
+                            rollback_err,
+                            attempt,
+                            max_attempts
+                        );
                     }
 
                     // Check if this is an OCC error from the closure execution
                     let Some(occ_type) = is_occ_error(&e) else {
                         return Err(DsqlError::DatabaseError(e));
                     };
-
-                    last_occ_type = Some(occ_type);
 
                     if attempt == max_attempts {
                         log::error!(
@@ -441,7 +305,7 @@ impl OCCRetryExt for sqlx::postgres::PgPool {
 
                     let delay = calculate_backoff(&config, attempt);
 
-                    log::warn!(
+                    log::debug!(
                         "OCC conflict during execution, type={:?}, retrying after backoff, attempt={}/{}, delay_ms={}",
                         occ_type, attempt + 1, max_attempts, delay.as_millis()
                     );
@@ -474,7 +338,99 @@ impl OCCRetryExt for sqlx::PgConnection {
             > + Send,
         T: Send,
     {
-        transaction_with_retry_impl(self, config, f).await
+        let config = config.cloned().unwrap_or_default();
+        let max_attempts = config.max_attempts;
+        let mut attempt = 1;
+
+        loop {
+            let mut tx = self.begin().await.map_err(DsqlError::DatabaseError)?;
+
+            // OCC errors may occur during execution or at commit; both are retried.
+            match f(&mut tx).await {
+                Ok(val) => {
+                    // Attempt commit - OCC errors occur at commit time
+                    match tx.commit().await {
+                        Ok(_) => {
+                            return Ok(val);
+                        }
+                        Err(e) => {
+                            log::debug!(
+                                "Commit failed: error={}, attempt={}/{}, will_retry={}",
+                                e,
+                                attempt,
+                                max_attempts,
+                                attempt < max_attempts
+                            );
+
+                            let Some(occ_type) = is_occ_error(&e) else {
+                                return Err(DsqlError::DatabaseError(e));
+                            };
+
+                            if attempt == max_attempts {
+                                log::error!(
+                                    "OCC transaction retry exhausted on commit, type={:?}, attempts={}",
+                                    occ_type, max_attempts
+                                );
+                                return Err(DsqlError::OCCRetryExhausted {
+                                    attempts: max_attempts,
+                                    occ_type,
+                                    source: Box::new(DsqlError::DatabaseError(e)),
+                                });
+                            }
+
+                            let delay = calculate_backoff(&config, attempt);
+
+                            log::debug!(
+                                "OCC conflict on commit, type={:?}, retrying after backoff, attempt={}/{}, delay_ms={}",
+                                occ_type, attempt + 1, max_attempts, delay.as_millis()
+                            );
+
+                            tokio::time::sleep(delay).await;
+                            attempt += 1;
+                        }
+                    }
+                }
+                Err(e) => {
+                    // Explicitly rollback before handling the error
+                    if let Err(rollback_err) = tx.rollback().await {
+                        log::debug!(
+                            "Rollback failed: original_error={}, rollback_error={}, attempt={}/{}",
+                            e,
+                            rollback_err,
+                            attempt,
+                            max_attempts
+                        );
+                    }
+
+                    // Check if this is an OCC error from the closure execution
+                    let Some(occ_type) = is_occ_error(&e) else {
+                        return Err(DsqlError::DatabaseError(e));
+                    };
+
+                    if attempt == max_attempts {
+                        log::error!(
+                            "OCC transaction retry exhausted during execution, type={:?}, attempts={}",
+                            occ_type, max_attempts
+                        );
+                        return Err(DsqlError::OCCRetryExhausted {
+                            attempts: max_attempts,
+                            occ_type,
+                            source: Box::new(DsqlError::DatabaseError(e)),
+                        });
+                    }
+
+                    let delay = calculate_backoff(&config, attempt);
+
+                    log::debug!(
+                        "OCC conflict during execution, type={:?}, retrying after backoff, attempt={}/{}, delay_ms={}",
+                        occ_type, attempt + 1, max_attempts, delay.as_millis()
+                    );
+
+                    tokio::time::sleep(delay).await;
+                    attempt += 1;
+                }
+            }
+        }
     }
 }
 
@@ -594,12 +550,12 @@ mod tests {
         let config = OCCRetryConfig::default();
 
         let delay1 = calculate_backoff(&config, 1);
-        assert!(delay1 >= Duration::from_millis(100));
-        assert!(delay1 <= Duration::from_millis(125));
+        assert!(delay1 >= Duration::from_millis(1));
+        assert!(delay1 <= Duration::from_millis(2));
 
         let delay2 = calculate_backoff(&config, 2);
-        assert!(delay2 >= Duration::from_millis(200));
-        assert!(delay2 <= Duration::from_millis(250));
+        assert!(delay2 >= Duration::from_millis(2));
+        assert!(delay2 <= Duration::from_millis(3));
     }
 
     #[test]
@@ -607,15 +563,15 @@ mod tests {
         let config = OCCRetryConfig::default();
 
         let delay = calculate_backoff(&config, 10);
-        assert!(delay <= Duration::from_millis(6250)); // max_delay + 25% jitter
+        assert!(delay <= Duration::from_millis(125)); // max_delay(100ms) + 25% jitter
     }
 
     #[test]
     fn test_builder_defaults() {
         let config = OCCRetryConfigBuilder::default().build().unwrap();
         assert_eq!(config.max_attempts, 3);
-        assert_eq!(config.base_delay_ms, 100);
-        assert_eq!(config.max_delay_ms, 5000);
+        assert_eq!(config.base_delay_ms, 1);
+        assert_eq!(config.max_delay_ms, 100);
         assert!((config.jitter_factor - 0.25).abs() < f64::EPSILON);
     }
 
@@ -623,12 +579,12 @@ mod tests {
     fn test_builder_custom_values() {
         let config = OCCRetryConfigBuilder::default()
             .max_attempts(5u32)
-            .base_delay_ms(200u64)
+            .base_delay_ms(10u64)
             .build()
             .unwrap();
         assert_eq!(config.max_attempts, 5);
-        assert_eq!(config.base_delay_ms, 200);
-        assert_eq!(config.max_delay_ms, 5000); // default
+        assert_eq!(config.base_delay_ms, 10);
+        assert_eq!(config.max_delay_ms, 100); // default
     }
 
     #[test]
@@ -833,7 +789,7 @@ mod tests {
     #[test]
     fn test_builder_rejects_excessive_max_delay() {
         let result = OCCRetryConfigBuilder::default()
-            .max_delay_ms(60_001u64)
+            .max_delay_ms(101u64)
             .build();
 
         assert!(result.is_err());

--- a/rust/sqlx/src/occ_retry.rs
+++ b/rust/sqlx/src/occ_retry.rs
@@ -3,7 +3,24 @@
 
 use crate::{DsqlError, Result};
 use derive_builder::Builder;
+use sqlx::Acquire;
 use std::time::Duration;
+
+/// Convenience macro to hide `Box::pin` boilerplate for transaction closures.
+#[macro_export]
+macro_rules! txn {
+    ($body:expr) => {
+        Box::pin(async move { $body })
+    };
+}
+
+/// OCC conflict type: Data (OC000), Schema (OC001), or Unknown (40001).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OCCType {
+    Data,    // OC000
+    Schema,  // OC001
+    Unknown, // 40001
+}
 
 #[derive(Debug, Clone, Builder)]
 #[builder(build_fn(validate = "Self::validate"))]
@@ -23,6 +40,35 @@ impl OCCRetryConfigBuilder {
         if let Some(0) = self.max_attempts {
             return Err("max_attempts must be greater than 0".into());
         }
+
+        if let Some(attempts) = self.max_attempts {
+            if attempts > 100 {
+                return Err("max_attempts should not exceed 100".into());
+            }
+        }
+
+        if let Some(0) = self.base_delay_ms {
+            return Err("base_delay_ms must be greater than 0".into());
+        }
+
+        if let Some(max) = self.max_delay_ms {
+            if max > 60_000 {
+                return Err("max_delay_ms exceeds 60 seconds".into());
+            }
+        }
+
+        if let (Some(base), Some(max)) = (self.base_delay_ms, self.max_delay_ms) {
+            if max < base {
+                return Err("max_delay_ms must be >= base_delay_ms".into());
+            }
+        }
+
+        if let Some(jitter) = self.jitter_factor {
+            if !(0.0..=1.0).contains(&jitter) {
+                return Err("jitter_factor must be between 0.0 and 1.0".into());
+            }
+        }
+
         Ok(())
     }
 }
@@ -35,18 +81,24 @@ impl Default for OCCRetryConfig {
     }
 }
 
-/// Detect OCC errors by inspecting the SQLSTATE code (40001, OC000, OC001).
-pub fn is_occ_error(err: &sqlx::Error) -> bool {
+/// Detect and classify OCC errors. Returns `Some(OCCType)` for OCC errors, `None` otherwise.
+pub fn is_occ_error(err: &sqlx::Error) -> Option<OCCType> {
     if let sqlx::Error::Database(db_err) = err {
-        matches!(db_err.code().as_deref(), Some("40001" | "OC000" | "OC001"))
+        match db_err.code().as_deref() {
+            Some("OC000") => Some(OCCType::Data),
+            Some("OC001") => Some(OCCType::Schema),
+            Some("40001") => Some(OCCType::Unknown),
+            _ => None,
+        }
     } else {
-        false
+        None
     }
 }
 
 pub(crate) fn calculate_backoff(config: &OCCRetryConfig, attempt: u32) -> Duration {
     let base = config.base_delay_ms as f64;
-    let delay = (base * 2_f64.powi((attempt - 1) as i32)).min(config.max_delay_ms as f64);
+    let exponent = (attempt - 1).min(31); // Cap at 2^31 to prevent overflow
+    let delay = (base * 2_f64.powi(exponent as i32)).min(config.max_delay_ms as f64);
     let jitter = delay * rand::random::<f64>() * config.jitter_factor;
 
     Duration::from_millis((delay + jitter) as u64)
@@ -67,49 +119,51 @@ pub(crate) fn calculate_backoff(config: &OCCRetryConfig, attempt: u32) -> Durati
 ///
 /// Returns `DsqlError::OCCRetryExhausted` with the last OCC error
 /// preserved as the cause when max attempts are exceeded.
-pub async fn retry_on_occ<F, Fut, T>(config: &OCCRetryConfig, mut f: F) -> Result<T>
+pub async fn retry_on_occ<F, Fut, T>(config: &OCCRetryConfig, f: F) -> Result<T>
 where
-    F: FnMut() -> Fut,
+    F: Fn() -> Fut,
     Fut: std::future::Future<Output = std::result::Result<T, sqlx::Error>>,
 {
     let max_attempts = config.max_attempts;
     let mut attempt = 1;
+    let mut last_occ_type: Option<OCCType> = None;
 
     loop {
         match f().await {
             Ok(val) => {
-                #[cfg(feature = "occ-tracing")]
                 if attempt > 1 {
-                    tracing::info!(
-                        attempt = attempt,
-                        max_attempts = max_attempts,
-                        "OCC transaction succeeded after retry"
+                    log::info!(
+                        "OCC transaction succeeded after retry, type={:?}, attempt={}, max_attempts={}",
+                        last_occ_type, attempt, max_attempts
                     );
                 }
                 return Ok(val);
             }
             Err(e) => {
-                if !is_occ_error(&e) {
+                let Some(occ_type) = is_occ_error(&e) else {
                     return Err(DsqlError::DatabaseError(e));
-                }
+                };
+
+                last_occ_type = Some(occ_type);
 
                 if attempt == max_attempts {
-                    #[cfg(feature = "occ-tracing")]
-                    tracing::error!(attempts = max_attempts, "OCC transaction retry exhausted");
+                    log::error!(
+                        "OCC transaction retry exhausted, type={:?}, attempts={}",
+                        occ_type,
+                        max_attempts
+                    );
                     return Err(DsqlError::OCCRetryExhausted {
                         attempts: max_attempts,
+                        occ_type,
                         source: Box::new(DsqlError::DatabaseError(e)),
                     });
                 }
 
                 let delay = calculate_backoff(config, attempt);
 
-                #[cfg(feature = "occ-tracing")]
-                tracing::warn!(
-                    attempt = attempt + 1,
-                    max_attempts = max_attempts,
-                    delay_ms = delay.as_millis(),
-                    "OCC conflict detected, retrying after backoff"
+                log::warn!(
+                    "OCC conflict detected, type={:?}, retrying after backoff, attempt={}/{}, delay_ms={}",
+                    occ_type, attempt + 1, max_attempts, delay.as_millis()
                 );
 
                 tokio::time::sleep(delay).await;
@@ -120,8 +174,133 @@ where
     }
 }
 
-/// Extension trait for `PgPool` providing ergonomic OCC retry methods.
-#[cfg(feature = "pool")]
+/// Helper for single-connection retry (reuses same connection).
+async fn transaction_with_retry_impl<F, T>(
+    conn: &mut sqlx::PgConnection,
+    config: Option<&OCCRetryConfig>,
+    f: F,
+) -> Result<T>
+where
+    F: for<'a> Fn(
+            &'a mut sqlx::Transaction<'_, sqlx::Postgres>,
+        ) -> std::pin::Pin<
+            Box<dyn std::future::Future<Output = std::result::Result<T, sqlx::Error>> + Send + 'a>,
+        > + Send,
+    T: Send,
+{
+    let config = config.cloned().unwrap_or_default();
+    let max_attempts = config.max_attempts;
+    let mut attempt = 1;
+    let mut last_occ_type: Option<OCCType> = None;
+
+    loop {
+        let mut tx = conn.begin().await.map_err(DsqlError::DatabaseError)?;
+
+        // OCC errors may occur during execution or at commit; both are retried.
+        match f(&mut tx).await {
+            Ok(val) => {
+                // Attempt commit - OCC errors occur at commit time
+                match tx.commit().await {
+                    Ok(_) => {
+                        if attempt > 1 {
+                            log::info!(
+                                "OCC transaction succeeded after retry, type={:?}, attempt={}, max_attempts={}",
+                                last_occ_type, attempt, max_attempts
+                            );
+                        }
+                        return Ok(val);
+                    }
+                    Err(e) => {
+                        log::debug!(
+                            "Commit failed: error={}, attempt={}/{}, will_retry={}",
+                            e,
+                            attempt,
+                            max_attempts,
+                            attempt < max_attempts
+                        );
+
+                        let Some(occ_type) = is_occ_error(&e) else {
+                            return Err(DsqlError::DatabaseError(e));
+                        };
+
+                        last_occ_type = Some(occ_type);
+
+                        if attempt == max_attempts {
+                            log::error!(
+                                "OCC transaction retry exhausted on commit, type={:?}, attempts={}",
+                                occ_type,
+                                max_attempts
+                            );
+                            return Err(DsqlError::OCCRetryExhausted {
+                                attempts: max_attempts,
+                                occ_type,
+                                source: Box::new(DsqlError::DatabaseError(e)),
+                            });
+                        }
+
+                        let delay = calculate_backoff(&config, attempt);
+
+                        log::warn!(
+                            "OCC conflict on commit, type={:?}, retrying after backoff, attempt={}/{}, delay_ms={}",
+                            occ_type, attempt + 1, max_attempts, delay.as_millis()
+                        );
+
+                        tokio::time::sleep(delay).await;
+                        attempt += 1;
+                    }
+                }
+            }
+            Err(e) => {
+                // Explicitly rollback before handling the error
+                if let Err(rollback_err) = tx.rollback().await {
+                    log::warn!(
+                        "Rollback failed: original_error={}, rollback_error={}, attempt={}/{}",
+                        e,
+                        rollback_err,
+                        attempt,
+                        max_attempts
+                    );
+                }
+
+                // Check if this is an OCC error from the closure execution
+                let Some(occ_type) = is_occ_error(&e) else {
+                    return Err(DsqlError::DatabaseError(e));
+                };
+
+                last_occ_type = Some(occ_type);
+
+                if attempt == max_attempts {
+                    log::error!(
+                        "OCC transaction retry exhausted during execution, type={:?}, attempts={}",
+                        occ_type,
+                        max_attempts
+                    );
+                    return Err(DsqlError::OCCRetryExhausted {
+                        attempts: max_attempts,
+                        occ_type,
+                        source: Box::new(DsqlError::DatabaseError(e)),
+                    });
+                }
+
+                let delay = calculate_backoff(&config, attempt);
+
+                log::warn!(
+                    "OCC conflict during execution, type={:?}, retrying after backoff, attempt={}/{}, delay_ms={}",
+                    occ_type, attempt + 1, max_attempts, delay.as_millis()
+                );
+
+                tokio::time::sleep(delay).await;
+                attempt += 1;
+            }
+        }
+    }
+}
+
+/// Extension trait for `PgPool` and `PgConnection` providing ergonomic OCC retry methods.
+///
+/// Connection behavior:
+/// - `PgPool`: Fresh connection per retry attempt
+/// - `PgConnection`: Reuses same connection per retry
 #[async_trait::async_trait]
 pub trait OCCRetryExt {
     /// Execute a closure within a transaction, retrying on OCC errors.
@@ -135,17 +314,13 @@ pub trait OCCRetryExt {
     /// # Idempotency Warning
     /// The closure may be called multiple times on OCC conflicts. Ensure it
     /// has no side effects that should not be repeated.
-    ///
-    /// # Box::pin Requirement
-    /// Due to lifetime constraints, the closure must return a pinned boxed future.
-    /// Use `Box::pin(async move { ... })` syntax.
     async fn transaction_with_retry<F, T>(
-        &self,
+        &mut self,
         config: Option<&OCCRetryConfig>,
         f: F,
     ) -> Result<T>
     where
-        F: for<'a> FnMut(
+        F: for<'a> Fn(
                 &'a mut sqlx::Transaction<'_, sqlx::Postgres>,
             ) -> std::pin::Pin<
                 Box<
@@ -157,16 +332,17 @@ pub trait OCCRetryExt {
         T: Send;
 }
 
+// PgPool impl - gets fresh connection per retry
 #[cfg(feature = "pool")]
 #[async_trait::async_trait]
 impl OCCRetryExt for sqlx::postgres::PgPool {
     async fn transaction_with_retry<F, T>(
-        &self,
+        &mut self,
         config: Option<&OCCRetryConfig>,
-        mut f: F,
+        f: F,
     ) -> Result<T>
     where
-        F: for<'a> FnMut(
+        F: for<'a> Fn(
                 &'a mut sqlx::Transaction<'_, sqlx::Postgres>,
             ) -> std::pin::Pin<
                 Box<
@@ -178,54 +354,59 @@ impl OCCRetryExt for sqlx::postgres::PgPool {
         T: Send,
     {
         let config = config.cloned().unwrap_or_default();
-        let pool = self.clone();
         let max_attempts = config.max_attempts;
         let mut attempt = 1;
+        let mut last_occ_type: Option<OCCType> = None;
 
         loop {
-            // Get new connection and start fresh transaction on each retry attempt
-            let mut tx = pool.begin().await.map_err(DsqlError::DatabaseError)?;
+            // Get fresh connection from pool on each retry
+            let mut tx = self.begin().await.map_err(DsqlError::DatabaseError)?;
 
             match f(&mut tx).await {
                 Ok(val) => {
-                    // Attempt commit - OCC errors typically occur here
+                    // Attempt commit - OCC errors occur at commit time
                     match tx.commit().await {
                         Ok(_) => {
-                            #[cfg(feature = "occ-tracing")]
                             if attempt > 1 {
-                                tracing::info!(
-                                    attempt = attempt,
-                                    max_attempts = max_attempts,
-                                    "OCC transaction succeeded after retry"
+                                log::info!(
+                                    "OCC transaction succeeded after retry, type={:?}, attempt={}, max_attempts={}",
+                                    last_occ_type, attempt, max_attempts
                                 );
                             }
                             return Ok(val);
                         }
                         Err(e) => {
-                            if !is_occ_error(&e) {
+                            log::debug!(
+                                "Commit failed: error={}, attempt={}/{}, will_retry={}",
+                                e,
+                                attempt,
+                                max_attempts,
+                                attempt < max_attempts
+                            );
+
+                            let Some(occ_type) = is_occ_error(&e) else {
                                 return Err(DsqlError::DatabaseError(e));
-                            }
+                            };
+
+                            last_occ_type = Some(occ_type);
 
                             if attempt == max_attempts {
-                                #[cfg(feature = "occ-tracing")]
-                                tracing::error!(
-                                    attempts = max_attempts,
-                                    "OCC transaction retry exhausted on commit"
+                                log::error!(
+                                    "OCC transaction retry exhausted on commit, type={:?}, attempts={}",
+                                    occ_type, max_attempts
                                 );
                                 return Err(DsqlError::OCCRetryExhausted {
                                     attempts: max_attempts,
+                                    occ_type,
                                     source: Box::new(DsqlError::DatabaseError(e)),
                                 });
                             }
 
                             let delay = calculate_backoff(&config, attempt);
 
-                            #[cfg(feature = "occ-tracing")]
-                            tracing::warn!(
-                                attempt = attempt + 1,
-                                max_attempts = max_attempts,
-                                delay_ms = delay.as_millis(),
-                                "OCC conflict on commit, retrying transaction after backoff"
+                            log::warn!(
+                                "OCC conflict on commit, type={:?}, retrying after backoff, attempt={}/{}, delay_ms={}",
+                                occ_type, attempt + 1, max_attempts, delay.as_millis()
                             );
 
                             tokio::time::sleep(delay).await;
@@ -234,34 +415,35 @@ impl OCCRetryExt for sqlx::postgres::PgPool {
                     }
                 }
                 Err(e) => {
-                    // Explicitly roll back the transaction before handling the error.
-                    let _ = tx.rollback().await;
-
-                    // Check if this is an OCC error from the closure execution
-                    if !is_occ_error(&e) {
-                        return Err(DsqlError::DatabaseError(e));
+                    // Explicitly rollback before handling the error
+                    if let Err(rollback_err) = tx.rollback().await {
+                        log::warn!("Rollback failed during error handling: {}", rollback_err);
                     }
 
+                    // Check if this is an OCC error from the closure execution
+                    let Some(occ_type) = is_occ_error(&e) else {
+                        return Err(DsqlError::DatabaseError(e));
+                    };
+
+                    last_occ_type = Some(occ_type);
+
                     if attempt == max_attempts {
-                        #[cfg(feature = "occ-tracing")]
-                        tracing::error!(
-                            attempts = max_attempts,
-                            "OCC transaction retry exhausted during execution"
+                        log::error!(
+                            "OCC transaction retry exhausted during execution, type={:?}, attempts={}",
+                            occ_type, max_attempts
                         );
                         return Err(DsqlError::OCCRetryExhausted {
                             attempts: max_attempts,
+                            occ_type,
                             source: Box::new(DsqlError::DatabaseError(e)),
                         });
                     }
 
                     let delay = calculate_backoff(&config, attempt);
 
-                    #[cfg(feature = "occ-tracing")]
-                    tracing::warn!(
-                        attempt = attempt + 1,
-                        max_attempts = max_attempts,
-                        delay_ms = delay.as_millis(),
-                        "OCC conflict during execution, retrying transaction after backoff"
+                    log::warn!(
+                        "OCC conflict during execution, type={:?}, retrying after backoff, attempt={}/{}, delay_ms={}",
+                        occ_type, attempt + 1, max_attempts, delay.as_millis()
                     );
 
                     tokio::time::sleep(delay).await;
@@ -269,6 +451,30 @@ impl OCCRetryExt for sqlx::postgres::PgPool {
                 }
             }
         }
+    }
+}
+
+// PgConnection impl - reuses same connection per retry
+#[async_trait::async_trait]
+impl OCCRetryExt for sqlx::PgConnection {
+    async fn transaction_with_retry<F, T>(
+        &mut self,
+        config: Option<&OCCRetryConfig>,
+        f: F,
+    ) -> Result<T>
+    where
+        F: for<'a> Fn(
+                &'a mut sqlx::Transaction<'_, sqlx::Postgres>,
+            ) -> std::pin::Pin<
+                Box<
+                    dyn std::future::Future<Output = std::result::Result<T, sqlx::Error>>
+                        + Send
+                        + 'a,
+                >,
+            > + Send,
+        T: Send,
+    {
+        transaction_with_retry_impl(self, config, f).await
     }
 }
 
@@ -350,7 +556,7 @@ mod tests {
             message: "serialization failure".to_string(),
         }));
 
-        assert!(is_occ_error(&err));
+        assert_eq!(is_occ_error(&err), Some(OCCType::Unknown));
     }
 
     #[test]
@@ -360,7 +566,7 @@ mod tests {
             message: "optimistic concurrency failure".to_string(),
         }));
 
-        assert!(is_occ_error(&err));
+        assert_eq!(is_occ_error(&err), Some(OCCType::Data));
     }
 
     #[test]
@@ -370,7 +576,7 @@ mod tests {
             message: "transaction conflict".to_string(),
         }));
 
-        assert!(is_occ_error(&err));
+        assert_eq!(is_occ_error(&err), Some(OCCType::Schema));
     }
 
     #[test]
@@ -380,7 +586,7 @@ mod tests {
             message: "unique violation".to_string(),
         }));
 
-        assert!(!is_occ_error(&err));
+        assert_eq!(is_occ_error(&err), None);
     }
 
     #[test]
@@ -428,7 +634,7 @@ mod tests {
     #[test]
     fn test_is_occ_error_non_database() {
         let err = sqlx::Error::Protocol("connection refused".into());
-        assert!(!is_occ_error(&err));
+        assert_eq!(is_occ_error(&err), None);
     }
 
     #[test]
@@ -437,7 +643,7 @@ mod tests {
             code: None,
             message: "unknown error".to_string(),
         }));
-        assert!(!is_occ_error(&err));
+        assert_eq!(is_occ_error(&err), None);
     }
 
     #[test]
@@ -448,6 +654,7 @@ mod tests {
         }));
         let err = DsqlError::OCCRetryExhausted {
             attempts: 3,
+            occ_type: OCCType::Data,
             source: Box::new(DsqlError::DatabaseError(sqlx_err)),
         };
         assert!(err.to_string().contains("3 attempts"));
@@ -515,7 +722,12 @@ mod tests {
         assert!(result.is_err());
         assert_eq!(calls.load(Ordering::SeqCst), 2);
         match result.unwrap_err() {
-            DsqlError::OCCRetryExhausted { attempts, .. } => assert_eq!(attempts, 2),
+            DsqlError::OCCRetryExhausted {
+                attempts, occ_type, ..
+            } => {
+                assert_eq!(attempts, 2);
+                assert_eq!(occ_type, OCCType::Data);
+            }
             other => panic!("Expected OCCRetryExhausted, got: {:?}", other),
         }
     }
@@ -546,6 +758,103 @@ mod tests {
             "Expected max_attempts error, got: {}",
             err
         );
+    }
+
+    #[test]
+    fn test_builder_rejects_inverted_delays() {
+        let result = OCCRetryConfigBuilder::default()
+            .base_delay_ms(5000u64)
+            .max_delay_ms(100u64)
+            .build();
+
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("max_delay_ms"),
+            "Expected max_delay_ms error, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_builder_rejects_negative_jitter() {
+        let result = OCCRetryConfigBuilder::default().jitter_factor(-0.5).build();
+
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("jitter_factor"),
+            "Expected jitter_factor error, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_builder_rejects_excessive_jitter() {
+        let result = OCCRetryConfigBuilder::default().jitter_factor(2.0).build();
+
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("jitter_factor"),
+            "Expected jitter_factor error, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_builder_rejects_excessive_max_attempts() {
+        let result = OCCRetryConfigBuilder::default()
+            .max_attempts(101u32)
+            .build();
+
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("max_attempts"),
+            "Expected max_attempts error, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_builder_rejects_zero_base_delay() {
+        let result = OCCRetryConfigBuilder::default().base_delay_ms(0u64).build();
+
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("base_delay_ms"),
+            "Expected base_delay_ms error, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_builder_rejects_excessive_max_delay() {
+        let result = OCCRetryConfigBuilder::default()
+            .max_delay_ms(60_001u64)
+            .build();
+
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("max_delay_ms"),
+            "Expected max_delay_ms error, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_builder_accepts_valid_config() {
+        let result = OCCRetryConfigBuilder::default()
+            .max_attempts(5u32)
+            .base_delay_ms(100u64)
+            .max_delay_ms(5000u64)
+            .jitter_factor(0.25)
+            .build();
+
+        assert!(result.is_ok());
     }
 
     #[tokio::test]
@@ -594,7 +903,12 @@ mod tests {
         assert!(result.is_err());
         assert_eq!(calls.load(Ordering::SeqCst), 2);
         match result.unwrap_err() {
-            DsqlError::OCCRetryExhausted { attempts, .. } => assert_eq!(attempts, 2),
+            DsqlError::OCCRetryExhausted {
+                attempts, occ_type, ..
+            } => {
+                assert_eq!(attempts, 2);
+                assert_eq!(occ_type, OCCType::Data);
+            }
             other => panic!("Expected OCCRetryExhausted, got: {:?}", other),
         }
     }

--- a/rust/sqlx/src/occ_retry.rs
+++ b/rust/sqlx/src/occ_retry.rs
@@ -77,13 +77,25 @@ where
 
     loop {
         match f().await {
-            Ok(val) => return Ok(val),
+            Ok(val) => {
+                #[cfg(feature = "occ-tracing")]
+                if attempt > 1 {
+                    tracing::info!(
+                        attempt = attempt,
+                        max_attempts = max_attempts,
+                        "OCC transaction succeeded after retry"
+                    );
+                }
+                return Ok(val);
+            }
             Err(e) => {
                 if !is_occ_error(&e) {
                     return Err(DsqlError::DatabaseError(e));
                 }
 
                 if attempt == max_attempts {
+                    #[cfg(feature = "occ-tracing")]
+                    tracing::error!(attempts = max_attempts, "OCC transaction retry exhausted");
                     return Err(DsqlError::OCCRetryExhausted {
                         attempts: max_attempts,
                         source: Box::new(DsqlError::DatabaseError(e)),
@@ -91,9 +103,170 @@ where
                 }
 
                 let delay = calculate_backoff(config, attempt);
+
+                #[cfg(feature = "occ-tracing")]
+                tracing::warn!(
+                    attempt = attempt + 1,
+                    max_attempts = max_attempts,
+                    delay_ms = delay.as_millis(),
+                    "OCC conflict detected, retrying after backoff"
+                );
+
                 tokio::time::sleep(delay).await;
 
                 attempt += 1;
+            }
+        }
+    }
+}
+
+/// Extension trait for `PgPool` providing ergonomic OCC retry methods.
+#[cfg(feature = "pool")]
+#[async_trait::async_trait]
+pub trait OCCRetryExt {
+    /// Execute a closure within a transaction, retrying on OCC errors.
+    ///
+    /// The transaction is automatically started before calling the closure and
+    /// committed on success. On error, the transaction is rolled back.
+    ///
+    /// Pass `None` to use default configuration (max_attempts: 3, exponential backoff),
+    /// or `Some(&config)` for custom retry behavior.
+    ///
+    /// # Idempotency Warning
+    /// The closure may be called multiple times on OCC conflicts. Ensure it
+    /// has no side effects that should not be repeated.
+    ///
+    /// # Box::pin Requirement
+    /// Due to lifetime constraints, the closure must return a pinned boxed future.
+    /// Use `Box::pin(async move { ... })` syntax.
+    async fn transaction_with_retry<F, T>(
+        &self,
+        config: Option<&OCCRetryConfig>,
+        f: F,
+    ) -> Result<T>
+    where
+        F: for<'a> FnMut(
+                &'a mut sqlx::Transaction<'_, sqlx::Postgres>,
+            ) -> std::pin::Pin<
+                Box<
+                    dyn std::future::Future<Output = std::result::Result<T, sqlx::Error>>
+                        + Send
+                        + 'a,
+                >,
+            > + Send,
+        T: Send;
+}
+
+#[cfg(feature = "pool")]
+#[async_trait::async_trait]
+impl OCCRetryExt for sqlx::postgres::PgPool {
+    async fn transaction_with_retry<F, T>(
+        &self,
+        config: Option<&OCCRetryConfig>,
+        mut f: F,
+    ) -> Result<T>
+    where
+        F: for<'a> FnMut(
+                &'a mut sqlx::Transaction<'_, sqlx::Postgres>,
+            ) -> std::pin::Pin<
+                Box<
+                    dyn std::future::Future<Output = std::result::Result<T, sqlx::Error>>
+                        + Send
+                        + 'a,
+                >,
+            > + Send,
+        T: Send,
+    {
+        let config = config.cloned().unwrap_or_default();
+        let pool = self.clone();
+        let max_attempts = config.max_attempts;
+        let mut attempt = 1;
+
+        loop {
+            // Get new connection and start fresh transaction on each retry attempt
+            let mut tx = pool.begin().await.map_err(DsqlError::DatabaseError)?;
+
+            match f(&mut tx).await {
+                Ok(val) => {
+                    // Attempt commit - OCC errors typically occur here
+                    match tx.commit().await {
+                        Ok(_) => {
+                            #[cfg(feature = "occ-tracing")]
+                            if attempt > 1 {
+                                tracing::info!(
+                                    attempt = attempt,
+                                    max_attempts = max_attempts,
+                                    "OCC transaction succeeded after retry"
+                                );
+                            }
+                            return Ok(val);
+                        }
+                        Err(e) => {
+                            if !is_occ_error(&e) {
+                                return Err(DsqlError::DatabaseError(e));
+                            }
+
+                            if attempt == max_attempts {
+                                #[cfg(feature = "occ-tracing")]
+                                tracing::error!(
+                                    attempts = max_attempts,
+                                    "OCC transaction retry exhausted on commit"
+                                );
+                                return Err(DsqlError::OCCRetryExhausted {
+                                    attempts: max_attempts,
+                                    source: Box::new(DsqlError::DatabaseError(e)),
+                                });
+                            }
+
+                            let delay = calculate_backoff(&config, attempt);
+
+                            #[cfg(feature = "occ-tracing")]
+                            tracing::warn!(
+                                attempt = attempt + 1,
+                                max_attempts = max_attempts,
+                                delay_ms = delay.as_millis(),
+                                "OCC conflict on commit, retrying transaction after backoff"
+                            );
+
+                            tokio::time::sleep(delay).await;
+                            attempt += 1;
+                        }
+                    }
+                }
+                Err(e) => {
+                    // Rollback happens via Drop
+                    let _ = tx.rollback().await;
+
+                    // Check if this is an OCC error from the closure execution
+                    if !is_occ_error(&e) {
+                        return Err(DsqlError::DatabaseError(e));
+                    }
+
+                    if attempt == max_attempts {
+                        #[cfg(feature = "occ-tracing")]
+                        tracing::error!(
+                            attempts = max_attempts,
+                            "OCC transaction retry exhausted during execution"
+                        );
+                        return Err(DsqlError::OCCRetryExhausted {
+                            attempts: max_attempts,
+                            source: Box::new(DsqlError::DatabaseError(e)),
+                        });
+                    }
+
+                    let delay = calculate_backoff(&config, attempt);
+
+                    #[cfg(feature = "occ-tracing")]
+                    tracing::warn!(
+                        attempt = attempt + 1,
+                        max_attempts = max_attempts,
+                        delay_ms = delay.as_millis(),
+                        "OCC conflict during execution, retrying transaction after backoff"
+                    );
+
+                    tokio::time::sleep(delay).await;
+                    attempt += 1;
+                }
             }
         }
     }

--- a/rust/sqlx/src/occ_retry.rs
+++ b/rust/sqlx/src/occ_retry.rs
@@ -234,7 +234,7 @@ impl OCCRetryExt for sqlx::postgres::PgPool {
                     }
                 }
                 Err(e) => {
-                    // Rollback happens via Drop
+                    // Explicitly roll back the transaction before handling the error.
                     let _ = tx.rollback().await;
 
                     // Check if this is an OCC error from the closure execution
@@ -546,5 +546,116 @@ mod tests {
             "Expected max_attempts error, got: {}",
             err
         );
+    }
+
+    #[tokio::test]
+    async fn test_retry_on_occ_handles_execution_errors() {
+        // Tests that OCC errors during closure execution (not just commit) are retried
+        let config = OCCRetryConfigBuilder::default()
+            .max_attempts(3u32)
+            .base_delay_ms(1u64)
+            .build()
+            .unwrap();
+        let calls = AtomicU32::new(0);
+
+        let result = retry_on_occ(&config, || async {
+            let attempt = calls.fetch_add(1, Ordering::SeqCst);
+            // Simulate OCC error during query execution on first two attempts
+            if attempt < 2 {
+                Err(make_occ_error())
+            } else {
+                Ok("success after retry")
+            }
+        })
+        .await;
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "success after retry");
+        assert_eq!(calls.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test]
+    async fn test_retry_on_occ_exhausted_on_execution_error() {
+        // Tests that retry exhaustion works for OCC errors during execution
+        let config = OCCRetryConfigBuilder::default()
+            .max_attempts(2u32)
+            .base_delay_ms(1u64)
+            .build()
+            .unwrap();
+        let calls = AtomicU32::new(0);
+
+        let result: Result<()> = retry_on_occ(&config, || async {
+            calls.fetch_add(1, Ordering::SeqCst);
+            // Always return OCC error during execution
+            Err::<(), sqlx::Error>(make_occ_error())
+        })
+        .await;
+
+        assert!(result.is_err());
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+        match result.unwrap_err() {
+            DsqlError::OCCRetryExhausted { attempts, .. } => assert_eq!(attempts, 2),
+            other => panic!("Expected OCCRetryExhausted, got: {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_retry_respects_custom_config() {
+        // Tests that custom retry config is respected
+        let config = OCCRetryConfigBuilder::default()
+            .max_attempts(5u32)
+            .base_delay_ms(1u64)
+            .build()
+            .unwrap();
+        let calls = AtomicU32::new(0);
+
+        let result = retry_on_occ(&config, || async {
+            let attempt = calls.fetch_add(1, Ordering::SeqCst);
+            if attempt < 4 {
+                Err(make_occ_error())
+            } else {
+                Ok("recovered on attempt 5")
+            }
+        })
+        .await;
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "recovered on attempt 5");
+        assert_eq!(calls.load(Ordering::SeqCst), 5);
+    }
+
+    #[tokio::test]
+    async fn test_retry_with_different_occ_codes() {
+        // Tests that all OCC error codes are recognized
+        let config = OCCRetryConfigBuilder::default()
+            .max_attempts(4u32)
+            .base_delay_ms(1u64)
+            .build()
+            .unwrap();
+        let calls = AtomicU32::new(0);
+
+        let result = retry_on_occ(&config, || async {
+            let attempt = calls.fetch_add(1, Ordering::SeqCst);
+            match attempt {
+                0 => Err(sqlx::Error::Database(Box::new(MockDbError {
+                    code: Some("40001".to_string()),
+                    message: "serialization failure".to_string(),
+                }))),
+                1 => Err(sqlx::Error::Database(Box::new(MockDbError {
+                    code: Some("OC000".to_string()),
+                    message: "data conflict".to_string(),
+                }))),
+                2 => Err(sqlx::Error::Database(Box::new(MockDbError {
+                    code: Some("OC001".to_string()),
+                    message: "schema conflict".to_string(),
+                }))),
+                _ => Ok("all occ codes handled"),
+            }
+        })
+        .await;
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "all occ codes handled");
+        assert_eq!(calls.load(Ordering::SeqCst), 4);
     }
 }

--- a/rust/sqlx/src/pool.rs
+++ b/rust/sqlx/src/pool.rs
@@ -53,10 +53,13 @@ fn spawn_refresh_task(
                 _ = pool.close_event() => break,
                 _ = interval.tick() => {
                     if let Err(e) = refresh_token(&config, &signer, &sdk_config, &pool).await {
+                        #[cfg(feature = "tracing")]
                         tracing::error!(
                             error = ?e,
                             "token refresh failed"
                         );
+                        #[cfg(not(feature = "tracing"))]
+                        let _ = e;
                     }
                 }
             }

--- a/rust/sqlx/src/pool.rs
+++ b/rust/sqlx/src/pool.rs
@@ -53,13 +53,7 @@ fn spawn_refresh_task(
                 _ = pool.close_event() => break,
                 _ = interval.tick() => {
                     if let Err(e) = refresh_token(&config, &signer, &sdk_config, &pool).await {
-                        #[cfg(feature = "tracing")]
-                        tracing::error!(
-                            error = ?e,
-                            "token refresh failed"
-                        );
-                        #[cfg(not(feature = "tracing"))]
-                        let _ = e;
+                        log::error!("token refresh failed: {:?}", e);
                     }
                 }
             }

--- a/rust/sqlx/tests/integration/pool_integration_test.rs
+++ b/rust/sqlx/tests/integration/pool_integration_test.rs
@@ -21,10 +21,16 @@ async fn test_pool_occ_retry_on_concurrent_conflict() -> Result<()> {
     let mut pool =
         aurora_dsql_sqlx_connector::pool::connect_with(&opts, PgPoolOptions::new()).await?;
 
+    // Cleanup any leftover table from previous runs
+    sqlx::query(&format!("DROP TABLE IF EXISTS {}", table_name))
+        .execute(&pool)
+        .await
+        .map_err(DsqlError::DatabaseError)?;
+
     // Setup: create table with a counter
     pool.transaction_with_retry(None, |tx| {
         let t = table_name.clone();
-        Box::pin(async move {
+        txn!({
             sqlx::query(&format!(
                 "CREATE TABLE IF NOT EXISTS {} (id INT PRIMARY KEY, counter INT NOT NULL)",
                 t
@@ -39,7 +45,7 @@ async fn test_pool_occ_retry_on_concurrent_conflict() -> Result<()> {
     // Initialize counter to 0
     pool.transaction_with_retry(None, |tx| {
         let t = table_name.clone();
-        Box::pin(async move {
+        txn!({
             sqlx::query(&format!("INSERT INTO {} (id, counter) VALUES (1, 0)", t))
                 .execute(&mut **tx)
                 .await?;
@@ -54,7 +60,7 @@ async fn test_pool_occ_retry_on_concurrent_conflict() -> Result<()> {
         .build()?;
 
     // Spawn 10 concurrent tasks that all read-modify-write the same counter
-    // This creates OCC conflicts that require retry
+    // This creates OCC conflicts (OC000, OC001, 40001) that require retry
     let mut handles = Vec::new();
     for _ in 0..10 {
         let mut pool = pool.clone();
@@ -63,7 +69,7 @@ async fn test_pool_occ_retry_on_concurrent_conflict() -> Result<()> {
         handles.push(tokio::spawn(async move {
             pool.transaction_with_retry(Some(&config), |tx| {
                 let t = table.clone();
-                Box::pin(async move {
+                txn!({
                     // Read current value
                     let row = sqlx::query(&format!("SELECT counter FROM {} WHERE id = 1", t))
                         .fetch_one(&mut **tx)
@@ -101,7 +107,7 @@ async fn test_pool_occ_retry_on_concurrent_conflict() -> Result<()> {
     // Cleanup
     pool.transaction_with_retry(None, |tx| {
         let t = table_name.clone();
-        Box::pin(async move {
+        txn!({
             sqlx::query(&format!("DROP TABLE IF EXISTS {}", t))
                 .execute(&mut **tx)
                 .await?;
@@ -160,7 +166,6 @@ async fn test_connection_occ_retry_with_conflict() -> Result<()> {
     let opts = DsqlConnectOptions::from_connection_string(&conn_str)?;
     let mut pool =
         aurora_dsql_sqlx_connector::pool::connect_with(&opts, PgPoolOptions::new()).await?;
-
     // Setup table
     pool.transaction_with_retry(None, |tx| {
         let t = table_name.clone();
@@ -298,6 +303,12 @@ async fn test_retry_exhaustion() -> Result<()> {
     let opts = DsqlConnectOptions::from_connection_string(&conn_str)?;
     let mut pool =
         aurora_dsql_sqlx_connector::pool::connect_with(&opts, PgPoolOptions::new()).await?;
+
+    // Cleanup any leftover table from previous runs
+    sqlx::query(&format!("DROP TABLE IF EXISTS {}", table_name))
+        .execute(&pool)
+        .await
+        .map_err(DsqlError::DatabaseError)?;
 
     // Setup table
     pool.transaction_with_retry(None, |tx| {
@@ -438,6 +449,12 @@ async fn test_return_value_preserved_across_retries() -> Result<()> {
     let opts = DsqlConnectOptions::from_connection_string(&conn_str)?;
     let mut pool =
         aurora_dsql_sqlx_connector::pool::connect_with(&opts, PgPoolOptions::new()).await?;
+
+    // Cleanup any leftover table from previous runs
+    sqlx::query(&format!("DROP TABLE IF EXISTS {}", table_name))
+        .execute(&pool)
+        .await
+        .map_err(DsqlError::DatabaseError)?;
 
     // Setup table
     pool.transaction_with_retry(None, |tx| {

--- a/rust/sqlx/tests/integration/pool_integration_test.rs
+++ b/rust/sqlx/tests/integration/pool_integration_test.rs
@@ -2,10 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use aurora_dsql_sqlx_connector::{
-    DsqlConnectOptions, DsqlError, OCCRetryConfigBuilder, OCCRetryExt, Result,
+    txn, DsqlConnectOptions, DsqlError, OCCRetryConfigBuilder, OCCRetryExt, Result,
 };
 use sqlx::postgres::PgPoolOptions;
 use sqlx::Row;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::Arc;
 use std::time::Duration;
 
 use super::test_util::build_conn_str;
@@ -16,7 +18,8 @@ async fn test_pool_occ_retry_on_concurrent_conflict() -> Result<()> {
     let table_name = format!("occ_test_{}", std::process::id());
 
     let opts = DsqlConnectOptions::from_connection_string(&conn_str)?;
-    let pool = aurora_dsql_sqlx_connector::pool::connect_with(&opts, PgPoolOptions::new()).await?;
+    let mut pool =
+        aurora_dsql_sqlx_connector::pool::connect_with(&opts, PgPoolOptions::new()).await?;
 
     // Setup: create table with a counter
     pool.transaction_with_retry(None, |tx| {
@@ -45,17 +48,16 @@ async fn test_pool_occ_retry_on_concurrent_conflict() -> Result<()> {
     })
     .await?;
 
-    // Use higher retry config for high-contention scenario
     let retry_config = OCCRetryConfigBuilder::default()
-        .max_attempts(10u32)
-        .base_delay_ms(50u64)
+        .max_attempts(20u32)
+        .base_delay_ms(10u64)
         .build()?;
 
     // Spawn 10 concurrent tasks that all read-modify-write the same counter
     // This creates OCC conflicts that require retry
     let mut handles = Vec::new();
     for _ in 0..10 {
-        let pool = pool.clone();
+        let mut pool = pool.clone();
         let table = table_name.clone();
         let config = retry_config.clone();
         handles.push(tokio::spawn(async move {
@@ -145,6 +147,394 @@ async fn test_pool_background_token_refresh() -> Result<()> {
         "Pool should establish a new connection after token refresh"
     );
     drop(held_conn);
+
+    pool.close().await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_connection_occ_retry_with_conflict() -> Result<()> {
+    let conn_str = build_conn_str();
+    let table_name = format!("conn_occ_test_{}", std::process::id());
+
+    let opts = DsqlConnectOptions::from_connection_string(&conn_str)?;
+    let mut pool =
+        aurora_dsql_sqlx_connector::pool::connect_with(&opts, PgPoolOptions::new()).await?;
+
+    // Setup table
+    pool.transaction_with_retry(None, |tx| {
+        let t = table_name.clone();
+        txn!({
+            sqlx::query(&format!(
+                "CREATE TABLE IF NOT EXISTS {} (id INT PRIMARY KEY, val INT)",
+                t
+            ))
+            .execute(&mut **tx)
+            .await?;
+            Ok(())
+        })
+    })
+    .await?;
+
+    pool.transaction_with_retry(None, |tx| {
+        let t = table_name.clone();
+        txn!({
+            sqlx::query(&format!("INSERT INTO {} VALUES (1, 0)", t))
+                .execute(&mut **tx)
+                .await?;
+            Ok(())
+        })
+    })
+    .await?;
+
+    let retry_config = OCCRetryConfigBuilder::default()
+        .max_attempts(5u32)
+        .base_delay_ms(10u64)
+        .build()?;
+
+    // Get a single connection and create OCC conflict via concurrent update
+    let mut conn = pool.acquire().await.map_err(DsqlError::ConnectionError)?;
+    let attempt_count = Arc::new(AtomicU32::new(0));
+    let count_clone = attempt_count.clone();
+
+    // Spawn concurrent conflicting update
+    let mut pool_clone = pool.clone();
+    let table_clone = table_name.clone();
+    let conflict_task = tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        pool_clone
+            .transaction_with_retry(None, |tx| {
+                let t = table_clone.clone();
+                txn!({
+                    sqlx::query(&format!("UPDATE {} SET val = 999 WHERE id = 1", t))
+                        .execute(&mut **tx)
+                        .await?;
+                    Ok(())
+                })
+            })
+            .await
+    });
+
+    // This transaction should retry when it conflicts with the concurrent update
+    let result = conn
+        .transaction_with_retry(Some(&retry_config), |tx| {
+            let c = count_clone.clone();
+            let t = table_name.clone();
+            txn!({
+                c.fetch_add(1, Ordering::SeqCst);
+                let row = sqlx::query(&format!("SELECT val FROM {} WHERE id = 1", t))
+                    .fetch_one(&mut **tx)
+                    .await?;
+                let current: i32 = row.get("val");
+                sqlx::query(&format!("UPDATE {} SET val = $1 WHERE id = 1", t))
+                    .bind(current + 1)
+                    .execute(&mut **tx)
+                    .await?;
+                Ok(())
+            })
+        })
+        .await;
+
+    conflict_task.await.expect("Conflict task panicked")?;
+
+    // Should succeed after retries
+    assert!(result.is_ok(), "Transaction should succeed after retries");
+    let attempts = attempt_count.load(Ordering::SeqCst);
+    assert!(
+        attempts >= 1,
+        "Should have made at least 1 attempt, got {}",
+        attempts
+    );
+
+    // Cleanup
+    pool.transaction_with_retry(None, |tx| {
+        let t = table_name.clone();
+        txn!({
+            sqlx::query(&format!("DROP TABLE IF EXISTS {}", t))
+                .execute(&mut **tx)
+                .await?;
+            Ok(())
+        })
+    })
+    .await?;
+
+    pool.close().await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_pool_no_retry_on_syntax_error() -> Result<()> {
+    let conn_str = build_conn_str();
+    let opts = DsqlConnectOptions::from_connection_string(&conn_str)?;
+    let mut pool =
+        aurora_dsql_sqlx_connector::pool::connect_with(&opts, PgPoolOptions::new()).await?;
+
+    let result = pool
+        .transaction_with_retry(None, |tx| {
+            txn!({
+                sqlx::query("INVALID SQL SYNTAX HERE")
+                    .execute(&mut **tx)
+                    .await?;
+                Ok(())
+            })
+        })
+        .await;
+
+    assert!(result.is_err());
+    match result.unwrap_err() {
+        DsqlError::DatabaseError(_) => {}
+        other => panic!("Expected DatabaseError for syntax error, got: {:?}", other),
+    }
+
+    pool.close().await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_retry_exhaustion() -> Result<()> {
+    let conn_str = build_conn_str();
+    let table_name = format!("exhaustion_test_{}", std::process::id());
+
+    let opts = DsqlConnectOptions::from_connection_string(&conn_str)?;
+    let mut pool =
+        aurora_dsql_sqlx_connector::pool::connect_with(&opts, PgPoolOptions::new()).await?;
+
+    // Setup table
+    pool.transaction_with_retry(None, |tx| {
+        let t = table_name.clone();
+        txn!({
+            sqlx::query(&format!(
+                "CREATE TABLE IF NOT EXISTS {} (id INT PRIMARY KEY, val INT)",
+                t
+            ))
+            .execute(&mut **tx)
+            .await?;
+            Ok(())
+        })
+    })
+    .await?;
+
+    pool.transaction_with_retry(None, |tx| {
+        let t = table_name.clone();
+        txn!({
+            sqlx::query(&format!("INSERT INTO {} VALUES (1, 0)", t))
+                .execute(&mut **tx)
+                .await?;
+            Ok(())
+        })
+    })
+    .await?;
+
+    // Set max_attempts to 2 so we can test exhaustion
+    let retry_config = OCCRetryConfigBuilder::default()
+        .max_attempts(2u32)
+        .base_delay_ms(10u64)
+        .build()?;
+
+    let attempt_count = Arc::new(AtomicU32::new(0));
+    let count_clone = attempt_count.clone();
+
+    // Create continuous conflicting updates to force exhaustion
+    let pool_clone = pool.clone();
+    let table_clone = table_name.clone();
+    let conflict_tasks: Vec<_> = (0..5)
+        .map(|_| {
+            let mut p = pool_clone.clone();
+            let t = table_clone.clone();
+            tokio::spawn(async move {
+                for _ in 0..3 {
+                    let _ = p
+                        .transaction_with_retry(None, |tx| {
+                            let tab = t.clone();
+                            txn!({
+                                sqlx::query(&format!(
+                                    "UPDATE {} SET val = val + 1 WHERE id = 1",
+                                    tab
+                                ))
+                                .execute(&mut **tx)
+                                .await?;
+                                Ok(())
+                            })
+                        })
+                        .await;
+                    tokio::time::sleep(Duration::from_millis(10)).await;
+                }
+                Ok::<(), DsqlError>(())
+            })
+        })
+        .collect();
+
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    // This should exhaust retries due to continuous conflicts
+    let result = pool
+        .transaction_with_retry(Some(&retry_config), |tx| {
+            let c = count_clone.clone();
+            let t = table_name.clone();
+            txn!({
+                c.fetch_add(1, Ordering::SeqCst);
+                let row = sqlx::query(&format!("SELECT val FROM {} WHERE id = 1", t))
+                    .fetch_one(&mut **tx)
+                    .await?;
+                let current: i32 = row.get("val");
+                sqlx::query(&format!("UPDATE {} SET val = $1 WHERE id = 1", t))
+                    .bind(current + 100)
+                    .execute(&mut **tx)
+                    .await?;
+                tokio::time::sleep(Duration::from_millis(100)).await; // Hold transaction longer
+                Ok(())
+            })
+        })
+        .await;
+
+    for task in conflict_tasks {
+        let _ = task.await;
+    }
+
+    // Should either succeed or exhaust with correct attempt count
+    match result {
+        Ok(_) => {
+            // Succeeded despite conflicts
+            let attempts = attempt_count.load(Ordering::SeqCst);
+            assert!(
+                (1..=2).contains(&attempts),
+                "Attempts should be 1-2, got {}",
+                attempts
+            );
+        }
+        Err(DsqlError::OCCRetryExhausted { attempts, .. }) => {
+            // Exhausted as expected
+            assert_eq!(attempts, 2, "Should exhaust at max_attempts=2");
+            assert_eq!(
+                attempt_count.load(Ordering::SeqCst),
+                2,
+                "Should have tried 2 times"
+            );
+        }
+        Err(e) => panic!("Expected success or OCCRetryExhausted, got: {:?}", e),
+    }
+
+    // Cleanup
+    pool.transaction_with_retry(None, |tx| {
+        let t = table_name.clone();
+        txn!({
+            sqlx::query(&format!("DROP TABLE IF EXISTS {}", t))
+                .execute(&mut **tx)
+                .await?;
+            Ok(())
+        })
+    })
+    .await?;
+
+    pool.close().await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_return_value_preserved_across_retries() -> Result<()> {
+    let conn_str = build_conn_str();
+    let table_name = format!("return_val_test_{}", std::process::id());
+
+    let opts = DsqlConnectOptions::from_connection_string(&conn_str)?;
+    let mut pool =
+        aurora_dsql_sqlx_connector::pool::connect_with(&opts, PgPoolOptions::new()).await?;
+
+    // Setup table
+    pool.transaction_with_retry(None, |tx| {
+        let t = table_name.clone();
+        txn!({
+            sqlx::query(&format!(
+                "CREATE TABLE IF NOT EXISTS {} (id INT PRIMARY KEY, val INT)",
+                t
+            ))
+            .execute(&mut **tx)
+            .await?;
+            Ok(())
+        })
+    })
+    .await?;
+
+    pool.transaction_with_retry(None, |tx| {
+        let t = table_name.clone();
+        txn!({
+            sqlx::query(&format!("INSERT INTO {} VALUES (1, 42)", t))
+                .execute(&mut **tx)
+                .await?;
+            Ok(())
+        })
+    })
+    .await?;
+
+    let retry_config = OCCRetryConfigBuilder::default()
+        .max_attempts(5u32)
+        .base_delay_ms(10u64)
+        .build()?;
+
+    let attempt_count = Arc::new(AtomicU32::new(0));
+    let count_clone = attempt_count.clone();
+
+    // Spawn conflicting update
+    let mut pool_clone = pool.clone();
+    let table_clone = table_name.clone();
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(30)).await;
+        pool_clone
+            .transaction_with_retry(None, |tx| {
+                let t = table_clone.clone();
+                txn!({
+                    sqlx::query(&format!("UPDATE {} SET val = 100 WHERE id = 1", t))
+                        .execute(&mut **tx)
+                        .await?;
+                    Ok(())
+                })
+            })
+            .await
+    });
+
+    // Transaction that returns a value
+    let result: i32 = pool
+        .transaction_with_retry(Some(&retry_config), |tx| {
+            let c = count_clone.clone();
+            let t = table_name.clone();
+            txn!({
+                c.fetch_add(1, Ordering::SeqCst);
+                let row = sqlx::query(&format!("SELECT val FROM {} WHERE id = 1", t))
+                    .fetch_one(&mut **tx)
+                    .await?;
+                let val: i32 = row.get("val");
+
+                // Update it
+                sqlx::query(&format!("UPDATE {} SET val = $1 WHERE id = 1", t))
+                    .bind(val + 10)
+                    .execute(&mut **tx)
+                    .await?;
+
+                // Return the computed value
+                Ok(val + 10)
+            })
+        })
+        .await?;
+
+    // Verify return value is preserved
+    assert!(result > 0, "Should return positive value, got {}", result);
+    let attempts = attempt_count.load(Ordering::SeqCst);
+    assert!(
+        attempts >= 1,
+        "Should have made at least 1 attempt, got {}",
+        attempts
+    );
+
+    // Cleanup
+    pool.transaction_with_retry(None, |tx| {
+        let t = table_name.clone();
+        txn!({
+            sqlx::query(&format!("DROP TABLE IF EXISTS {}", t))
+                .execute(&mut **tx)
+                .await?;
+            Ok(())
+        })
+    })
+    .await?;
 
     pool.close().await;
     Ok(())

--- a/rust/sqlx/tests/integration/pool_integration_test.rs
+++ b/rust/sqlx/tests/integration/pool_integration_test.rs
@@ -1,79 +1,110 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use aurora_dsql_sqlx_connector::{DsqlConnectOptions, DsqlError, OCCRetryConfig, Result};
+use aurora_dsql_sqlx_connector::{
+    DsqlConnectOptions, DsqlError, OCCRetryConfigBuilder, OCCRetryExt, Result,
+};
 use sqlx::postgres::PgPoolOptions;
-use sqlx::{Connection, Row};
+use sqlx::Row;
 use std::time::Duration;
 
 use super::test_util::build_conn_str;
 
 #[tokio::test]
-async fn test_pool_transactional_write() -> Result<()> {
+async fn test_pool_occ_retry_on_concurrent_conflict() -> Result<()> {
     let conn_str = build_conn_str();
-    let table_name = format!("tx_test_{}", std::process::id());
+    let table_name = format!("occ_test_{}", std::process::id());
 
     let opts = DsqlConnectOptions::from_connection_string(&conn_str)?;
     let pool = aurora_dsql_sqlx_connector::pool::connect_with(&opts, PgPoolOptions::new()).await?;
 
-    let occ_config = OCCRetryConfig::default();
-
-    // Setup: create table with OCC retry
-    aurora_dsql_sqlx_connector::retry_on_occ(&occ_config, || {
-        let p = pool.clone();
+    // Setup: create table with a counter
+    pool.transaction_with_retry(None, |tx| {
         let t = table_name.clone();
-        async move {
-            let mut conn = p.acquire().await?;
-            let mut tx = conn.begin().await?;
+        Box::pin(async move {
             sqlx::query(&format!(
-                "CREATE TABLE IF NOT EXISTS {} (id INT PRIMARY KEY, name TEXT)",
+                "CREATE TABLE IF NOT EXISTS {} (id INT PRIMARY KEY, counter INT NOT NULL)",
                 t
             ))
-            .execute(&mut *tx)
+            .execute(&mut **tx)
             .await?;
-            tx.commit().await?;
             Ok(())
-        }
+        })
     })
     .await?;
 
-    // Transactional write with OCC retry
-    aurora_dsql_sqlx_connector::retry_on_occ(&occ_config, || {
-        let p = pool.clone();
+    // Initialize counter to 0
+    pool.transaction_with_retry(None, |tx| {
         let t = table_name.clone();
-        async move {
-            let mut conn = p.acquire().await?;
-            let mut tx = conn.begin().await?;
-            sqlx::query(&format!("INSERT INTO {} (id, name) VALUES (1, 'alice')", t))
-                .execute(&mut *tx)
+        Box::pin(async move {
+            sqlx::query(&format!("INSERT INTO {} (id, counter) VALUES (1, 0)", t))
+                .execute(&mut **tx)
                 .await?;
-            tx.commit().await?;
             Ok(())
-        }
+        })
     })
     .await?;
 
-    // Verify the write persisted
-    let row = sqlx::query(&format!("SELECT name FROM {} WHERE id = 1", table_name))
+    // Use higher retry config for high-contention scenario
+    let retry_config = OCCRetryConfigBuilder::default()
+        .max_attempts(10u32)
+        .base_delay_ms(50u64)
+        .build()?;
+
+    // Spawn 10 concurrent tasks that all read-modify-write the same counter
+    // This creates OCC conflicts that require retry
+    let mut handles = Vec::new();
+    for _ in 0..10 {
+        let pool = pool.clone();
+        let table = table_name.clone();
+        let config = retry_config.clone();
+        handles.push(tokio::spawn(async move {
+            pool.transaction_with_retry(Some(&config), |tx| {
+                let t = table.clone();
+                Box::pin(async move {
+                    // Read current value
+                    let row = sqlx::query(&format!("SELECT counter FROM {} WHERE id = 1", t))
+                        .fetch_one(&mut **tx)
+                        .await?;
+                    let current: i32 = row.get("counter");
+
+                    // Increment (classic read-modify-write that triggers OCC)
+                    sqlx::query(&format!("UPDATE {} SET counter = $1 WHERE id = 1", t))
+                        .bind(current + 1)
+                        .execute(&mut **tx)
+                        .await?;
+                    Ok(())
+                })
+            })
+            .await
+        }));
+    }
+
+    // Wait for all tasks to complete
+    for handle in handles {
+        handle.await.expect("Task panicked")?;
+    }
+
+    // Verify all increments succeeded - counter should be 10
+    let row = sqlx::query(&format!("SELECT counter FROM {} WHERE id = 1", table_name))
         .fetch_one(&pool)
         .await
         .map_err(DsqlError::DatabaseError)?;
-    let name: String = row.get("name");
-    assert_eq!(name, "alice");
+    let final_count: i32 = row.get("counter");
+    assert_eq!(
+        final_count, 10,
+        "Expected counter to be 10 after concurrent increments with OCC retry"
+    );
 
     // Cleanup
-    aurora_dsql_sqlx_connector::retry_on_occ(&occ_config, || {
-        let p = pool.clone();
+    pool.transaction_with_retry(None, |tx| {
         let t = table_name.clone();
-        async move {
-            let mut conn = p.acquire().await?;
-            let mut tx = conn.begin().await?;
+        Box::pin(async move {
             sqlx::query(&format!("DROP TABLE IF EXISTS {}", t))
-                .execute(&mut *tx)
+                .execute(&mut **tx)
                 .await?;
-            tx.commit().await?;
             Ok(())
-        }
+        })
     })
     .await?;
 


### PR DESCRIPTION
Add OCCRetryExt extension trait providing ergonomic automatic OCC retry for PgPool operations with optional config and tracing.

Core changes:
- Add OCCRetryExt trait with transaction_with_retry method
- Automatically retry on OCC errors during execution and commit
- Support optional retry config (None for defaults, Some for custom)
- Add log crate for detailed logging
- Add From impl for OCCRetryConfigBuilder error conversion
- Update integration tests with real concurrent conflict test
- Add async-trait dependency gated to occ feature

Issue #, if available:
N/A

Description of changes:
Implemented automatic OCC retry trait for Rust SQLx connector

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.