### PR TITLE
feat(node-postgres): add automatic OCC retry support

### DIFF
--- a/node/node-postgres/README.md
+++ b/node/node-postgres/README.md
@@ -137,6 +137,35 @@ await client.end();
 
 All other parameters from [Client](https://node-postgres.com/apis/client) / [Pool](https://node-postgres.com/apis/pool) are supported.
 
+### OCC Retry
+
+Aurora DSQL uses Optimistic Concurrency Control (OCC). The connector provides automatic retry on OCC conflicts (error codes: OC000, OC001, 40001).
+
+```typescript
+const pool = new AuroraDSQLPool({
+  host: "<CLUSTER_ENDPOINT>",
+  user: "admin",
+  occ: {
+    enabled: true,     // Automatically retry on OCC conflicts
+    maxAttempts: 3,    // Optional: defaults shown
+    baseDelayMs: 1,
+    maxDelayMs: 100,
+    jitterFactor: 0.25
+  }
+});
+
+// All queries automatically retry
+await pool.query("INSERT INTO accounts VALUES($1, $2)", [1, 100]);
+
+// Opt-out per query
+await pool.query({ text: "SELECT * FROM accounts", skipRetry: true });
+
+// Explicit transaction retry (works with both pool and client)
+await pool.transactionWithRetry(async (c) => {
+  await c.query("UPDATE accounts SET balance = balance - 10 WHERE id = $1", [1]);
+});
+```
+
 ## Authentication
 
 The connector automatically handles DSQL authentication by generating tokens using the DSQL client token generator. If the AWS region is not provided, it will be automatically parsed from the hostname provided.

--- a/node/node-postgres/example/README.md
+++ b/node/node-postgres/example/README.md
@@ -11,7 +11,7 @@ you to interact with PostgreSQL databases using JavaScript code.
 
 ## About the code example
 
-The example demonstrates a flexible connection approach that works for both admin and non-admin users:
+The example demonstrates OCC retry and a flexible connection approach that works for both admin and non-admin users:
 
 - When connecting as an **admin user**, the example uses the `public` schema and generates an admin authentication
   token.
@@ -19,6 +19,10 @@ The example demonstrates a flexible connection approach that works for both admi
   authentication token.
 
 The code automatically detects the user type and adjusts its behavior accordingly.
+
+## OCC Automatic Retry
+
+Aurora DSQL uses Optimistic Concurrency Control (OCC). This connector provides automatic retry via `occ: { enabled: true }` config (pool or client level) or `transactionWithRetry()` method. See examples for usage.
 
 ## ⚠️ Important
 

--- a/node/node-postgres/example/src/alternatives/README.md
+++ b/node/node-postgres/example/src/alternatives/README.md
@@ -1,6 +1,6 @@
 # Alternative Examples
 
-The recommended approach is `example_preferred.ts` in the parent directory, which uses AuroraDSQLPool with the Aurora DSQL Node.js Connector.
+The recommended approach is `example_preferred.js` in the parent directory, which uses AuroraDSQLPool with the Aurora DSQL Node.js Connector.
 
 ## Why Connection Pooling with the Connector?
 
@@ -27,8 +27,8 @@ The connector + pool combination handles this automatically:
 
 ### `pool/`
 Other pool configurations:
-- `example_with_nonconcurrent_connection_pool.ts` - Sequential pool usage
+- `example_with_nonconcurrent_connection_pool.js` - Sequential pool usage
 
 ### `no_connection_pool/`
 Examples without pooling:
-- `example_with_no_connection_pool.ts` - Single connection with connector
+- `example_with_no_connection_pool.js` - Single connection with `transactionWithRetry()` for OCC handling

--- a/node/node-postgres/example/src/alternatives/no_connection_pool/example_with_no_connection_pool.js
+++ b/node/node-postgres/example/src/alternatives/no_connection_pool/example_with_no_connection_pool.js
@@ -12,7 +12,7 @@ const NON_ADMIN_SCHEMA = "myschema";
 async function getConnection(clusterEndpoint, user) {
   const client = new AuroraDSQLClient({
     host: clusterEndpoint,
-    user: user,
+    user: user
   });
 
   await client.connect();
@@ -33,7 +33,10 @@ async function example() {
       await client.query("SET search_path=" + NON_ADMIN_SCHEMA);
     }
 
-    // Create a new table
+    // Use transactionWithRetry() to handle OCC conflicts
+    // Wraps operations in BEGIN/COMMIT with automatic retry
+
+    // Create a new table (DDL - outside transaction)
     await client.query(`CREATE TABLE IF NOT EXISTS owner (
       id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
       name VARCHAR(30) NOT NULL,
@@ -41,11 +44,13 @@ async function example() {
       telephone VARCHAR(20)
     )`);
 
-    // Insert some data
-    await client.query(
-      "INSERT INTO owner(name, city, telephone) VALUES($1, $2, $3)",
-      ["John Doe", "Anytown", "555-555-1900"]
-    );
+    // Insert data with OCC retry
+    await client.transactionWithRetry(async (c) => {
+      await c.query(
+        "INSERT INTO owner(name, city, telephone) VALUES($1, $2, $3)",
+        ["John Doe", "Anytown", "555-555-1900"]
+      );
+    });
 
     // Check that data is inserted by reading it back
     const result = await client.query(
@@ -54,7 +59,11 @@ async function example() {
     assert.deepEqual(result.rows[0].city, "Anytown");
     assert.notEqual(result.rows[0].id, null);
 
-    await client.query("DELETE FROM owner where name='John Doe'");
+    // Delete with OCC retry
+    await client.transactionWithRetry(async (c) => {
+      await c.query("DELETE FROM owner where name='John Doe'");
+    });
+
     console.log("Completed successfully");
   } catch (error) {
     console.error(error);

--- a/node/node-postgres/example/src/example_preferred.js
+++ b/node/node-postgres/example/src/example_preferred.js
@@ -15,6 +15,13 @@ function createPool(clusterEndpoint, user) {
     max: 10,
     idleTimeoutMillis: 30000,
     connectionTimeoutMillis: 10000,
+    occ: {
+      enabled: true,        // Enable automatic retry for all queries
+      maxAttempts: 3,       // Optional (default: 3)
+      baseDelayMs: 1,       // Optional (default: 1)
+      maxDelayMs: 100,      // Optional (default: 100)
+      jitterFactor: 0.25    // Optional (default: 0.25)
+    }
   });
 }
 
@@ -33,6 +40,8 @@ async function example() {
   const pool = createPool(clusterEndpoint, user);
 
   try {
+    // OCC retry is enabled - all queries automatically retry on conflicts
+
     // Run concurrent queries using the connection pool
     const workers = [];
     for (let i = 1; i <= NUM_CONCURRENT_QUERIES; i++) {
@@ -41,6 +50,9 @@ async function example() {
 
     // Wait for all workers to complete
     await Promise.all(workers);
+
+    // Opt-out per query using QueryConfig
+    await pool.query({ text: "SELECT 1", skipRetry: true });
 
     console.log("Connection pool with concurrent connections exercised successfully");
   } catch (error) {

--- a/node/node-postgres/src/aurora-dsql-client.ts
+++ b/node/node-postgres/src/aurora-dsql-client.ts
@@ -2,19 +2,21 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
+/* eslint-disable @typescript-eslint/no-explicit-any -- Required for pg library query overload compatibility */
 import { Client, QueryResult, QueryResultRow, QueryConfig, QueryArrayConfig, QueryConfigValues, QueryArrayResult, Submittable } from "pg";
 import { AuroraDSQLConfig } from "./config/aurora-dsql-config.js";
 import { AuroraDSQLUtil } from "./aurora-dsql-util.js";
 import {
   DEFAULT_OCC_CONFIG,
   OccRetryConfig,
+  validateOccConfig,
   executeWithRetry,
   OccRetryEvent,
   OccRetryExhaustedEvent
 } from "./occ-retry.js";
 
 // Extended QueryConfig to support skipRetry option
-interface QueryConfigWithRetry<I = any[]> extends QueryConfig<I> {
+export interface QueryConfigWithRetry<I = any[]> extends QueryConfig<I> {
   skipRetry?: boolean;
 }
 
@@ -35,6 +37,7 @@ class AuroraDSQLClient extends Client {
     // Initialize OCC retry config if provided
     if (dsqlConfig.occ) {
       this.occConfig = { ...DEFAULT_OCC_CONFIG, ...dsqlConfig.occ };
+      validateOccConfig(this.occConfig);
     }
   }
 
@@ -79,16 +82,16 @@ class AuroraDSQLClient extends Client {
   ): Promise<QueryResult<R>>;
   override query<R extends any[] = any[], I = any[]>(
     queryConfig: QueryArrayConfig<I>,
-    callback: (err: Error, result: QueryArrayResult<R>) => void,
+    callback: (err: Error | null, result: QueryArrayResult<R>) => void,
   ): void;
   override query<R extends QueryResultRow = any, I = any[]>(
     queryTextOrConfig: string | QueryConfigWithRetry<I>,
-    callback: (err: Error, result: QueryResult<R>) => void,
+    callback: (err: Error | null, result: QueryResult<R>) => void,
   ): void;
   override query<R extends QueryResultRow = any, I = any[]>(
     queryText: string,
     values: QueryConfigValues<I>,
-    callback: (err: Error, result: QueryResult<R>) => void,
+    callback: (err: Error | null, result: QueryResult<R>) => void,
   ): void;
 
   // Implementation
@@ -167,27 +170,36 @@ class AuroraDSQLClient extends Client {
       enabled: true
     };
 
-    return executeWithRetry(
-      async () => {
-        await super.query('BEGIN');
-        try {
-          const result = await callback(this);
-          await super.query('COMMIT');
-          return result;
-        } catch (error) {
+    // Temporarily disable query-level retry inside transaction to avoid double-retry
+    const savedOccConfig = this.occConfig;
+    this.occConfig = undefined;
+
+    try {
+      return await executeWithRetry(
+        async () => {
+          await super.query('BEGIN');
           try {
-            await super.query('ROLLBACK');
-          } catch (rollbackError) {
-            console.debug(
-              `Rollback failed: original_error=${error}, rollback_error=${rollbackError}`
-            );
+            const result = await callback(this);
+            await super.query('COMMIT');
+            return result;
+          } catch (error) {
+            try {
+              await super.query('ROLLBACK');
+            } catch (rollbackError) {
+              console.debug(
+                `Rollback failed: original_error=${error}, rollback_error=${rollbackError}`
+              );
+            }
+            throw error;
           }
-          throw error;
-        }
-      },
-      effectiveConfig,
-      (event) => this.emitOccEvent(event)
-    );
+        },
+        effectiveConfig,
+        (event) => this.emitOccEvent(event)
+      );
+    } finally {
+      // Restore query-level retry config
+      this.occConfig = savedOccConfig;
+    }
   }
 }
 

--- a/node/node-postgres/src/aurora-dsql-client.ts
+++ b/node/node-postgres/src/aurora-dsql-client.ts
@@ -2,12 +2,25 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { Client } from "pg";
+import { Client, QueryResult, QueryResultRow, QueryConfig, QueryArrayConfig, QueryConfigValues, QueryArrayResult, Submittable } from "pg";
 import { AuroraDSQLConfig } from "./config/aurora-dsql-config.js";
 import { AuroraDSQLUtil } from "./aurora-dsql-util.js";
+import {
+  DEFAULT_OCC_CONFIG,
+  OccRetryConfig,
+  executeWithRetry,
+  OccRetryEvent,
+  OccRetryExhaustedEvent
+} from "./occ-retry.js";
+
+// Extended QueryConfig to support skipRetry option
+interface QueryConfigWithRetry<I = any[]> extends QueryConfig<I> {
+  skipRetry?: boolean;
+}
 
 class AuroraDSQLClient extends Client {
   private dsqlConfig?: AuroraDSQLConfig;
+  private occConfig?: Required<OccRetryConfig>;
 
   constructor(config?: string | AuroraDSQLConfig) {
     if (config === undefined) {
@@ -18,6 +31,11 @@ class AuroraDSQLClient extends Client {
     super(dsqlConfig);
 
     this.dsqlConfig = dsqlConfig;
+
+    // Initialize OCC retry config if provided
+    if (dsqlConfig.occ) {
+      this.occConfig = { ...DEFAULT_OCC_CONFIG, ...dsqlConfig.occ };
+    }
   }
 
   // TypeScript doesn't allow multiple declarations of the same function name hence the following declaration was used
@@ -44,6 +62,132 @@ class AuroraDSQLClient extends Client {
       return super.connect(callback);
     }
     return super.connect();
+  }
+
+  // Override query method with all pg overloads to support OCC retry
+  override query<T extends Submittable>(queryStream: T): T;
+  override query<R extends any[] = any[], I = any[]>(
+    queryConfig: QueryArrayConfig<I>,
+    values?: QueryConfigValues<I>,
+  ): Promise<QueryArrayResult<R>>;
+  override query<R extends QueryResultRow = any, I = any[]>(
+    queryConfig: QueryConfigWithRetry<I>,
+  ): Promise<QueryResult<R>>;
+  override query<R extends QueryResultRow = any, I = any[]>(
+    queryTextOrConfig: string | QueryConfigWithRetry<I>,
+    values?: QueryConfigValues<I>,
+  ): Promise<QueryResult<R>>;
+  override query<R extends any[] = any[], I = any[]>(
+    queryConfig: QueryArrayConfig<I>,
+    callback: (err: Error, result: QueryArrayResult<R>) => void,
+  ): void;
+  override query<R extends QueryResultRow = any, I = any[]>(
+    queryTextOrConfig: string | QueryConfigWithRetry<I>,
+    callback: (err: Error, result: QueryResult<R>) => void,
+  ): void;
+  override query<R extends QueryResultRow = any, I = any[]>(
+    queryText: string,
+    values: QueryConfigValues<I>,
+    callback: (err: Error, result: QueryResult<R>) => void,
+  ): void;
+
+  // Implementation
+  override query(
+    queryTextOrConfig: any,
+    valuesOrCallback?: any,
+    callback?: any,
+  ): any {
+    // Pass through for QueryStream (Submittable)
+    if (queryTextOrConfig && typeof queryTextOrConfig.submit === 'function') {
+      return super.query(queryTextOrConfig, valuesOrCallback, callback);
+    }
+
+    // Check if retry should be skipped
+    const skipRetry = !this.occConfig?.enabled ||
+      (typeof queryTextOrConfig === 'object' && queryTextOrConfig?.skipRetry);
+
+    if (skipRetry) {
+      return super.query(queryTextOrConfig, valuesOrCallback, callback);
+    }
+
+    // Extract query text for logging
+    const queryText = typeof queryTextOrConfig === 'string'
+      ? queryTextOrConfig
+      : queryTextOrConfig?.text;
+
+    // Determine if callback-based or promise-based
+    const hasCallback = typeof valuesOrCallback === 'function' || typeof callback === 'function';
+    const actualCallback = (typeof valuesOrCallback === 'function' ? valuesOrCallback : callback);
+
+    // Wrap query with retry logic
+    const operation = () => super.query(
+      queryTextOrConfig,
+      typeof valuesOrCallback === 'function' ? undefined : valuesOrCallback
+    );
+
+    if (hasCallback && actualCallback) {
+      executeWithRetry(
+        operation,
+        this.occConfig!,
+        (event) => this.emitOccEvent(event),
+        queryText
+      )
+        .then(result => actualCallback(null, result))
+        .catch(err => actualCallback(err, undefined as any));
+      return;
+    }
+
+    return executeWithRetry(
+      operation,
+      this.occConfig!,
+      (event) => this.emitOccEvent(event),
+      queryText
+    );
+  }
+
+  // Emit OCC events (occRetry and occRetryExhausted)
+  private emitOccEvent(event: OccRetryEvent | OccRetryExhaustedEvent): void {
+    if (event.type === 'occRetry') {
+      this.emit('occRetry', event);
+    } else {
+      this.emit('occRetryExhausted', event);
+    }
+  }
+
+  // Execute transaction with automatic OCC retry
+  async transactionWithRetry<T>(
+    callback: (client: this) => Promise<T>,
+    occConfig?: Partial<OccRetryConfig>
+  ): Promise<T> {
+    // Merge client config, custom config, and always enable retry
+    const effectiveConfig: Required<OccRetryConfig> = {
+      ...DEFAULT_OCC_CONFIG,
+      ...this.occConfig,
+      ...occConfig,
+      enabled: true
+    };
+
+    return executeWithRetry(
+      async () => {
+        await super.query('BEGIN');
+        try {
+          const result = await callback(this);
+          await super.query('COMMIT');
+          return result;
+        } catch (error) {
+          try {
+            await super.query('ROLLBACK');
+          } catch (rollbackError) {
+            console.debug(
+              `Rollback failed: original_error=${error}, rollback_error=${rollbackError}`
+            );
+          }
+          throw error;
+        }
+      },
+      effectiveConfig,
+      (event) => this.emitOccEvent(event)
+    );
   }
 }
 

--- a/node/node-postgres/src/aurora-dsql-pool.ts
+++ b/node/node-postgres/src/aurora-dsql-pool.ts
@@ -2,12 +2,25 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { Pool, PoolClient } from "pg";
+import { Pool, PoolClient, QueryResult, QueryResultRow, QueryConfig, QueryArrayConfig, QueryConfigValues, QueryArrayResult, Submittable } from "pg";
 import { AuroraDSQLPoolConfig } from "./config/aurora-dsql-pool-config.js";
 import { AuroraDSQLUtil } from "./aurora-dsql-util.js";
+import {
+  DEFAULT_OCC_CONFIG,
+  OccRetryConfig,
+  executeWithRetry,
+  OccRetryEvent,
+  OccRetryExhaustedEvent
+} from "./occ-retry.js";
+
+// Extended QueryConfig to support skipRetry option
+interface QueryConfigWithRetry<I = any[]> extends QueryConfig<I> {
+  skipRetry?: boolean;
+}
 
 class AuroraDSQLPool extends Pool {
   private dsqlConfig?: AuroraDSQLPoolConfig;
+  private occConfig?: Required<OccRetryConfig>;
 
   constructor(config?: AuroraDSQLPoolConfig) {
     if (config === undefined) {
@@ -18,6 +31,11 @@ class AuroraDSQLPool extends Pool {
     super(dsqlConfig);
 
     this.dsqlConfig = dsqlConfig;
+
+    // Initialize OCC retry config if provided
+    if (dsqlConfig.occ) {
+      this.occConfig = { ...DEFAULT_OCC_CONFIG, ...dsqlConfig.occ };
+    }
   }
 
   // These declaration are needed as they have different returns otherwise a compile error will occur
@@ -53,7 +71,7 @@ class AuroraDSQLPool extends Pool {
       }
     } catch (error) {
       if (callback) {
-        callback(error as Error, undefined, () => {});
+        callback(error as Error, undefined, () => { });
         return;
       }
       throw error;
@@ -62,6 +80,139 @@ class AuroraDSQLPool extends Pool {
       return super.connect(callback);
     }
     return super.connect();
+  }
+
+  // Override query method with all pg overloads to support OCC retry
+  override query<T extends Submittable>(queryStream: T): T;
+  override query<R extends any[] = any[], I = any[]>(
+    queryConfig: QueryArrayConfig<I>,
+    values?: QueryConfigValues<I>,
+  ): Promise<QueryArrayResult<R>>;
+  override query<R extends QueryResultRow = any, I = any[]>(
+    queryConfig: QueryConfigWithRetry<I>,
+  ): Promise<QueryResult<R>>;
+  override query<R extends QueryResultRow = any, I = any[]>(
+    queryTextOrConfig: string | QueryConfigWithRetry<I>,
+    values?: QueryConfigValues<I>,
+  ): Promise<QueryResult<R>>;
+  override query<R extends any[] = any[], I = any[]>(
+    queryConfig: QueryArrayConfig<I>,
+    callback: (err: Error, result: QueryArrayResult<R>) => void,
+  ): void;
+  override query<R extends QueryResultRow = any, I = any[]>(
+    queryTextOrConfig: string | QueryConfigWithRetry<I>,
+    callback: (err: Error, result: QueryResult<R>) => void,
+  ): void;
+  override query<R extends QueryResultRow = any, I = any[]>(
+    queryText: string,
+    values: QueryConfigValues<I>,
+    callback: (err: Error, result: QueryResult<R>) => void,
+  ): void;
+
+  // Implementation
+  override query(
+    queryTextOrConfig: any,
+    valuesOrCallback?: any,
+    callback?: any,
+  ): any {
+    // Pass through for QueryStream (Submittable)
+    if (queryTextOrConfig && typeof queryTextOrConfig.submit === 'function') {
+      return super.query(queryTextOrConfig, valuesOrCallback, callback);
+    }
+
+    // Check if retry should be skipped
+    const skipRetry = !this.occConfig?.enabled ||
+      (typeof queryTextOrConfig === 'object' && queryTextOrConfig?.skipRetry);
+
+    if (skipRetry) {
+      return super.query(queryTextOrConfig, valuesOrCallback, callback);
+    }
+
+    // Extract query text for logging
+    const queryText = typeof queryTextOrConfig === 'string'
+      ? queryTextOrConfig
+      : queryTextOrConfig?.text;
+
+    // Determine if callback-based or promise-based
+    const hasCallback = typeof valuesOrCallback === 'function' || typeof callback === 'function';
+    const actualCallback = (typeof valuesOrCallback === 'function' ? valuesOrCallback : callback);
+
+    // Wrap query with retry logic
+    const operation = () => super.query(
+      queryTextOrConfig,
+      typeof valuesOrCallback === 'function' ? undefined : valuesOrCallback
+    );
+
+    if (hasCallback && actualCallback) {
+      executeWithRetry(
+        operation,
+        this.occConfig!,
+        (event) => this.emitOccEvent(event),
+        queryText
+      )
+        .then(result => actualCallback(null, result))
+        .catch(err => actualCallback(err, undefined as any));
+      return;
+    }
+
+    return executeWithRetry(
+      operation,
+      this.occConfig!,
+      (event) => this.emitOccEvent(event),
+      queryText
+    );
+  }
+
+  // Emit OCC events (occRetry and occRetryExhausted)
+  private emitOccEvent(event: OccRetryEvent | OccRetryExhaustedEvent): void {
+    if (event.type === 'occRetry') {
+      this.emit('occRetry', event);
+    } else {
+      this.emit('occRetryExhausted', event);
+    }
+  }
+
+  // Execute transaction with automatic OCC retry
+  async transactionWithRetry<T>(
+    callback: (client: PoolClient) => Promise<T>,
+    occConfig?: Partial<OccRetryConfig>
+  ): Promise<T> {
+    // Merge pool config, custom config, and always enable retry
+    const effectiveConfig: Required<OccRetryConfig> = {
+      ...DEFAULT_OCC_CONFIG,
+      ...this.occConfig,
+      ...occConfig,
+      enabled: true
+    };
+
+    return executeWithRetry(
+      async () => {
+        const client = await this.connect();
+        try {
+          await client.query('BEGIN');
+          const result = await callback(client);
+          await client.query('COMMIT');
+          return result;
+        } catch (error) {
+          try {
+            await client.query('ROLLBACK');
+          } catch (rollbackError) {
+            console.debug(
+              `Rollback failed: original_error=${error}, rollback_error=${rollbackError}`
+            );
+          }
+          throw error;
+        } finally {
+          try {
+            client.release();
+          } catch (releaseError) {
+            console.debug(`Client release failed: ${releaseError}`);
+          }
+        }
+      },
+      effectiveConfig,
+      (event) => this.emitOccEvent(event)
+    );
   }
 }
 

--- a/node/node-postgres/src/aurora-dsql-pool.ts
+++ b/node/node-postgres/src/aurora-dsql-pool.ts
@@ -2,19 +2,21 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
+/* eslint-disable @typescript-eslint/no-explicit-any -- Required for pg library query overload compatibility */
 import { Pool, PoolClient, QueryResult, QueryResultRow, QueryConfig, QueryArrayConfig, QueryConfigValues, QueryArrayResult, Submittable } from "pg";
 import { AuroraDSQLPoolConfig } from "./config/aurora-dsql-pool-config.js";
 import { AuroraDSQLUtil } from "./aurora-dsql-util.js";
 import {
   DEFAULT_OCC_CONFIG,
   OccRetryConfig,
+  validateOccConfig,
   executeWithRetry,
   OccRetryEvent,
   OccRetryExhaustedEvent
 } from "./occ-retry.js";
 
 // Extended QueryConfig to support skipRetry option
-interface QueryConfigWithRetry<I = any[]> extends QueryConfig<I> {
+export interface QueryConfigWithRetry<I = any[]> extends QueryConfig<I> {
   skipRetry?: boolean;
 }
 
@@ -35,6 +37,7 @@ class AuroraDSQLPool extends Pool {
     // Initialize OCC retry config if provided
     if (dsqlConfig.occ) {
       this.occConfig = { ...DEFAULT_OCC_CONFIG, ...dsqlConfig.occ };
+      validateOccConfig(this.occConfig);
     }
   }
 
@@ -97,16 +100,16 @@ class AuroraDSQLPool extends Pool {
   ): Promise<QueryResult<R>>;
   override query<R extends any[] = any[], I = any[]>(
     queryConfig: QueryArrayConfig<I>,
-    callback: (err: Error, result: QueryArrayResult<R>) => void,
+    callback: (err: Error | null, result: QueryArrayResult<R>) => void,
   ): void;
   override query<R extends QueryResultRow = any, I = any[]>(
     queryTextOrConfig: string | QueryConfigWithRetry<I>,
-    callback: (err: Error, result: QueryResult<R>) => void,
+    callback: (err: Error | null, result: QueryResult<R>) => void,
   ): void;
   override query<R extends QueryResultRow = any, I = any[]>(
     queryText: string,
     values: QueryConfigValues<I>,
-    callback: (err: Error, result: QueryResult<R>) => void,
+    callback: (err: Error | null, result: QueryResult<R>) => void,
   ): void;
 
   // Implementation

--- a/node/node-postgres/src/config/aurora-dsql-config.ts
+++ b/node/node-postgres/src/config/aurora-dsql-config.ts
@@ -4,12 +4,14 @@
  */
 import { ClientConfig } from "pg";
 import { AwsCredentialIdentity, AwsCredentialIdentityProvider } from "@smithy/types";
+import { OccRetryConfig } from "../occ-retry.js";
 
 interface AuroraDSQLConfig extends ClientConfig {
   profile?: string;
   region?: string;
   tokenDurationSecs?: number;
   customCredentialsProvider?: AwsCredentialIdentity | AwsCredentialIdentityProvider;
+  occ?: OccRetryConfig;
 }
 
 export { AuroraDSQLConfig };

--- a/node/node-postgres/src/index.ts
+++ b/node/node-postgres/src/index.ts
@@ -8,5 +8,6 @@ export type { AuroraDSQLConfig } from './config/aurora-dsql-config.js';
 export type { AuroraDSQLPoolConfig } from './config/aurora-dsql-pool-config.js';
 
 // OCC Retry exports
-export { OCCType, OccRetryExhaustedError, DEFAULT_OCC_CONFIG } from './occ-retry.js';
+export { OCCType, OccRetryExhaustedError, DEFAULT_OCC_CONFIG, validateOccConfig } from './occ-retry.js';
 export type { OccRetryConfig, OccErrorInfo, OccRetryEvent, OccRetryExhaustedEvent } from './occ-retry.js';
+export type { QueryConfigWithRetry } from './aurora-dsql-client.js';

--- a/node/node-postgres/src/index.ts
+++ b/node/node-postgres/src/index.ts
@@ -6,3 +6,7 @@ export { AuroraDSQLClient } from "./aurora-dsql-client.js";
 export { AuroraDSQLPool } from "./aurora-dsql-pool.js";
 export type { AuroraDSQLConfig } from './config/aurora-dsql-config.js';
 export type { AuroraDSQLPoolConfig } from './config/aurora-dsql-pool-config.js';
+
+// OCC Retry exports
+export { OCCType, OccRetryExhaustedError, DEFAULT_OCC_CONFIG } from './occ-retry.js';
+export type { OccRetryConfig, OccErrorInfo, OccRetryEvent, OccRetryExhaustedEvent } from './occ-retry.js';

--- a/node/node-postgres/src/occ-retry.ts
+++ b/node/node-postgres/src/occ-retry.ts
@@ -2,6 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
+/* eslint-disable @typescript-eslint/no-explicit-any -- Required for untyped pg error properties */
 
 /**
  * OCC error type classification
@@ -90,6 +91,27 @@ export const DEFAULT_OCC_CONFIG: Required<OccRetryConfig> = {
 };
 
 /**
+ * Validate OCC retry configuration
+ */
+export function validateOccConfig(config: Required<OccRetryConfig>): void {
+  if (config.maxAttempts < 1 || config.maxAttempts > 100) {
+    throw new Error('occ.maxAttempts must be between 1 and 100');
+  }
+  if (config.baseDelayMs < 1) {
+    throw new Error('occ.baseDelayMs must be at least 1');
+  }
+  if (config.maxDelayMs > 100) {
+    throw new Error('occ.maxDelayMs must not exceed 100');
+  }
+  if (config.maxDelayMs < config.baseDelayMs) {
+    throw new Error('occ.maxDelayMs must be >= occ.baseDelayMs');
+  }
+  if (config.jitterFactor < 0 || config.jitterFactor > 1) {
+    throw new Error('occ.jitterFactor must be between 0 and 1');
+  }
+}
+
+/**
  * Detect if error is an OCC error and classify it
  *
  * @param error - Database error to check
@@ -118,11 +140,11 @@ export function isOccError(error: Error): OccErrorInfo | null {
     const message = dbError.message || '';
 
     // Parse message for embedded OCC codes
-    if (message.includes('OC000')) {
+    if (message.includes('(OC000)')) {
       return { type: OCCType.Data, code: 'OC000' };
     }
 
-    if (message.includes('OC001')) {
+    if (message.includes('(OC001)')) {
       return { type: OCCType.Schema, code: 'OC001' };
     }
 
@@ -136,9 +158,6 @@ export function isOccError(error: Error): OccErrorInfo | null {
 /**
  * Calculate exponential backoff delay with jitter
  *
- * Formula: delay = min(baseDelayMs * 2^(attempt-1) + jitter, maxDelayMs)
- * Jitter: random(0, delay * jitterFactor)
- *
  * @param config - Retry configuration
  * @param attempt - Current attempt number (1-based)
  * @returns Calculated delay in milliseconds
@@ -147,16 +166,11 @@ export function calculateBackoff(
   config: Required<OccRetryConfig>,
   attempt: number
 ): number {
-  // Exponential backoff: baseDelayMs * 2^(attempt-1)
-  const exponentialDelay = config.baseDelayMs * Math.pow(2, attempt - 1);
-
-  // Calculate jitter: random value between 0 and (delay * jitterFactor)
-  const jitterRange = exponentialDelay * config.jitterFactor;
-  const jitter = Math.random() * jitterRange;
-
-  // Apply jitter and cap at maxDelayMs
-  const delayWithJitter = exponentialDelay + jitter;
-  return Math.min(Math.round(delayWithJitter), config.maxDelayMs);
+  const exponent = Math.min(attempt - 1, 31); // Cap at 2^31 to prevent overflow
+  const exponentialDelay = config.baseDelayMs * Math.pow(2, exponent);
+  const cappedDelay = Math.min(exponentialDelay, config.maxDelayMs);
+  const jitter = Math.random() * cappedDelay * config.jitterFactor;
+  return Math.round(cappedDelay + jitter);
 }
 
 /**

--- a/node/node-postgres/src/occ-retry.ts
+++ b/node/node-postgres/src/occ-retry.ts
@@ -1,0 +1,243 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * OCC error type classification
+ */
+export enum OCCType {
+  Data = 'Data',       // OC000 - concurrent data modification
+  Schema = 'Schema',   // OC001 - DDL during transaction
+  Unknown = 'Unknown'  // 40001 - generic serialization failure
+}
+
+/**
+ * OCC error detection result
+ */
+export interface OccErrorInfo {
+  type: OCCType;
+  code: string;
+}
+
+/**
+ * OCC retry configuration
+ */
+export interface OccRetryConfig {
+  enabled: boolean;          // Required to enable retry
+  maxAttempts?: number;      // Default: 3, Range: 1-100
+  baseDelayMs?: number;      // Default: 1
+  maxDelayMs?: number;       // Default: 100
+  jitterFactor?: number;     // Default: 0.25, Range: 0-1
+}
+
+/**
+ * Event emitted on retry attempt
+ */
+export interface OccRetryEvent {
+  type: 'occRetry';
+  attempt: number;           // Current attempt number (1-based)
+  maxAttempts: number;       // Maximum attempts configured
+  delayMs: number;           // Calculated backoff delay
+  error: Error;              // Original database error
+  occType: OCCType;          // Classified OCC type
+  occCode: string;           // SQL error code
+  queryText?: string;        // Query text if available
+}
+
+/**
+ * Event emitted when retries exhausted
+ */
+export interface OccRetryExhaustedEvent {
+  type: 'occRetryExhausted';
+  attempts: number;          // Total attempts made
+  error: Error;              // Last database error
+  occType: OCCType;          // Classified OCC type
+  occCode: string;           // SQL error code
+  queryText?: string;        // Query text if available
+}
+
+/**
+ * Custom error thrown when retries exhausted
+ */
+export class OccRetryExhaustedError extends Error {
+  name = 'OccRetryExhaustedError';
+
+  constructor(
+    public readonly attempts: number,
+    public readonly lastError: Error,
+    public readonly occInfo: OccErrorInfo
+  ) {
+    super(
+      `OCC retry exhausted after ${attempts} attempts ` +
+      `(type=${occInfo.type}, code=${occInfo.code})`
+    );
+
+    // Restore prototype chain for instanceof checks
+    Object.setPrototypeOf(this, OccRetryExhaustedError.prototype);
+  }
+}
+
+/**
+ * Default OCC retry configuration
+ */
+export const DEFAULT_OCC_CONFIG: Required<OccRetryConfig> = {
+  enabled: false,
+  maxAttempts: 3,
+  baseDelayMs: 1,
+  maxDelayMs: 100,
+  jitterFactor: 0.25
+};
+
+/**
+ * Detect if error is an OCC error and classify it
+ *
+ * @param error - Database error to check
+ * @returns OccErrorInfo if OCC error, null otherwise
+ */
+export function isOccError(error: Error): OccErrorInfo | null {
+  const dbError = error as any;
+
+  // Check for PostgreSQL error code
+  if (!dbError.code) {
+    return null;
+  }
+
+  // OC000 - Data conflict (concurrent data modification)
+  if (dbError.code === 'OC000') {
+    return { type: OCCType.Data, code: 'OC000' };
+  }
+
+  // OC001 - Schema conflict (DDL during transaction)
+  if (dbError.code === 'OC001') {
+    return { type: OCCType.Schema, code: 'OC001' };
+  }
+
+  // 40001 - Serialization failure (may contain embedded OC000/OC001)
+  if (dbError.code === '40001') {
+    const message = dbError.message || '';
+
+    // Parse message for embedded OCC codes
+    if (message.includes('OC000')) {
+      return { type: OCCType.Data, code: 'OC000' };
+    }
+
+    if (message.includes('OC001')) {
+      return { type: OCCType.Schema, code: 'OC001' };
+    }
+
+    // Generic serialization failure
+    return { type: OCCType.Unknown, code: '40001' };
+  }
+
+  return null;
+}
+
+/**
+ * Calculate exponential backoff delay with jitter
+ *
+ * Formula: delay = min(baseDelayMs * 2^(attempt-1) + jitter, maxDelayMs)
+ * Jitter: random(0, delay * jitterFactor)
+ *
+ * @param config - Retry configuration
+ * @param attempt - Current attempt number (1-based)
+ * @returns Calculated delay in milliseconds
+ */
+export function calculateBackoff(
+  config: Required<OccRetryConfig>,
+  attempt: number
+): number {
+  // Exponential backoff: baseDelayMs * 2^(attempt-1)
+  const exponentialDelay = config.baseDelayMs * Math.pow(2, attempt - 1);
+
+  // Calculate jitter: random value between 0 and (delay * jitterFactor)
+  const jitterRange = exponentialDelay * config.jitterFactor;
+  const jitter = Math.random() * jitterRange;
+
+  // Apply jitter and cap at maxDelayMs
+  const delayWithJitter = exponentialDelay + jitter;
+  return Math.min(Math.round(delayWithJitter), config.maxDelayMs);
+}
+
+/**
+ * Sleep for specified milliseconds
+ *
+ * @param ms - Milliseconds to sleep
+ */
+export function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+/**
+ * Execute operation with automatic OCC retry
+ *
+ * @param operation - Operation to execute
+ * @param config - Retry configuration
+ * @param emitEvent - Event emitter callback
+ * @param queryText - Optional query text for logging
+ * @returns Operation result
+ * @throws OccRetryExhaustedError if retries exhausted
+ * @throws Error if non-OCC error occurs
+ */
+export async function executeWithRetry<T>(
+  operation: () => Promise<T>,
+  config: Required<OccRetryConfig>,
+  emitEvent: (event: OccRetryEvent | OccRetryExhaustedEvent) => void,
+  queryText?: string
+): Promise<T> {
+  let attempt = 1;
+
+  while (true) {
+    try {
+      return await operation();
+    } catch (error) {
+      // Detect OCC error
+      const occInfo = isOccError(error as Error);
+
+      // Only retry OCC errors (40001, OC000, OC001)
+      if (!occInfo) {
+        throw error;
+      }
+
+      // Check if max attempts reached
+      if (attempt >= config.maxAttempts) {
+        console.error(
+          `OCC transaction retry exhausted, type=${occInfo.type}, code=${occInfo.code}, attempts=${config.maxAttempts}`
+        );
+
+        emitEvent({
+          type: 'occRetryExhausted',
+          attempts: config.maxAttempts,
+          error: error as Error,
+          occType: occInfo.type,
+          occCode: occInfo.code,
+          queryText
+        });
+
+        throw new OccRetryExhaustedError(config.maxAttempts, error as Error, occInfo);
+      }
+
+      // Calculate exponential backoff with jitter
+      const delayMs = calculateBackoff(config, attempt);
+
+      console.debug(
+        `OCC conflict detected, type=${occInfo.type}, code=${occInfo.code}, ` +
+        `retrying after backoff, attempt=${attempt + 1}/${config.maxAttempts}, delay_ms=${delayMs}`
+      );
+
+      emitEvent({
+        type: 'occRetry',
+        attempt: attempt + 1,
+        maxAttempts: config.maxAttempts,
+        delayMs,
+        error: error as Error,
+        occType: occInfo.type,
+        occCode: occInfo.code,
+        queryText
+      });
+
+      await sleep(delayMs);
+      attempt++;
+    }
+  }
+}

--- a/node/node-postgres/test/aurora-dsql-client.test.ts
+++ b/node/node-postgres/test/aurora-dsql-client.test.ts
@@ -289,4 +289,109 @@ describe("AuroraDSQLClient", () => {
       );
     });
   });
+
+  describe("OCC retry integration", () => {
+    let client: AuroraDSQLClient;
+    let mockQuery: jest.Mock;
+
+    beforeEach(() => {
+      mockQuery = jest.fn();
+      mockClient.prototype.query = mockQuery;
+
+      mockAuroraDSQLUtil.parsePgConfig.mockReturnValueOnce({
+        host: "example.dsql.us-east-1.on.aws",
+        user: "admin",
+        port: 5432,
+        database: "postgres",
+        region: "us-east-1",
+        profile: "default",
+        ssl: { rejectUnauthorized: true },
+        occ: { enabled: true, maxAttempts: 3, baseDelayMs: 1, maxDelayMs: 10, jitterFactor: 0 }
+      });
+
+      client = new AuroraDSQLClient({
+        host: "example.dsql.us-east-1.on.aws",
+        user: "admin",
+        occ: { enabled: true, maxAttempts: 3, baseDelayMs: 1, maxDelayMs: 10, jitterFactor: 0 }
+      });
+    });
+
+    it("should retry query on OCC conflict and succeed", async () => {
+      const occError = new Error("conflict") as any;
+      occError.code = "OC000";
+
+      mockQuery
+        .mockRejectedValueOnce(occError)
+        .mockResolvedValueOnce({ rows: [{ id: 1 }] });
+
+      const result = await client.query("SELECT * FROM accounts");
+
+      expect(mockQuery).toHaveBeenCalledTimes(2);
+      expect(result.rows).toEqual([{ id: 1 }]);
+    });
+
+    it("should skip retry when skipRetry is true", async () => {
+      const occError = new Error("conflict") as any;
+      occError.code = "OC000";
+
+      mockQuery.mockRejectedValueOnce(occError);
+
+      await expect(client.query({ text: "SELECT 1", skipRetry: true })).rejects.toThrow("conflict");
+      expect(mockQuery).toHaveBeenCalledTimes(1);
+    });
+
+    it("should not retry on non-OCC errors", async () => {
+      const syntaxError = new Error("syntax error") as any;
+      syntaxError.code = "42601";
+
+      mockQuery.mockRejectedValueOnce(syntaxError);
+
+      await expect(client.query("INVALID SQL")).rejects.toThrow("syntax error");
+      expect(mockQuery).toHaveBeenCalledTimes(1);
+    });
+
+    it("should retry transaction on OCC conflict", async () => {
+      const occError = new Error("conflict") as any;
+      occError.code = "OC000";
+
+      let attempts = 0;
+      mockQuery.mockImplementation(async (sql: string) => {
+        if (sql === 'BEGIN') return { rows: [] };
+        if (sql === 'COMMIT') {
+          attempts++;
+          if (attempts === 1) throw occError;
+          return { rows: [] };
+        }
+        if (sql === 'ROLLBACK') return { rows: [] };
+        return { rows: [{ id: 1 }] };
+      });
+
+      const result = await client.transactionWithRetry(async (c) => {
+        await c.query("INSERT INTO accounts VALUES(1)");
+        return "success";
+      });
+
+      expect(result).toBe("success");
+      expect(attempts).toBe(2);
+    });
+
+    it("should validate occ config on initialization", () => {
+      mockAuroraDSQLUtil.parsePgConfig.mockReturnValueOnce({
+        host: "example.dsql.us-east-1.on.aws",
+        user: "admin",
+        port: 5432,
+        database: "postgres",
+        region: "us-east-1",
+        profile: "default",
+        ssl: { rejectUnauthorized: true },
+        occ: { enabled: true, maxAttempts: 0 }
+      });
+
+      expect(() => new AuroraDSQLClient({
+        host: "example.dsql.us-east-1.on.aws",
+        user: "admin",
+        occ: { enabled: true, maxAttempts: 0 }
+      })).toThrow('occ.maxAttempts must be between 1 and 100');
+    });
+  });
 });

--- a/node/node-postgres/test/aurora-dsql-pool.test.ts
+++ b/node/node-postgres/test/aurora-dsql-pool.test.ts
@@ -395,4 +395,127 @@ describe("AuroraDSQLPool", () => {
       );
     });
   });
+
+  describe("OCC retry integration", () => {
+    let pool: AuroraDSQLPool;
+    let mockQuery: jest.Mock;
+
+    beforeEach(() => {
+      mockQuery = jest.fn();
+      mockPool.prototype.query = mockQuery;
+
+      mockAuroraDSQLUtil.parsePgConfig.mockReturnValueOnce({
+        host: "example.dsql.us-east-1.on.aws",
+        user: "admin",
+        port: 5432,
+        database: "postgres",
+        region: "us-east-1",
+        profile: "default",
+        ssl: { rejectUnauthorized: true },
+        occ: { enabled: true, maxAttempts: 3, baseDelayMs: 1, maxDelayMs: 10, jitterFactor: 0 }
+      });
+
+      pool = new AuroraDSQLPool({
+        host: "example.dsql.us-east-1.on.aws",
+        user: "admin",
+        occ: { enabled: true, maxAttempts: 3, baseDelayMs: 1, maxDelayMs: 10, jitterFactor: 0 }
+      });
+    });
+
+    it("should retry query on OCC conflict and succeed", async () => {
+      const occError = new Error("conflict") as any;
+      occError.code = "OC000";
+
+      mockQuery
+        .mockRejectedValueOnce(occError)
+        .mockResolvedValueOnce({ rows: [{ id: 1 }] });
+
+      const result = await pool.query("INSERT INTO accounts VALUES($1)", [1]);
+
+      expect(mockQuery).toHaveBeenCalledTimes(2);
+      expect(result.rows).toEqual([{ id: 1 }]);
+    });
+
+    it("should skip retry when skipRetry is true", async () => {
+      const occError = new Error("conflict") as any;
+      occError.code = "OC000";
+
+      mockQuery.mockRejectedValueOnce(occError);
+
+      await expect(pool.query({ text: "SELECT 1", skipRetry: true })).rejects.toThrow("conflict");
+      expect(mockQuery).toHaveBeenCalledTimes(1);
+    });
+
+    it("should not retry on non-OCC errors", async () => {
+      const uniqueViolation = new Error("unique violation") as any;
+      uniqueViolation.code = "23505";
+
+      mockQuery.mockRejectedValueOnce(uniqueViolation);
+
+      await expect(pool.query("INSERT INTO accounts VALUES(1)")).rejects.toThrow("unique violation");
+      expect(mockQuery).toHaveBeenCalledTimes(1);
+    });
+
+    it("should retry transaction on OCC conflict", async () => {
+      const occError = new Error("conflict") as any;
+      occError.code = "OC000";
+
+      const mockConnect = jest.fn();
+      const mockClient = {
+        query: jest.fn(),
+        release: jest.fn()
+      };
+
+      mockPool.prototype.connect = mockConnect;
+      mockConnect.mockResolvedValue(mockClient);
+
+      // Mock pool options
+      (pool as any).options = {
+        host: "example.dsql.us-east-1.on.aws",
+        user: "admin"
+      };
+
+      mockAuroraDSQLUtil.getDSQLToken.mockResolvedValue("mock-token");
+
+      let attempts = 0;
+      mockClient.query.mockImplementation(async (sql: string) => {
+        if (sql === 'BEGIN') return { rows: [] };
+        if (sql === 'COMMIT') {
+          attempts++;
+          if (attempts === 1) throw occError;
+          return { rows: [] };
+        }
+        if (sql === 'ROLLBACK') return { rows: [] };
+        return { rows: [{ id: 1 }] };
+      });
+
+      const result = await pool.transactionWithRetry(async (c) => {
+        await c.query("INSERT INTO accounts VALUES(1)");
+        return "success";
+      });
+
+      expect(result).toBe("success");
+      expect(attempts).toBe(2);
+      expect(mockClient.release).toHaveBeenCalled();
+    });
+
+    it("should validate occ config on initialization", () => {
+      mockAuroraDSQLUtil.parsePgConfig.mockReturnValueOnce({
+        host: "example.dsql.us-east-1.on.aws",
+        user: "admin",
+        port: 5432,
+        database: "postgres",
+        region: "us-east-1",
+        profile: "default",
+        ssl: { rejectUnauthorized: true },
+        occ: { enabled: true, jitterFactor: 2 }
+      });
+
+      expect(() => new AuroraDSQLPool({
+        host: "example.dsql.us-east-1.on.aws",
+        user: "admin",
+        occ: { enabled: true, jitterFactor: 2 }
+      })).toThrow('occ.jitterFactor must be between 0 and 1');
+    });
+  });
 });

--- a/node/node-postgres/test/occ-retry.test.ts
+++ b/node/node-postgres/test/occ-retry.test.ts
@@ -1,0 +1,293 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {
+  OCCType,
+  isOccError,
+  calculateBackoff,
+  executeWithRetry,
+  OccRetryExhaustedError,
+  DEFAULT_OCC_CONFIG,
+  OccRetryConfig,
+  OccRetryEvent,
+  OccRetryExhaustedEvent
+} from '../src/occ-retry';
+
+// Mock database error helper
+function createDbError(code: string, message: string): Error {
+  const error = new Error(message) as any;
+  error.code = code;
+  return error;
+}
+
+describe('OCC Retry - Core Feature Tests', () => {
+  describe('isOccError - OCC Error Detection', () => {
+    it('should detect OC000 data conflict', () => {
+      const error = createDbError('OC000', 'concurrent data modification');
+      const result = isOccError(error);
+
+      expect(result).toEqual({ type: OCCType.Data, code: 'OC000' });
+    });
+
+    it('should detect OC001 schema conflict', () => {
+      const error = createDbError('OC001', 'DDL during transaction');
+      const result = isOccError(error);
+
+      expect(result).toEqual({ type: OCCType.Schema, code: 'OC001' });
+    });
+
+    it('should detect 40001 with embedded (OC000) in message', () => {
+      const error = createDbError('40001', 'serialization failure (OC000)');
+      const result = isOccError(error);
+
+      expect(result).toEqual({ type: OCCType.Data, code: 'OC000' });
+    });
+
+    it('should detect 40001 with embedded (OC001) in message', () => {
+      const error = createDbError('40001', 'serialization failure (OC001)');
+      const result = isOccError(error);
+
+      expect(result).toEqual({ type: OCCType.Schema, code: 'OC001' });
+    });
+
+    it('should detect 40001 without embedded code as Unknown', () => {
+      const error = createDbError('40001', 'serialization failure');
+      const result = isOccError(error);
+
+      expect(result).toEqual({ type: OCCType.Unknown, code: '40001' });
+    });
+
+    it('should return null for non-OCC errors', () => {
+      const error = createDbError('23505', 'unique violation');
+      expect(isOccError(error)).toBeNull();
+    });
+
+    it('should return null for errors without code', () => {
+      const error = new Error('generic error');
+      expect(isOccError(error)).toBeNull();
+    });
+  });
+
+  describe('calculateBackoff - Exponential Backoff', () => {
+    const config: Required<OccRetryConfig> = {
+      enabled: true,
+      maxAttempts: 3,
+      baseDelayMs: 10,
+      maxDelayMs: 100,
+      jitterFactor: 0.25
+    };
+
+    it('should calculate exponential backoff correctly', () => {
+      // Attempt 1: 10 * 2^0 = 10ms, jitter up to 2.5ms
+      const delay1 = calculateBackoff(config, 1);
+      expect(delay1).toBeGreaterThanOrEqual(10);
+      expect(delay1).toBeLessThanOrEqual(13);
+
+      // Attempt 2: 10 * 2^1 = 20ms, jitter up to 5ms
+      const delay2 = calculateBackoff(config, 2);
+      expect(delay2).toBeGreaterThanOrEqual(20);
+      expect(delay2).toBeLessThanOrEqual(26);
+
+      // Attempt 3: 10 * 2^2 = 40ms, jitter up to 10ms
+      const delay3 = calculateBackoff(config, 3);
+      expect(delay3).toBeGreaterThanOrEqual(40);
+      expect(delay3).toBeLessThanOrEqual(51);
+    });
+
+    it('should respect maxDelayMs cap', () => {
+      const delay = calculateBackoff(config, 10);
+      // 10 * 2^9 = 5120ms, but capped at 100ms + jitter (25ms) = max 125ms
+      expect(delay).toBeLessThanOrEqual(126);
+    });
+
+    it('should work with zero jitter', () => {
+      const noJitterConfig = { ...config, jitterFactor: 0 };
+
+      expect(calculateBackoff(noJitterConfig, 1)).toBe(10);
+      expect(calculateBackoff(noJitterConfig, 2)).toBe(20);
+      expect(calculateBackoff(noJitterConfig, 3)).toBe(40);
+    });
+  });
+
+  describe('executeWithRetry - Core Retry Logic', () => {
+    const config: Required<OccRetryConfig> = {
+      enabled: true,
+      maxAttempts: 3,
+      baseDelayMs: 1,
+      maxDelayMs: 10,
+      jitterFactor: 0
+    };
+
+    let events: Array<OccRetryEvent | OccRetryExhaustedEvent>;
+
+    beforeEach(() => {
+      events = [];
+    });
+
+    const captureEvent = (event: OccRetryEvent | OccRetryExhaustedEvent) => {
+      events.push(event);
+    };
+
+    it('should succeed on first attempt without retry', async () => {
+      const operation = jest.fn().mockResolvedValue('success');
+
+      const result = await executeWithRetry(operation, config, captureEvent);
+
+      expect(result).toBe('success');
+      expect(operation).toHaveBeenCalledTimes(1);
+      expect(events).toHaveLength(0);
+    });
+
+    it('should retry on OCC error and eventually succeed', async () => {
+      const operation = jest.fn()
+        .mockRejectedValueOnce(createDbError('OC000', 'conflict'))
+        .mockResolvedValueOnce('success');
+
+      const result = await executeWithRetry(operation, config, captureEvent);
+
+      expect(result).toBe('success');
+      expect(operation).toHaveBeenCalledTimes(2);
+      expect(events).toHaveLength(1);
+      expect(events[0].type).toBe('occRetry');
+    });
+
+    it('should retry multiple times on repeated OCC errors', async () => {
+      const operation = jest.fn()
+        .mockRejectedValueOnce(createDbError('OC000', 'conflict 1'))
+        .mockRejectedValueOnce(createDbError('OC000', 'conflict 2'))
+        .mockResolvedValueOnce('success');
+
+      const result = await executeWithRetry(operation, config, captureEvent);
+
+      expect(result).toBe('success');
+      expect(operation).toHaveBeenCalledTimes(3);
+      expect(events).toHaveLength(2);
+      expect(events[0].type).toBe('occRetry');
+      expect(events[1].type).toBe('occRetry');
+    });
+
+    it('should throw non-OCC errors immediately without retry', async () => {
+      const nonOccError = createDbError('23505', 'unique violation');
+      const operation = jest.fn().mockRejectedValue(nonOccError);
+
+      await expect(
+        executeWithRetry(operation, config, captureEvent)
+      ).rejects.toThrow('unique violation');
+
+      expect(operation).toHaveBeenCalledTimes(1);
+      expect(events).toHaveLength(0);
+    });
+
+    it('should throw OccRetryExhaustedError after max attempts', async () => {
+      const occError = createDbError('OC000', 'persistent conflict');
+      const operation = jest.fn().mockRejectedValue(occError);
+
+      await expect(
+        executeWithRetry(operation, config, captureEvent)
+      ).rejects.toThrow(OccRetryExhaustedError);
+
+      expect(operation).toHaveBeenCalledTimes(3);
+      expect(events).toHaveLength(3); // 2 retry events + 1 exhausted event
+
+      const exhaustedEvent = events[2] as OccRetryExhaustedEvent;
+      expect(exhaustedEvent.type).toBe('occRetryExhausted');
+      expect(exhaustedEvent.attempts).toBe(3);
+    });
+
+    it('should emit occRetry events with correct metadata', async () => {
+      const operation = jest.fn()
+        .mockRejectedValueOnce(createDbError('OC001', 'schema conflict'))
+        .mockResolvedValueOnce('success');
+
+      await executeWithRetry(operation, config, captureEvent, 'UPDATE test');
+
+      const retryEvent = events[0] as OccRetryEvent;
+      expect(retryEvent.type).toBe('occRetry');
+      expect(retryEvent.attempt).toBe(2);
+      expect(retryEvent.maxAttempts).toBe(3);
+      expect(retryEvent.occType).toBe(OCCType.Schema);
+      expect(retryEvent.occCode).toBe('OC001');
+      expect(retryEvent.queryText).toBe('UPDATE test');
+      expect(retryEvent.delayMs).toBeGreaterThanOrEqual(0);
+    });
+
+    it('should emit occRetryExhausted event with correct metadata', async () => {
+      const occError = createDbError('40001', 'serialization failure');
+      const operation = jest.fn().mockRejectedValue(occError);
+
+      await expect(
+        executeWithRetry(operation, config, captureEvent, 'SELECT * FROM test')
+      ).rejects.toThrow(OccRetryExhaustedError);
+
+      const exhaustedEvent = events[2] as OccRetryExhaustedEvent;
+      expect(exhaustedEvent.type).toBe('occRetryExhausted');
+      expect(exhaustedEvent.attempts).toBe(3);
+      expect(exhaustedEvent.occType).toBe(OCCType.Unknown);
+      expect(exhaustedEvent.occCode).toBe('40001');
+      expect(exhaustedEvent.queryText).toBe('SELECT * FROM test');
+    });
+
+    it('should handle maxAttempts of 1 (no retry)', async () => {
+      const singleConfig = { ...config, maxAttempts: 1 };
+      const occError = createDbError('OC000', 'conflict');
+      const operation = jest.fn().mockRejectedValue(occError);
+
+      await expect(
+        executeWithRetry(operation, singleConfig, captureEvent)
+      ).rejects.toThrow(OccRetryExhaustedError);
+
+      expect(operation).toHaveBeenCalledTimes(1);
+      expect(events).toHaveLength(1);
+      expect(events[0].type).toBe('occRetryExhausted');
+    });
+  });
+
+  describe('OccRetryExhaustedError', () => {
+    it('should construct with correct properties', () => {
+      const lastError = createDbError('OC000', 'conflict');
+      const occInfo = { type: OCCType.Data, code: 'OC000' };
+
+      const error = new OccRetryExhaustedError(3, lastError, occInfo);
+
+      expect(error.name).toBe('OccRetryExhaustedError');
+      expect(error.attempts).toBe(3);
+      expect(error.lastError).toBe(lastError);
+      expect(error.occInfo).toEqual(occInfo);
+      expect(error.message).toContain('3 attempts');
+      expect(error.message).toContain('Data');
+      expect(error.message).toContain('OC000');
+    });
+
+    it('should be instanceof OccRetryExhaustedError', () => {
+      const error = new OccRetryExhaustedError(
+        3,
+        new Error('test'),
+        { type: OCCType.Data, code: 'OC000' }
+      );
+
+      expect(error instanceof OccRetryExhaustedError).toBe(true);
+      expect(error instanceof Error).toBe(true);
+    });
+  });
+
+  describe('DEFAULT_OCC_CONFIG', () => {
+    it('should match Rust implementation defaults', () => {
+      expect(DEFAULT_OCC_CONFIG).toEqual({
+        enabled: false,
+        maxAttempts: 3,
+        baseDelayMs: 1,
+        maxDelayMs: 100,
+        jitterFactor: 0.25
+      });
+    });
+  });
+
+  describe('OCCType enum', () => {
+    it('should have correct values', () => {
+      expect(OCCType.Data).toBe('Data');
+      expect(OCCType.Schema).toBe('Schema');
+      expect(OCCType.Unknown).toBe('Unknown');
+    });
+  });
+});

--- a/node/node-postgres/test/occ-retry.test.ts
+++ b/node/node-postgres/test/occ-retry.test.ts
@@ -11,7 +11,8 @@ import {
   DEFAULT_OCC_CONFIG,
   OccRetryConfig,
   OccRetryEvent,
-  OccRetryExhaustedEvent
+  OccRetryExhaustedEvent,
+  validateOccConfig
 } from '../src/occ-retry';
 
 // Mock database error helper
@@ -95,10 +96,11 @@ describe('OCC Retry - Core Feature Tests', () => {
       expect(delay3).toBeLessThanOrEqual(51);
     });
 
-    it('should respect maxDelayMs cap', () => {
+    it('should respect maxDelayMs cap with jitter', () => {
       const delay = calculateBackoff(config, 10);
-      // 10 * 2^9 = 5120ms, but capped at 100ms + jitter (25ms) = max 125ms
-      expect(delay).toBeLessThanOrEqual(126);
+      // 10 * 2^9 = 5120ms, capped at 100ms, then jitter added (up to 25ms)
+      expect(delay).toBeGreaterThanOrEqual(100);
+      expect(delay).toBeLessThanOrEqual(125);
     });
 
     it('should work with zero jitter', () => {
@@ -288,6 +290,88 @@ describe('OCC Retry - Core Feature Tests', () => {
       expect(OCCType.Data).toBe('Data');
       expect(OCCType.Schema).toBe('Schema');
       expect(OCCType.Unknown).toBe('Unknown');
+    });
+  });
+
+  describe('validateOccConfig', () => {
+    it('should accept valid config', () => {
+      expect(() => validateOccConfig({
+        enabled: true,
+        maxAttempts: 3,
+        baseDelayMs: 1,
+        maxDelayMs: 100,
+        jitterFactor: 0.25
+      })).not.toThrow();
+    });
+
+    it('should reject maxAttempts less than 1', () => {
+      expect(() => validateOccConfig({
+        enabled: true,
+        maxAttempts: 0,
+        baseDelayMs: 1,
+        maxDelayMs: 100,
+        jitterFactor: 0.25
+      })).toThrow('occ.maxAttempts must be between 1 and 100');
+    });
+
+    it('should reject maxAttempts greater than 100', () => {
+      expect(() => validateOccConfig({
+        enabled: true,
+        maxAttempts: 101,
+        baseDelayMs: 1,
+        maxDelayMs: 100,
+        jitterFactor: 0.25
+      })).toThrow('occ.maxAttempts must be between 1 and 100');
+    });
+
+    it('should reject baseDelayMs less than 1', () => {
+      expect(() => validateOccConfig({
+        enabled: true,
+        maxAttempts: 3,
+        baseDelayMs: 0,
+        maxDelayMs: 100,
+        jitterFactor: 0.25
+      })).toThrow('occ.baseDelayMs must be at least 1');
+    });
+
+    it('should reject maxDelayMs greater than 100', () => {
+      expect(() => validateOccConfig({
+        enabled: true,
+        maxAttempts: 3,
+        baseDelayMs: 1,
+        maxDelayMs: 101,
+        jitterFactor: 0.25
+      })).toThrow('occ.maxDelayMs must not exceed 100');
+    });
+
+    it('should reject maxDelayMs less than baseDelayMs', () => {
+      expect(() => validateOccConfig({
+        enabled: true,
+        maxAttempts: 3,
+        baseDelayMs: 50,
+        maxDelayMs: 10,
+        jitterFactor: 0.25
+      })).toThrow('occ.maxDelayMs must be >= occ.baseDelayMs');
+    });
+
+    it('should reject jitterFactor less than 0', () => {
+      expect(() => validateOccConfig({
+        enabled: true,
+        maxAttempts: 3,
+        baseDelayMs: 1,
+        maxDelayMs: 100,
+        jitterFactor: -0.1
+      })).toThrow('occ.jitterFactor must be between 0 and 1');
+    });
+
+    it('should reject jitterFactor greater than 1', () => {
+      expect(() => validateOccConfig({
+        enabled: true,
+        maxAttempts: 3,
+        baseDelayMs: 1,
+        maxDelayMs: 100,
+        jitterFactor: 1.5
+      })).toThrow('occ.jitterFactor must be between 0 and 1');
     });
   });
 });


### PR DESCRIPTION
Add automatic retry for Aurora DSQL OCC errors with query-level (occ: { enabled: true }) and transaction-level (transactionWithRetry()) support. Includes configurable backoff, event emission, opt-out mechanism, and 110 passing tests. Fixes: export QueryConfigWithRetry type and prevent double-retry in Client transactions. No breaking changes.

*Issue #, if available:*
N/A
*Description of changes:*
Add automatic OCC retry support for Aurora DSQL errors (OC000, OC001, 40001)
Query-level retry via occ: { enabled: true } config
Transaction-level retry via transactionWithRetry() method
Configurable retry policy (maxAttempts, backoff, jitter)
Event emission for observability (occRetry, occRetryExhausted)
skipRetry option to opt-out on specific queries
Export QueryConfigWithRetry type for TypeScript users
Matches Rust connector design (same defaults, algorithm, error detection)
No breaking changes (opt-in feature, disabled by default)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
