### PR TITLE
feat(node-postgres): add automatic OCC retry for transactions

### DIFF
--- a/node/node-postgres/README.md
+++ b/node/node-postgres/README.md
@@ -35,6 +35,7 @@ The Aurora DSQL Connector for node-postgres is designed to understand these requ
 - **Full TypeScript Support** - Provides full type safety
 - **AWS Credentials Support** - Supports various AWS credential providers (default, profile-based, custom)
 - **Connection Pooling Compatibility** - Works seamlessly with built-in connection pooling
+- **OCC Retry** - Automatic retry with jitter for optimistic concurrency control conflicts
 
 ## Example Application
 
@@ -134,6 +135,8 @@ await client.end();
 | `customCredentialsProvider` | `AwsCredentialIdentity / AwsCredentialIdentityProvider` | No       | Custom AWS credentials provider                          |
 | `profile`                   | `string`                                                | No       | The IAM profile name. Default to "default"               |
 | `tokenDurationSecs`         | `number`                                                | No       | Token expiration time in seconds                         |
+| `logger`                    | `(msg: string) => void`                                 | No       | Optional callback for connector diagnostics              |
+| `transaction`               | `{ retry?: RetryConfig }`                               | No       | Default retry config for `transaction()` calls           |
 
 All other parameters from [Client](https://node-postgres.com/apis/client) / [Pool](https://node-postgres.com/apis/pool) are supported.
 
@@ -148,6 +151,117 @@ For more information on authentication in Aurora DSQL, see the [user guide](http
 - Users named "admin" automatically use admin authentication tokens
 - All other users use regular authentication tokens
 - Tokens are generated dynamically for each connection
+
+## OCC Retry
+
+Aurora DSQL uses optimistic concurrency control (OCC). Transactions may fail with OCC errors when concurrent modifications conflict. The connector provides a `transaction()` method on both `AuroraDSQLPool` and `AuroraDSQLClient` that automatically detects and retries these conflicts.
+
+### Using Pool (Recommended)
+
+```typescript
+import { AuroraDSQLPool } from "@aws/aurora-dsql-node-postgres-connector";
+
+const pool = new AuroraDSQLPool({
+  host: "<CLUSTER_ENDPOINT>",
+  user: "admin",
+  transaction: {
+    retry: { maxAttempts: 5, baseDelayMs: 10 },
+  },
+});
+
+// Transactions are automatically retried on OCC conflict
+const result = await pool.transaction(async (client) => {
+  await client.query("UPDATE accounts SET balance = balance - $1 WHERE id = $2", [100, fromId]);
+  await client.query("UPDATE accounts SET balance = balance + $1 WHERE id = $2", [100, toId]);
+  return client.query("SELECT balance FROM accounts WHERE id = $1", [fromId]);
+});
+```
+
+### Using Client
+
+```typescript
+import { AuroraDSQLClient } from "@aws/aurora-dsql-node-postgres-connector";
+
+const client = new AuroraDSQLClient({
+  host: "<CLUSTER_ENDPOINT>",
+  user: "admin",
+  transaction: {
+    retry: { maxAttempts: 5},
+  },
+});
+await client.connect();
+
+const result = await client.transaction(async (c) => {
+  await c.query("INSERT INTO users (id, name) VALUES (gen_random_uuid(), $1)", ["Alice"]);
+  return c.query("SELECT * FROM users WHERE name = $1", ["Alice"]);
+});
+```
+
+**Opting Out:** For operations that don't need retry, use node-postgres directly:
+
+```typescript
+// Direct usage - no OCC retry
+await client.query("BEGIN");
+await client.query("SELECT * FROM users");
+await client.query("COMMIT");
+```
+
+### OCC Configuration
+
+Retry options can be set at the constructor level (shown above) or overridden per-call:
+
+| Option         | Type      | Default | Description                              |
+|----------------|-----------|---------|------------------------------------------|
+| `maxAttempts`  | `number`  | `3`     | Total attempts (must be a positive integer) |
+| `baseDelayMs`  | `number`  | `1`     | Base delay between retries (ms)          |
+| `maxDelayMs`   | `number`  | `100`   | Maximum delay cap (ms)                   |
+| `jitter`       | `boolean` | `true`  | Randomize delay to reduce contention     |
+
+```typescript
+// Per-call override
+await pool.transaction(callback, {
+  retry: { maxAttempts: 10 },
+});
+
+// Disable retry for a single call
+await pool.transaction(callback, { retry: false });
+```
+
+**Backoff Strategy:**
+- Jittered: `delay = baseDelayMs + random(0..1) * baseDelayMs`
+- Capped at `maxDelayMs`
+- When jitter is disabled, delay is constant at `baseDelayMs`
+
+### OCC Error Types
+
+The connector classifies OCC errors by type:
+
+| SQLSTATE | Type     | Description                                              |
+|----------|----------|----------------------------------------------------------|
+| `OC000`  | Data     | Data conflict - concurrent modification of same rows     |
+| `OC001`  | Schema   | Schema conflict - DDL changes during transaction         |
+| `40001`  | Unknown  | Generic serialization failure (parsed for embedded OC000/OC001) |
+
+Non-OCC errors are not retried and propagate immediately.
+
+### Logging
+
+The `logger` option is optional. If enabled, the connector sends OCC retry logs to your function. You can also customize the output:
+
+```typescript
+const pool = new AuroraDSQLPool({
+  host: "<CLUSTER_ENDPOINT>",
+  user: "admin",
+  logger: (msg) => console.log(`[pool] ${msg}`),
+  transaction: { retry: { maxAttempts: 5 } },
+});
+```
+
+Output:
+```
+[pool] OCC conflict (Data) on attempt 1, retrying in 1.4ms
+[pool] OCC retry exhausted after 5 attempts (Data conflict)
+```
 
 ## Development
 

--- a/node/node-postgres/example/README.md
+++ b/node/node-postgres/example/README.md
@@ -59,7 +59,7 @@ The example demonstrates the following operations:
 
 - Opening a connection to an Aurora DSQL cluster
 - Creating a table
-- Inserting and querying data
+- Concurrent transactional writes with automatic OCC retry
 
 The example is designed to work with both admin and non-admin users:
 

--- a/node/node-postgres/example/src/alternatives/no_connection_pool/example_with_no_connection_pool.js
+++ b/node/node-postgres/example/src/alternatives/no_connection_pool/example_with_no_connection_pool.js
@@ -9,14 +9,14 @@ import { AuroraDSQLClient } from "@aws/aurora-dsql-node-postgres-connector";
 const ADMIN = "admin";
 const NON_ADMIN_SCHEMA = "myschema";
 
-async function getConnection(clusterEndpoint, user) {
-  const client = new AuroraDSQLClient({
+function createClient(clusterEndpoint, user) {
+  return new AuroraDSQLClient({
     host: clusterEndpoint,
     user: user,
+    transaction: {
+      retry: { maxAttempts: 10, baseDelayMs: 10, jitter: true },
+    },
   });
-
-  await client.connect();
-  return client;
 }
 
 async function example() {
@@ -25,42 +25,46 @@ async function example() {
   const user = process.env.CLUSTER_USER;
   assert(user, "CLUSTER_USER environment variable is not set");
 
-  let client;
-  try {
-    client = await getConnection(clusterEndpoint, user);
+  const client1 = createClient(clusterEndpoint, user);
+  const client2 = createClient(clusterEndpoint, user);
+  await client1.connect();
+  await client2.connect();
 
+  try {
     if (user !== ADMIN) {
-      await client.query("SET search_path=" + NON_ADMIN_SCHEMA);
+      await client1.query("SET search_path=" + NON_ADMIN_SCHEMA);
+      await client2.query("SET search_path=" + NON_ADMIN_SCHEMA);
     }
 
-    // Create a new table
-    await client.query(`CREATE TABLE IF NOT EXISTS owner (
-      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-      name VARCHAR(30) NOT NULL,
-      city VARCHAR(80) NOT NULL,
-      telephone VARCHAR(20)
-    )`);
+    await client1.query("CREATE TABLE IF NOT EXISTS occ_test_client (id INT PRIMARY KEY, value INT)");
+    await client1.query("INSERT INTO occ_test_client (id, value) VALUES (1, 0) ON CONFLICT (id) DO UPDATE SET value = 0");
 
-    // Insert some data
-    await client.query(
-      "INSERT INTO owner(name, city, telephone) VALUES($1, $2, $3)",
-      ["John Doe", "Anytown", "555-555-1900"]
-    );
+    // Run concurrent transactional writes across two clients.
+    // OCC conflicts are automatically retried by client.transaction().
+    await Promise.all([
+      client1.transaction(async (c) => {
+        const result = await c.query("SELECT value FROM occ_test_client WHERE id = 1");
+        const currentValue = result.rows[0].value;
+        await c.query("UPDATE occ_test_client SET value = $1 WHERE id = 1", [currentValue + 1]);
+      }),
+      client2.transaction(async (c) => {
+        const result = await c.query("SELECT value FROM occ_test_client WHERE id = 1");
+        const currentValue = result.rows[0].value;
+        await c.query("UPDATE occ_test_client SET value = $1 WHERE id = 1", [currentValue + 1]);
+      }),
+    ]);
 
-    // Check that data is inserted by reading it back
-    const result = await client.query(
-      "SELECT id, city FROM owner where name='John Doe'"
-    );
-    assert.deepEqual(result.rows[0].city, "Anytown");
-    assert.notEqual(result.rows[0].id, null);
-
-    await client.query("DELETE FROM owner where name='John Doe'");
-    console.log("Completed successfully");
+    const { rows } = await client1.query("SELECT value FROM occ_test_client WHERE id = 1");
+    assert.strictEqual(rows[0].value, 2);
+    console.log(`Final counter value: ${rows[0].value} (expected 2)`);
+    console.log("Client with OCC retry exercised successfully");
   } catch (error) {
     console.error(error);
     throw error;
   } finally {
-    await client?.end();
+    await client1.query("DROP TABLE IF EXISTS occ_test_client");
+    await client1.end();
+    await client2.end();
   }
 }
 

--- a/node/node-postgres/example/src/example_preferred.js
+++ b/node/node-postgres/example/src/example_preferred.js
@@ -6,7 +6,7 @@
 import assert from "node:assert";
 import { AuroraDSQLPool } from "@aws/aurora-dsql-node-postgres-connector";
 
-const NUM_CONCURRENT_QUERIES = 8;
+const NUM_CONCURRENT_WORKERS = 8;
 
 function createPool(clusterEndpoint, user) {
   return new AuroraDSQLPool({
@@ -15,13 +15,19 @@ function createPool(clusterEndpoint, user) {
     max: 10,
     idleTimeoutMillis: 30000,
     connectionTimeoutMillis: 10000,
+    transaction: {
+      retry: { maxAttempts: 10, baseDelayMs: 10, jitter: true },
+    },
   });
 }
 
 async function worker(pool, workerId) {
-  const result = await pool.query("SELECT $1::int as worker_id", [workerId]);
-  console.log(`Worker ${workerId} result: ${result.rows[0].worker_id}`);
-  assert.strictEqual(result.rows[0].worker_id, workerId);
+  await pool.transaction(async (client) => {
+    const result = await client.query("SELECT value FROM occ_test WHERE id = 1");
+    const currentValue = result.rows[0].value;
+    await client.query("UPDATE occ_test SET value = $1 WHERE id = 1", [currentValue + 1]);
+  });
+  console.log(`Worker ${workerId} completed`);
 }
 
 async function example() {
@@ -33,20 +39,26 @@ async function example() {
   const pool = createPool(clusterEndpoint, user);
 
   try {
-    // Run concurrent queries using the connection pool
+    await pool.query("CREATE TABLE IF NOT EXISTS occ_test (id INT PRIMARY KEY, value INT)");
+    await pool.query("INSERT INTO occ_test (id, value) VALUES (1, 0) ON CONFLICT (id) DO UPDATE SET value = 0");
+
+    // Run concurrent transactional writes.
+    // OCC conflicts are automatically retried by pool.transaction().
     const workers = [];
-    for (let i = 1; i <= NUM_CONCURRENT_QUERIES; i++) {
+    for (let i = 1; i <= NUM_CONCURRENT_WORKERS; i++) {
       workers.push(worker(pool, i));
     }
-
-    // Wait for all workers to complete
     await Promise.all(workers);
 
-    console.log("Connection pool with concurrent connections exercised successfully");
+    const { rows } = await pool.query("SELECT value FROM occ_test WHERE id = 1");
+    assert.strictEqual(rows[0].value, NUM_CONCURRENT_WORKERS);
+    console.log(`Final counter value: ${rows[0].value} (expected ${NUM_CONCURRENT_WORKERS})`);
+    console.log("Connection pool with OCC retry exercised successfully");
   } catch (error) {
     console.error(error);
     throw error;
   } finally {
+    await pool.query("DROP TABLE IF EXISTS occ_test");
     await pool.end();
   }
 }

--- a/node/node-postgres/example/test/alternatives/no_connection_pool/example_with_no_connection_pool.test.js
+++ b/node/node-postgres/example/test/alternatives/no_connection_pool/example_with_no_connection_pool.test.js
@@ -8,4 +8,4 @@ import { example } from "../../../src/alternatives/no_connection_pool/example_wi
 
 test("Example with no connection pool", async () => {
   await example();
-});
+}, 30000);

--- a/node/node-postgres/example/test/example_preferred.test.js
+++ b/node/node-postgres/example/test/example_preferred.test.js
@@ -8,4 +8,4 @@ import { example } from "../src/example_preferred.js";
 
 test("Preferred example (connection pool concurrent)", async () => {
   await example();
-});
+}, 30000);

--- a/node/node-postgres/src/aurora-dsql-client.ts
+++ b/node/node-postgres/src/aurora-dsql-client.ts
@@ -3,8 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { Client } from "pg";
-import { AuroraDSQLConfig } from "./config/aurora-dsql-config.js";
+import { AuroraDSQLConfig, TransactionOptions } from "./config/aurora-dsql-config.js";
 import { AuroraDSQLUtil } from "./aurora-dsql-util.js";
+import { resolveRetryConfig, executeTransaction } from "./occ-retry.js";
 
 class AuroraDSQLClient extends Client {
   private dsqlConfig?: AuroraDSQLConfig;
@@ -44,6 +45,29 @@ class AuroraDSQLClient extends Client {
       return super.connect(callback);
     }
     return super.connect();
+  }
+
+  async transaction<T>(
+    callback: (client: this) => Promise<T>,
+    options?: TransactionOptions,
+  ): Promise<T> {
+    const retryConfig = resolveRetryConfig(this.dsqlConfig?.transaction, options);
+
+    return executeTransaction(async () => {
+      await this.query("BEGIN");
+      try {
+        const result = await callback(this);
+        await this.query("COMMIT");
+        return result;
+      } catch (error) {
+        try {
+          await this.query("ROLLBACK");
+        } catch (rollbackError) {
+          this.dsqlConfig?.logger?.(`Failed to rollback transaction: ${rollbackError}`);
+        }
+        throw error;
+      }
+    }, retryConfig, this.dsqlConfig?.logger);
   }
 }
 

--- a/node/node-postgres/src/aurora-dsql-pool.ts
+++ b/node/node-postgres/src/aurora-dsql-pool.ts
@@ -4,7 +4,9 @@
  */
 import { Pool, PoolClient } from "pg";
 import { AuroraDSQLPoolConfig } from "./config/aurora-dsql-pool-config.js";
+import { TransactionOptions } from "./config/aurora-dsql-config.js";
 import { AuroraDSQLUtil } from "./aurora-dsql-util.js";
+import { resolveRetryConfig, executeTransaction } from "./occ-retry.js";
 
 class AuroraDSQLPool extends Pool {
   private dsqlConfig?: AuroraDSQLPoolConfig;
@@ -62,6 +64,39 @@ class AuroraDSQLPool extends Pool {
       return super.connect(callback);
     }
     return super.connect();
+  }
+
+  async transaction<T>(
+    callback: (client: PoolClient) => Promise<T>,
+    options?: TransactionOptions,
+  ): Promise<T> {
+    const retryConfig = resolveRetryConfig(this.dsqlConfig?.transaction, options);
+
+    return executeTransaction(async () => {
+      // Get fresh connection from pool on each retry attempt
+      const client = await this.connect();
+      try {
+        await client.query("BEGIN");
+        try {
+          const result = await callback(client);
+          await client.query("COMMIT");
+          return result;
+        } catch (error) {
+          try {
+            await client.query("ROLLBACK");
+          } catch (rollbackError) {
+            this.dsqlConfig?.logger?.(`Failed to rollback transaction: ${rollbackError}`);
+          }
+          throw error;
+        }
+      } finally {
+        try {
+          client.release();
+        } catch (releaseError) {
+          this.dsqlConfig?.logger?.(`Failed to release pool connection: ${releaseError}`);
+        }
+      }
+    }, retryConfig, this.dsqlConfig?.logger);
   }
 }
 

--- a/node/node-postgres/src/config/aurora-dsql-config.ts
+++ b/node/node-postgres/src/config/aurora-dsql-config.ts
@@ -10,6 +10,21 @@ interface AuroraDSQLConfig extends ClientConfig {
   region?: string;
   tokenDurationSecs?: number;
   customCredentialsProvider?: AwsCredentialIdentity | AwsCredentialIdentityProvider;
+  logger?: (msg: string) => void;
+  transaction?: {
+    retry?: RetryConfig;
+  };
 }
 
-export { AuroraDSQLConfig };
+interface RetryConfig {
+  maxAttempts?: number;
+  baseDelayMs?: number;
+  maxDelayMs?: number;
+  jitter?: boolean;
+}
+
+interface TransactionOptions {
+  retry?: RetryConfig | false;
+}
+
+export { AuroraDSQLConfig, RetryConfig, TransactionOptions };

--- a/node/node-postgres/src/index.ts
+++ b/node/node-postgres/src/index.ts
@@ -4,5 +4,5 @@
  */
 export { AuroraDSQLClient } from "./aurora-dsql-client.js";
 export { AuroraDSQLPool } from "./aurora-dsql-pool.js";
-export type { AuroraDSQLConfig } from './config/aurora-dsql-config.js';
+export type { AuroraDSQLConfig, RetryConfig, TransactionOptions } from './config/aurora-dsql-config.js';
 export type { AuroraDSQLPoolConfig } from './config/aurora-dsql-pool-config.js';

--- a/node/node-postgres/src/occ-retry.ts
+++ b/node/node-postgres/src/occ-retry.ts
@@ -1,0 +1,123 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { DatabaseError } from "pg";
+import { RetryConfig, TransactionOptions } from "./config/aurora-dsql-config.js";
+
+type OCCType = "Data" | "Schema" | "Unknown";
+
+const DEFAULT_RETRY_CONFIG: Required<RetryConfig> = {
+  maxAttempts: 3,
+  baseDelayMs: 1,
+  maxDelayMs: 100,
+  jitter: true,
+};
+
+function getOCCType(error: unknown): OCCType | null {
+  if (!error || typeof error !== "object") {
+    return null;
+  }
+
+  const dbError = error as DatabaseError;
+  if (!dbError.code) {
+    return null;
+  }
+
+  if (dbError.code === "OC000") {
+    return "Data";
+  }
+  if (dbError.code === "OC001") {
+    return "Schema";
+  }
+  if (dbError.code === "40001") {
+    if (dbError.message && (dbError.message.includes("(OC000)") || dbError.message.includes("(OC001)"))) {
+      return dbError.message.includes("(OC000)") ? "Data" : "Schema";
+    }
+    return "Unknown";
+  }
+
+  return null;
+}
+
+function calculateBackoff(baseDelayMs: number, maxDelayMs: number, jitter: boolean): number {
+  if (!jitter) {
+    return baseDelayMs;
+  }
+
+  const delay = baseDelayMs + Math.random() * baseDelayMs;
+  return Math.min(delay, maxDelayMs);
+}
+
+function validateRetryConfig(config: Required<RetryConfig>): void {
+  if (!Number.isInteger(config.maxAttempts) || config.maxAttempts <= 0) {
+    throw new TypeError('maxAttempts must be a positive integer');
+  }
+  if (!Number.isFinite(config.baseDelayMs) || config.baseDelayMs <= 0) {
+    throw new TypeError('baseDelayMs must be a positive number');
+  }
+  if (!Number.isFinite(config.maxDelayMs) || config.maxDelayMs <= 0) {
+    throw new TypeError('maxDelayMs must be a positive number');
+  }
+  if (config.maxDelayMs < config.baseDelayMs) {
+    throw new TypeError('maxDelayMs must be >= baseDelayMs');
+  }
+}
+
+function resolveRetryConfig(
+  constructorConfig: { retry?: RetryConfig } | undefined,
+  callOptions: TransactionOptions | undefined,
+): Required<RetryConfig> | null {
+  if (callOptions?.retry === false) {
+    return null;
+  }
+
+  const config = {
+    ...DEFAULT_RETRY_CONFIG,
+    ...(constructorConfig?.retry || {}),
+    ...(callOptions?.retry || {}),
+  };
+
+  validateRetryConfig(config);
+
+  return config;
+}
+
+async function executeTransaction<T>(
+  executeCallback: () => Promise<T>,
+  retryConfig: Required<RetryConfig> | null,
+  logger?: (msg: string) => void,
+): Promise<T> {
+  if (retryConfig === null) {
+    return executeCallback();
+  }
+
+  let lastError: Error | undefined;
+
+  for (let attempt = 1; attempt <= retryConfig.maxAttempts; attempt++) {
+    try {
+      return await executeCallback();
+    } catch (error) {
+      const occType = getOCCType(error);
+
+      if (occType === null) {
+        throw error;
+      }
+
+      lastError = error as Error;
+
+      if (attempt < retryConfig.maxAttempts) {
+        const delay = calculateBackoff(retryConfig.baseDelayMs, retryConfig.maxDelayMs, retryConfig.jitter);
+        logger?.(`OCC conflict (${occType}) on attempt ${attempt}, retrying in ${delay.toFixed(1)}ms`);
+        await new Promise((resolve) => setTimeout(resolve, delay));
+      } else {
+        logger?.(`OCC retry exhausted after ${retryConfig.maxAttempts} attempts (${occType} conflict)`);
+        throw error;
+      }
+    }
+  }
+
+  throw lastError;
+}
+
+export { resolveRetryConfig, executeTransaction };

--- a/node/node-postgres/test/integration/dsql.integration.test.ts
+++ b/node/node-postgres/test/integration/dsql.integration.test.ts
@@ -304,4 +304,102 @@ describe("DSQL Integration Tests", () => {
       }
     });
   });
+
+  describe("OCC Retry", () => {
+    test("should retry OCC conflicts with Client", async () => {
+      const client1 = new AuroraDSQLClient({
+        host: clusterEndpoint,
+        user: "admin",
+        logger: (msg) => console.log(`[client1] ${msg}`),
+        transaction: { retry: { maxAttempts: 5, baseDelayMs: 10, jitter: true } },
+      });
+
+      const client2 = new AuroraDSQLClient({
+        host: clusterEndpoint,
+        user: "admin",
+        logger: (msg) => console.log(`[client2] ${msg}`),
+        transaction: { retry: { maxAttempts: 5, baseDelayMs: 10, jitter: true } },
+      });
+
+      try {
+        await client1.connect();
+        await client2.connect();
+        await client1.query("CREATE TABLE IF NOT EXISTS occ_test_client (id INT PRIMARY KEY, value INT)");
+        await client1.query("INSERT INTO occ_test_client (id, value) VALUES (1, 0) ON CONFLICT (id) DO UPDATE SET value = 0");
+
+        const updatePromises = [
+          client1.transaction(async (c) => {
+            const result = await c.query("SELECT value FROM occ_test_client WHERE id = 1");
+            const currentValue = result.rows[0].value;
+            await c.query("UPDATE occ_test_client SET value = $1 WHERE id = 1", [currentValue + 1]);
+          }),
+          client2.transaction(async (c) => {
+            const result = await c.query("SELECT value FROM occ_test_client WHERE id = 1");
+            const currentValue = result.rows[0].value;
+            await c.query("UPDATE occ_test_client SET value = $1 WHERE id = 1", [currentValue + 1]);
+          }),
+        ];
+
+        await Promise.all(updatePromises);
+
+        const finalResult = await client1.query("SELECT value FROM occ_test_client WHERE id = 1");
+        expect(finalResult.rows[0].value).toBe(2);
+      } finally {
+        await client1.query("DROP TABLE IF EXISTS occ_test_client");
+        await client1.end();
+        await client2.end();
+      }
+    });
+
+    test("should retry OCC conflicts with Pool", async () => {
+      const pool = new AuroraDSQLPool({
+        host: clusterEndpoint,
+        user: "admin",
+        max: 5,
+        logger: (msg) => console.log(`[pool] ${msg}`),
+        transaction: { retry: { maxAttempts: 10, baseDelayMs: 10, maxDelayMs: 100, jitter: true } },
+      });
+
+      try {
+        await pool.query("CREATE TABLE IF NOT EXISTS occ_test_pool (id INT PRIMARY KEY, value INT)");
+        await pool.query("INSERT INTO occ_test_pool (id, value) VALUES (1, 0) ON CONFLICT (id) DO UPDATE SET value = 0");
+
+        const updatePromises = Array.from({ length: 10 }, () =>
+          pool.transaction(async (client) => {
+            const result = await client.query("SELECT value FROM occ_test_pool WHERE id = 1");
+            const currentValue = result.rows[0].value;
+            await client.query("UPDATE occ_test_pool SET value = $1 WHERE id = 1", [currentValue + 1]);
+          })
+        );
+
+        await Promise.all(updatePromises);
+
+        const finalResult = await pool.query("SELECT value FROM occ_test_pool WHERE id = 1");
+        expect(finalResult.rows[0].value).toBe(10);
+      } finally {
+        await pool.query("DROP TABLE IF EXISTS occ_test_pool");
+        await pool.end();
+      }
+    });
+
+    test("should not retry non-OCC errors", async () => {
+      const client = new AuroraDSQLClient({
+        host: clusterEndpoint,
+        user: "admin",
+        transaction: { retry: { maxAttempts: 3 } },
+      });
+
+      try {
+        await client.connect();
+
+        await expect(
+          client.transaction(async (c) => {
+            await c.query("SELECT * FROM nonexistent_table");
+          })
+        ).rejects.toThrow();
+      } finally {
+        await client.end();
+      }
+    });
+  });
 });

--- a/node/node-postgres/test/occ-retry.test.ts
+++ b/node/node-postgres/test/occ-retry.test.ts
@@ -1,0 +1,330 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { AuroraDSQLPool } from "../src/aurora-dsql-pool";
+import { AuroraDSQLClient } from "../src/aurora-dsql-client";
+import { AuroraDSQLUtil } from "../src/aurora-dsql-util";
+import { Pool, Client } from "pg";
+
+jest.mock("pg");
+jest.mock("../src/aurora-dsql-util");
+
+const mockPool = Pool as jest.MockedClass<typeof Pool>;
+const mockClient = Client as jest.MockedClass<typeof Client>;
+const mockAuroraDSQLUtil = AuroraDSQLUtil as jest.Mocked<typeof AuroraDSQLUtil>;
+
+describe("OCC Retry", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAuroraDSQLUtil.parsePgConfig.mockImplementation((config) => ({
+      host: "example.dsql.us-east-1.on.aws",
+      user: "admin",
+      port: 5432,
+      database: "postgres",
+      region: "us-east-1",
+      profile: "default",
+      ssl: { rejectUnauthorized: true },
+      ...(typeof config === "string" ? {} : config),
+    }));
+    mockAuroraDSQLUtil.getDSQLToken.mockResolvedValue("mock-token");
+  });
+
+  describe("Pool.transaction", () => {
+    let pool: AuroraDSQLPool;
+    let mockPoolClient: any;
+
+    beforeEach(() => {
+      mockPoolClient = {
+        query: jest.fn().mockResolvedValue({ rows: [] }),
+        release: jest.fn(),
+      };
+      mockPool.prototype.connect = jest.fn().mockResolvedValue(mockPoolClient);
+
+      pool = new AuroraDSQLPool({
+        host: "example.dsql.us-east-1.on.aws",
+        user: "admin",
+        transaction: { retry: { maxAttempts: 3 } },
+      });
+
+      (pool as any).options = {
+        host: "example.dsql.us-east-1.on.aws",
+        user: "admin",
+      };
+    });
+
+    it("should execute transaction successfully without retry", async () => {
+      const callback = jest.fn().mockResolvedValue("result");
+
+      const result = await pool.transaction(callback);
+
+      expect(result).toBe("result");
+      expect(callback).toHaveBeenCalledTimes(1);
+      expect(mockPoolClient.query).toHaveBeenCalledWith("BEGIN");
+      expect(mockPoolClient.query).toHaveBeenCalledWith("COMMIT");
+      expect(mockPoolClient.release).toHaveBeenCalled();
+    });
+
+    it("should retry on OC000 data conflict", async () => {
+      const occError = Object.assign(new Error("OCC"), { code: "OC000" });
+      const callback = jest.fn()
+        .mockRejectedValueOnce(occError)
+        .mockResolvedValue("success");
+
+      const result = await pool.transaction(callback);
+
+      expect(result).toBe("success");
+      expect(callback).toHaveBeenCalledTimes(2);
+    });
+
+    it("should retry on OC001 schema conflict", async () => {
+      const occError = Object.assign(new Error("OCC"), { code: "OC001" });
+      const callback = jest.fn()
+        .mockRejectedValueOnce(occError)
+        .mockResolvedValue("success");
+
+      const result = await pool.transaction(callback);
+
+      expect(result).toBe("success");
+      expect(callback).toHaveBeenCalledTimes(2);
+    });
+
+    it("should retry on 40001 serialization failure", async () => {
+      const occError = Object.assign(
+        new Error("serialization failure"),
+        { code: "40001" },
+      );
+      const callback = jest.fn()
+        .mockRejectedValueOnce(occError)
+        .mockResolvedValue("success");
+
+      const result = await pool.transaction(callback);
+
+      expect(result).toBe("success");
+      expect(callback).toHaveBeenCalledTimes(2);
+    });
+
+    it("should not retry non-OCC errors", async () => {
+      const genericError = new Error("syntax error");
+      const callback = jest.fn().mockRejectedValue(genericError);
+
+      await expect(pool.transaction(callback)).rejects.toThrow("syntax error");
+      expect(callback).toHaveBeenCalledTimes(1);
+    });
+
+    it("should throw after max attempts exhausted", async () => {
+      const occError = Object.assign(new Error("OCC"), { code: "OC000" });
+      const callback = jest.fn().mockRejectedValue(occError);
+
+      await expect(pool.transaction(callback)).rejects.toThrow("OCC");
+      expect(callback).toHaveBeenCalledTimes(3);
+    });
+
+    it("should not retry when disabled via options", async () => {
+      const occError = Object.assign(new Error("OCC"), { code: "OC000" });
+      const callback = jest.fn().mockRejectedValue(occError);
+
+      await expect(pool.transaction(callback, { retry: false })).rejects.toThrow("OCC");
+      expect(callback).toHaveBeenCalledTimes(1);
+    });
+
+    it("should override constructor config with per-call options", async () => {
+      const occError = Object.assign(new Error("OCC"), { code: "OC000" });
+      const callback = jest.fn().mockRejectedValue(occError);
+
+      await expect(pool.transaction(callback, { retry: { maxAttempts: 5 } })).rejects.toThrow("OCC");
+      expect(callback).toHaveBeenCalledTimes(5);
+    });
+
+    it("should release pool client after each attempt", async () => {
+      const occError = Object.assign(new Error("OCC"), { code: "OC000" });
+      const callback = jest.fn()
+        .mockRejectedValueOnce(occError)
+        .mockResolvedValue("success");
+
+      await pool.transaction(callback);
+
+      expect(mockPoolClient.release).toHaveBeenCalledTimes(2);
+    });
+
+    it("should rollback on error before retrying", async () => {
+      const occError = Object.assign(new Error("OCC"), { code: "OC000" });
+      const callback = jest.fn()
+        .mockRejectedValueOnce(occError)
+        .mockResolvedValue("success");
+
+      await pool.transaction(callback);
+
+      expect(mockPoolClient.query).toHaveBeenCalledWith("ROLLBACK");
+    });
+
+    it("should still retry and release client when ROLLBACK fails", async () => {
+      const occError = Object.assign(new Error("OCC"), { code: "OC000" });
+      mockPoolClient.query = jest.fn().mockImplementation((sql: string) => {
+        if (sql === "ROLLBACK") return Promise.reject(new Error("connection lost"));
+        return Promise.resolve({ rows: [] });
+      });
+      const callback = jest.fn()
+        .mockRejectedValueOnce(occError)
+        .mockResolvedValue("success");
+
+      const result = await pool.transaction(callback);
+
+      expect(result).toBe("success");
+      expect(callback).toHaveBeenCalledTimes(2);
+      expect(mockPoolClient.release).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("Client.transaction", () => {
+    let client: AuroraDSQLClient;
+    let mockQuery: jest.Mock;
+
+    beforeEach(() => {
+      mockQuery = jest.fn().mockResolvedValue({ rows: [] });
+      mockClient.prototype.query = mockQuery;
+      mockClient.prototype.connect = jest.fn().mockResolvedValue(undefined);
+
+      client = new AuroraDSQLClient({
+        host: "example.dsql.us-east-1.on.aws",
+        user: "admin",
+        transaction: { retry: { maxAttempts: 3 } },
+      });
+    });
+
+    it("should execute transaction successfully without retry", async () => {
+      const callback = jest.fn().mockResolvedValue("result");
+
+      const result = await client.transaction(callback);
+
+      expect(result).toBe("result");
+      expect(callback).toHaveBeenCalledTimes(1);
+      expect(mockQuery).toHaveBeenCalledWith("BEGIN");
+      expect(mockQuery).toHaveBeenCalledWith("COMMIT");
+    });
+
+    it("should retry on OC000 data conflict", async () => {
+      const occError = Object.assign(new Error("OCC"), { code: "OC000" });
+      const callback = jest.fn()
+        .mockRejectedValueOnce(occError)
+        .mockResolvedValue("success");
+
+      const result = await client.transaction(callback);
+
+      expect(result).toBe("success");
+      expect(callback).toHaveBeenCalledTimes(2);
+    });
+
+    it("should retry on OC001 schema conflict", async () => {
+      const occError = Object.assign(new Error("OCC"), { code: "OC001" });
+      const callback = jest.fn()
+        .mockRejectedValueOnce(occError)
+        .mockResolvedValue("success");
+
+      const result = await client.transaction(callback);
+
+      expect(result).toBe("success");
+      expect(callback).toHaveBeenCalledTimes(2);
+    });
+
+    it("should not retry non-OCC errors", async () => {
+      const genericError = new Error("syntax error");
+      const callback = jest.fn().mockRejectedValue(genericError);
+
+      await expect(client.transaction(callback)).rejects.toThrow("syntax error");
+      expect(callback).toHaveBeenCalledTimes(1);
+    });
+
+    it("should throw after max attempts exhausted", async () => {
+      const occError = Object.assign(new Error("OCC"), { code: "OC000" });
+      const callback = jest.fn().mockRejectedValue(occError);
+
+      await expect(client.transaction(callback)).rejects.toThrow("OCC");
+      expect(callback).toHaveBeenCalledTimes(3);
+    });
+
+    it("should not retry when disabled via options", async () => {
+      const occError = Object.assign(new Error("OCC"), { code: "OC000" });
+      const callback = jest.fn().mockRejectedValue(occError);
+
+      await expect(client.transaction(callback, { retry: false })).rejects.toThrow("OCC");
+      expect(callback).toHaveBeenCalledTimes(1);
+    });
+
+    it("should override constructor config with per-call options", async () => {
+      const occError = Object.assign(new Error("OCC"), { code: "OC000" });
+      const callback = jest.fn().mockRejectedValue(occError);
+
+      await expect(client.transaction(callback, { retry: { maxAttempts: 5 } })).rejects.toThrow("OCC");
+      expect(callback).toHaveBeenCalledTimes(5);
+    });
+
+    it("should rollback on error before retrying", async () => {
+      const occError = Object.assign(new Error("OCC"), { code: "OC000" });
+      const callback = jest.fn()
+        .mockRejectedValueOnce(occError)
+        .mockResolvedValue("success");
+
+      await client.transaction(callback);
+
+      expect(mockQuery).toHaveBeenCalledWith("ROLLBACK");
+    });
+  });
+
+  describe("retry config validation", () => {
+    let pool: AuroraDSQLPool;
+
+    beforeEach(() => {
+      const mockPoolClient = {
+        query: jest.fn().mockResolvedValue({ rows: [] }),
+        release: jest.fn(),
+      };
+      mockPool.prototype.connect = jest.fn().mockResolvedValue(mockPoolClient);
+
+      pool = new AuroraDSQLPool({
+        host: "example.dsql.us-east-1.on.aws",
+        user: "admin",
+      });
+
+      (pool as any).options = {
+        host: "example.dsql.us-east-1.on.aws",
+        user: "admin",
+      };
+    });
+
+    it("should reject maxAttempts <= 0", async () => {
+      const callback = jest.fn();
+      await expect(
+        pool.transaction(callback, { retry: { maxAttempts: 0 } }),
+      ).rejects.toThrow("maxAttempts must be a positive integer");
+    });
+
+    it("should reject non-integer maxAttempts", async () => {
+      const callback = jest.fn();
+      await expect(
+        pool.transaction(callback, { retry: { maxAttempts: 2.5 } }),
+      ).rejects.toThrow("maxAttempts must be a positive integer");
+    });
+
+    it("should reject baseDelayMs <= 0", async () => {
+      const callback = jest.fn();
+      await expect(
+        pool.transaction(callback, { retry: { baseDelayMs: 0 } }),
+      ).rejects.toThrow("baseDelayMs must be a positive number");
+    });
+
+    it("should reject maxDelayMs <= 0", async () => {
+      const callback = jest.fn();
+      await expect(
+        pool.transaction(callback, { retry: { maxDelayMs: 0 } }),
+      ).rejects.toThrow("maxDelayMs must be a positive number");
+    });
+
+    it("should reject maxDelayMs < baseDelayMs", async () => {
+      const callback = jest.fn();
+      await expect(
+        pool.transaction(callback, { retry: { baseDelayMs: 50, maxDelayMs: 10 } }),
+      ).rejects.toThrow("maxDelayMs must be >= baseDelayMs");
+    });
+  });
+});


### PR DESCRIPTION
Add automatic OCC retry for both Pool and Client configurable retry on OCC conflicts (OC000, OC001, 40001). Pool acquires a fresh connection per attempt; Client reuses the same connection. Includes config validation, jittered backoff, per-call overrides, and opt-out via retry: false. Unit and integration tests included.

*Issue #, if available:*

*Description of changes:*
Add `transaction()` method to `AuroraDSQLPool` and `AuroraDSQLClient` with automatic OCC retry.

- Pool acquires a fresh connection per retry attempt; Client reuses the same connection
- Configurable via constructor-level defaults and per-call overrides
- Jittered backoff: `baseDelayMs + random * baseDelayMs`, capped at `maxDelayMs`
- Opt-out per-call with `{ retry: false }`
- Config validation rejects invalid values (non-positive, NaN, Infinity, maxDelay < baseDelay)
- Unit tests (23 cases) and integration tests for concurrent OCC scenarios
- README updated with usage examples and configuration reference

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
