### PR TITLE
feat(java): add per-connection credentials provider support

### DIFF
--- a/java/jdbc/README.md
+++ b/java/jdbc/README.md
@@ -105,6 +105,40 @@ The connector supports the following connection properties:
 
 **Note:** The database name is specified in the URL path (e.g., `/postgres`). If not specified in the URL, it defaults to `postgres`.
 
+### Credentials Resolution
+
+The driver resolves AWS credentials in the following order:
+
+1. **Per-connection provider** — an `AwsCredentialsProvider` passed in the `Properties` object via `PropertyDefinition.CREDENTIALS_PROVIDER_KEY`
+2. **Profile** — a `ProfileCredentialsProvider` created from the `profile` property
+3. **Global provider** — the provider configured via `AuroraDsqlCredentialsManager.setProvider()` (defaults to the AWS SDK default credential chain)
+
+### Custom Credentials Provider (Per-Connection)
+
+For environments where different connections need different credentials (e.g., multi-tenant Lambda, assumed roles), pass an `AwsCredentialsProvider` directly in the `Properties` object:
+
+```java
+import software.amazon.dsql.jdbc.PropertyDefinition;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
+
+// Create credentials for a specific role
+AwsCredentialsProvider roleCredentials = StsAssumeRoleCredentialsProvider.builder()
+    .refreshRequest(r -> r.roleArn("arn:aws:iam::123456789012:role/MyRole")
+                          .roleSessionName("dsql-session"))
+    .stsClient(stsClient)
+    .build();
+
+Properties props = new Properties();
+props.setProperty("user", "admin");
+props.put(PropertyDefinition.CREDENTIALS_PROVIDER_KEY, roleCredentials);
+
+Connection conn = DriverManager.getConnection(
+    "jdbc:aws-dsql:postgresql://cluster.dsql.us-east-1.on.aws/postgres", props);
+```
+
+This per-connection approach takes precedence over both the `profile` property and the global `AuroraDsqlCredentialsManager`.
+
 ## Logging
 Enabling logging is a very useful mechanism for troubleshooting any issue one might potentially experience while using the Aurora DSQL Connector for JDBC.
 

--- a/java/jdbc/integration-tests/build.gradle.kts
+++ b/java/jdbc/integration-tests/build.gradle.kts
@@ -16,6 +16,7 @@ tasks.withType<JavaCompile> {
 
 dependencies {
     testImplementation(project(":"))
+    testImplementation("software.amazon.awssdk:auth:2.43.0")
 
     testImplementation("org.junit.jupiter:junit-jupiter:5.14.3")
     testRuntimeOnly("org.junit.platform:junit-platform-console-standalone:1.14.3")

--- a/java/jdbc/integration-tests/src/test/java/software/amazon/dsql/jdbc/integration/BasicConnectionIntegrationTest.java
+++ b/java/jdbc/integration-tests/src/test/java/software/amazon/dsql/jdbc/integration/BasicConnectionIntegrationTest.java
@@ -34,6 +34,8 @@ import java.util.Properties;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import software.amazon.dsql.jdbc.AuroraDsqlCredentialsManager;
+import software.amazon.dsql.jdbc.PropertyDefinition;
 
 /**
  * Integration tests for basic Aurora DSQL Connector for JDBC connections. These tests require a
@@ -328,6 +330,23 @@ public class BasicConnectionIntegrationTest {
                         "Application name should start with 'aurora-dsql-jdbc/', got: " + appName);
                 System.out.println("Application name: " + appName);
             }
+        }
+    }
+
+    @Test
+    void testConnectionWithPerConnectionCredentialsProvider() throws SQLException {
+        String user = CLUSTER_USER != null ? CLUSTER_USER : "admin";
+
+        Properties props = new Properties();
+        props.setProperty("user", user);
+        props.put(
+                PropertyDefinition.CREDENTIALS_PROVIDER_KEY,
+                AuroraDsqlCredentialsManager.getProvider());
+
+        String url = "jdbc:aws-dsql:postgresql://" + CLUSTER_ENDPOINT + "/postgres";
+
+        try (Connection conn = DriverManager.getConnection(url, props)) {
+            assertConnectionValid(conn);
         }
     }
 

--- a/java/jdbc/src/main/java/software/amazon/dsql/jdbc/DSQLConnector.java
+++ b/java/jdbc/src/main/java/software/amazon/dsql/jdbc/DSQLConnector.java
@@ -65,10 +65,11 @@ import software.amazon.awssdk.services.dsql.model.GenerateAuthTokenRequest;
  * can be sourced from:
  *
  * <ul>
- *   <li>The default AWS profile
+ *   <li>A per-connection {@link AwsCredentialsProvider} passed via the {@link java.util.Properties}
+ *       object using {@link PropertyDefinition#CREDENTIALS_PROVIDER_KEY}
  *   <li>A configurable AWS profile specified via the {@code profile} connection property
- *   <li>A custom credentials provider configured through {@link AuroraDsqlCredentialsManager} for
- *       advanced use cases
+ *   <li>The global provider from {@link AuroraDsqlCredentialsManager} (defaults to the AWS SDK
+ *       default credential chain)
  * </ul>
  *
  * <p>See {@link #connect(String, Properties)} for more details on configuring the driver and the
@@ -185,12 +186,15 @@ public class DSQLConnector implements java.sql.Driver {
      * <p>The driver resolves AWS credentials in the following order:
      *
      * <ol>
+     *   <li>If an {@link AwsCredentialsProvider} is passed in the {@link Properties} object via
+     *       {@link PropertyDefinition#CREDENTIALS_PROVIDER_KEY}, it is used directly
+     *       (per-connection)
      *   <li>If the {@code profile} connection property is specified, credentials are loaded from
      *       that named profile in the AWS credentials file
-     *   <li>If no {@code profile} is specified, the driver uses the credentials provider configured
-     *       via {@link AuroraDsqlCredentialsManager#setProvider(AwsCredentialsProvider)}
-     *   <li>By default, {@link AuroraDsqlCredentialsManager} uses the AWS SDK's default credentials
-     *       provider.
+     *   <li>Otherwise, the driver uses the provider from {@link
+     *       AuroraDsqlCredentialsManager#getProvider()}, which defaults to the AWS SDK default
+     *       credential chain unless overridden via {@link
+     *       AuroraDsqlCredentialsManager#setProvider(AwsCredentialsProvider)}
      * </ol>
      *
      * <h3>Error Scenarios</h3>
@@ -242,10 +246,13 @@ public class DSQLConnector implements java.sql.Driver {
             final Duration tokenDurationInSecond =
                     tokenDuration == 0 ? null : Duration.ofSeconds(tokenDuration);
 
+            // Resolve credentials provider and clean up non-String entry before props reach pgJDBC
+            final AwsCredentialsProvider credentialsProvider = getCredentialsProvider(props);
+            props.remove(PropertyDefinition.CREDENTIALS_PROVIDER_KEY);
+
             // Generate IAM authentication token
             final String authToken;
             try {
-                final AwsCredentialsProvider credentialsProvider = getCredentialsProvider(props);
                 final DsqlUtilities utilities =
                         DsqlUtilities.builder()
                                 .region(regionObj)
@@ -308,7 +315,19 @@ public class DSQLConnector implements java.sql.Driver {
         return ConnUrlParser.extractRegionFromHost(host);
     }
 
-    private AwsCredentialsProvider getCredentialsProvider(final Properties props) {
+    private AwsCredentialsProvider getCredentialsProvider(final Properties props)
+            throws SQLException {
+        final Object perConnection = props.get(PropertyDefinition.CREDENTIALS_PROVIDER_KEY);
+        if (perConnection != null) {
+            if (perConnection instanceof AwsCredentialsProvider) {
+                return (AwsCredentialsProvider) perConnection;
+            }
+            throw new SQLException(
+                    "Property '"
+                            + PropertyDefinition.CREDENTIALS_PROVIDER_KEY
+                            + "' must be an instance of AwsCredentialsProvider, but was: "
+                            + perConnection.getClass().getName());
+        }
         final String profile = PropertyDefinition.PROFILE.get(props);
         if (profile != null) {
             return ProfileCredentialsProvider.create(profile);

--- a/java/jdbc/src/main/java/software/amazon/dsql/jdbc/PropertyDefinition.java
+++ b/java/jdbc/src/main/java/software/amazon/dsql/jdbc/PropertyDefinition.java
@@ -150,6 +150,29 @@ public final class PropertyDefinition {
                             + "their name (e.g., 'hibernate'). Max 39 characters.");
 
     /**
+     * Property key for passing a per-connection {@link
+     * software.amazon.awssdk.auth.credentials.AwsCredentialsProvider} via the {@link Properties}
+     * object.
+     *
+     * <p>This property cannot be set via URL query parameters since it requires an object value.
+     * Use {@link Properties#put(Object, Object)} to set it:
+     *
+     * <pre>{@code
+     * Properties props = new Properties();
+     * props.setProperty("user", "admin");
+     * props.put(PropertyDefinition.CREDENTIALS_PROVIDER_KEY, myCredentialsProvider);
+     * Connection conn = DriverManager.getConnection(url, props);
+     * }</pre>
+     *
+     * <p>When set, this takes precedence over both the {@code profile} property and the global
+     * provider configured via {@link AuroraDsqlCredentialsManager}.
+     *
+     * @see DSQLConnector#connect(String, Properties)
+     * @see AuroraDsqlCredentialsManager
+     */
+    public static final String CREDENTIALS_PROVIDER_KEY = "credentialsProvider";
+
+    /**
      * Specifies the SSL mode for the connection.
      *
      * <p>This property controls how SSL/TLS encryption is negotiated with the server. Aurora DSQL

--- a/java/jdbc/src/main/java/software/amazon/dsql/jdbc/PropertyUtils.java
+++ b/java/jdbc/src/main/java/software/amazon/dsql/jdbc/PropertyUtils.java
@@ -57,8 +57,12 @@ final class PropertyUtils {
                         "The key and value of the entry cannot be null.");
             }
             String key = entry.getKey().toString();
-            String value = sanitizePropertyValue(entry.getValue().toString());
-            dest.setProperty(key, value);
+            if (entry.getValue() instanceof String) {
+                String value = sanitizePropertyValue((String) entry.getValue());
+                dest.setProperty(key, value);
+            } else {
+                dest.put(key, entry.getValue());
+            }
         }
         return dest;
     }

--- a/java/jdbc/src/test/java/software/amazon/dsql/jdbc/DSQLConnectorTest.java
+++ b/java/jdbc/src/test/java/software/amazon/dsql/jdbc/DSQLConnectorTest.java
@@ -442,6 +442,100 @@ class DSQLConnectorTest {
     }
 
     @Test
+    void testConnect_WithPerConnectionCredentialsProvider()
+            throws SQLException, URISyntaxException {
+        // Arrange
+        String url = "jdbc:aws-dsql:postgresql://test-cluster.dsql.us-east-1.on.aws/testdb";
+        Properties info = new Properties();
+        info.setProperty("user", "testuser");
+
+        AwsCredentialsProvider perConnectionProvider = mock(AwsCredentialsProvider.class);
+        info.put(PropertyDefinition.CREDENTIALS_PROVIDER_KEY, perConnectionProvider);
+
+        Properties copiedProps = new Properties();
+        copiedProps.setProperty("user", "testuser");
+        copiedProps.put(PropertyDefinition.CREDENTIALS_PROVIDER_KEY, perConnectionProvider);
+
+        propertyUtilsMock.when(() -> PropertyUtils.copyProperties(info)).thenReturn(copiedProps);
+
+        // Mock ConnWrapper to prevent actual network connection
+        Connection mockConnection = mock(Connection.class);
+        try (MockedConstruction<ConnWrapper> connWrapperMock =
+                mockConstruction(
+                        ConnWrapper.class,
+                        (mock, context) -> {
+                            when(mock.makeConnection()).thenReturn(mockConnection);
+                        })) {
+            // Act
+            Connection result = driver.connect(url, info);
+
+            // Assert - connection succeeds without touching the global credentials manager
+            assertNotNull(result);
+            assertEquals(mockConnection, result);
+            credentialsManagerMock.verifyNoInteractions();
+        }
+    }
+
+    @Test
+    void testConnect_PerConnectionProviderTakesPrecedenceOverProfile()
+            throws SQLException, URISyntaxException {
+        // Arrange
+        String url = "jdbc:aws-dsql:postgresql://test-cluster.dsql.us-east-1.on.aws/testdb";
+        Properties info = new Properties();
+        info.setProperty("user", "testuser");
+        info.setProperty("profile", "test-profile");
+
+        AwsCredentialsProvider perConnectionProvider = mock(AwsCredentialsProvider.class);
+        info.put(PropertyDefinition.CREDENTIALS_PROVIDER_KEY, perConnectionProvider);
+
+        Properties copiedProps = new Properties();
+        copiedProps.setProperty("user", "testuser");
+        copiedProps.setProperty("profile", "test-profile");
+        copiedProps.put(PropertyDefinition.CREDENTIALS_PROVIDER_KEY, perConnectionProvider);
+
+        propertyUtilsMock.when(() -> PropertyUtils.copyProperties(info)).thenReturn(copiedProps);
+
+        // Mock ConnWrapper to prevent actual network connection
+        Connection mockConnection = mock(Connection.class);
+        try (MockedConstruction<ConnWrapper> connWrapperMock =
+                mockConstruction(
+                        ConnWrapper.class,
+                        (mock, context) -> {
+                            when(mock.makeConnection()).thenReturn(mockConnection);
+                        })) {
+            // Act
+            Connection result = driver.connect(url, info);
+
+            // Assert - per-connection provider used, profile and global manager both skipped
+            assertNotNull(result);
+            assertEquals(mockConnection, result);
+            credentialsManagerMock.verifyNoInteractions();
+            profileCredentialsProviderMock.verifyNoInteractions();
+        }
+    }
+
+    @Test
+    void testConnect_WrongTypeCredentialsProviderThrowsException()
+            throws SQLException, URISyntaxException {
+        // Arrange
+        String url = "jdbc:aws-dsql:postgresql://test-cluster.dsql.us-east-1.on.aws/testdb";
+        Properties info = new Properties();
+        info.setProperty("user", "testuser");
+        info.put(PropertyDefinition.CREDENTIALS_PROVIDER_KEY, "com.example.MyProvider");
+
+        Properties copiedProps = new Properties();
+        copiedProps.setProperty("user", "testuser");
+        copiedProps.put(PropertyDefinition.CREDENTIALS_PROVIDER_KEY, "com.example.MyProvider");
+
+        propertyUtilsMock.when(() -> PropertyUtils.copyProperties(info)).thenReturn(copiedProps);
+
+        // Act & Assert
+        SQLException exception = assertThrows(SQLException.class, () -> driver.connect(url, info));
+        assertTrue(exception.getMessage().contains("AwsCredentialsProvider"));
+        assertTrue(exception.getMessage().contains("java.lang.String"));
+    }
+
+    @Test
     void testConnect_WithRegionFromProperties() throws SQLException, URISyntaxException {
         // Arrange
         String url = "jdbc:aws-dsql:postgresql://test-cluster.dsql.us-east-1.on.aws/testdb";

--- a/java/jdbc/src/test/java/software/amazon/dsql/jdbc/PropertyUtilsTest.java
+++ b/java/jdbc/src/test/java/software/amazon/dsql/jdbc/PropertyUtilsTest.java
@@ -295,6 +295,20 @@ class PropertyUtilsTest {
     }
 
     @Test
+    void testCopyPropertiesPreservesNonStringValues() {
+        Properties source = new Properties();
+        Object objectValue = new Object();
+        source.put("objectKey", objectValue);
+        source.setProperty("stringKey", "stringValue");
+
+        Properties result = PropertyUtils.copyProperties(source);
+
+        assertSame(objectValue, result.get("objectKey"));
+        assertNull(result.getProperty("objectKey"));
+        assertEquals("stringValue", result.getProperty("stringKey"));
+    }
+
+    @Test
     void testNullHandling() {
         // Test null source properties
         assertNotNull(PropertyUtils.copyProperties(null));


### PR DESCRIPTION
## Summary

- Add per-connection `AwsCredentialsProvider` support via `PropertyDefinition.CREDENTIALS_PROVIDER_KEY` in the `Properties` object, aligning the Java JDBC connector with every other language connector
- Credential resolution priority: per-connection provider → `profile` → global `AuroraDsqlCredentialsManager` → default chain
- Throw `SQLException` on wrong-type value instead of silently falling through to default credentials
- Remove non-String provider object from properties before forwarding to pgJDBC driver

## Test plan

- [x] Unit tests: per-connection provider works, takes precedence over profile, wrong-type throws
- [x] Unit test: `PropertyUtils.copyProperties` preserves non-String values
- [x] Integration test: connects to real DSQL cluster with per-connection provider
- [x] `./gradlew check` passes (tests, spotless, spotbugs)
- [ ] CI integration tests pass against live cluster