### PR TITLE
Replace inline DSQL best practices with link to official docs

### DIFF
--- a/go/pgx/README.md
+++ b/go/pgx/README.md
@@ -384,15 +384,7 @@ go run ./src/connection_string/...
 
 ## DSQL Best Practices
 
-When using this connector with Aurora DSQL, follow these practices:
-
-1. **UUID Primary Keys**: Always use `UUID DEFAULT gen_random_uuid()` - DSQL doesn't support sequences or SERIAL
-2. **OCC Handling**: DSQL uses optimistic concurrency control. Handle error codes `OC000` (data conflict) and `OC001` (schema conflict) with retry logic
-3. **No Foreign Keys**: DSQL doesn't support foreign key constraints - enforce relationships in your application
-4. **Async Indexes**: Use `CREATE INDEX ASYNC` for index creation
-5. **Transaction Limits**: Transactions are limited to 3,000 rows, 10 MiB, and 5 minutes
-6. **Connection Limits**: Connections timeout after 60 minutes; configure `MaxConnLifetime` on your `pgxpool.Config` accordingly
-7. **No SAVEPOINT**: Partial rollbacks via SAVEPOINT are not supported
+For Aurora DSQL best practices including primary key selection, concurrency handling, index creation, and transaction limits, see the [Aurora DSQL documentation](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/working-with-postgresql-compatibility.html).
 
 ## Additional Resources
 

--- a/ruby/pg/README.md
+++ b/ruby/pg/README.md
@@ -212,15 +212,7 @@ bundle exec rake integration # Run integration tests (requires CLUSTER_ENDPOINT)
 
 ## DSQL Best Practices
 
-When using this connector with Aurora DSQL, follow these practices:
-
-1. **UUID Primary Keys**: Always use `UUID DEFAULT gen_random_uuid()` - DSQL doesn't support sequences or SERIAL
-2. **OCC Handling**: DSQL uses optimistic concurrency control. Enable retry via `occ_max_retries` on the pool; for single connections, use `OCCRetry` explicitly
-3. **No Foreign Keys**: DSQL doesn't support foreign key constraints - enforce relationships in your application
-4. **Async Indexes**: Use `CREATE INDEX ASYNC` for index creation
-5. **Transaction Limits**: Transactions are limited to 3,000 rows, 10 MiB, and 5 minutes
-6. **Connection Limits**: Connections timeout after 60 minutes; configure pool `max_lifetime` accordingly
-7. **No SAVEPOINT**: Partial rollbacks via SAVEPOINT are not supported
+For Aurora DSQL best practices including primary key selection, concurrency handling, index creation, and transaction limits, see the [Aurora DSQL documentation](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/working-with-postgresql-compatibility.html).
 
 ## Additional Resources
 


### PR DESCRIPTION
## Summary

The 'DSQL Best Practices' sections in `go/pgx/README.md` and `ruby/pg/README.md` duplicated information from the official Aurora DSQL documentation (transaction limits, connection limits, foreign key behavior, SAVEPOINT behavior, etc.).

This creates a maintenance burden — every time DSQL ships a new feature (e.g., JSONB support), these inline lists go stale and need manual updates across multiple repos.

## Changes

Replace the inline best practices lists with a single link to the official [PostgreSQL compatibility documentation](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/working-with-postgresql-compatibility.html), which is the source of truth.

## Before (both files had similar content)

```markdown
1. **UUID Primary Keys**: Always use ... - DSQL doesn't support sequences or SERIAL
2. **OCC Handling**: DSQL uses optimistic concurrency control...
3. **No Foreign Keys**: DSQL doesn't support foreign key constraints...
4. **Async Indexes**: Use CREATE INDEX ASYNC...
5. **Transaction Limits**: Transactions are limited to 3,000 rows...
6. **Connection Limits**: Connections timeout after 60 minutes...
7. **No SAVEPOINT**: Partial rollbacks via SAVEPOINT are not supported
```

## After

```markdown
For Aurora DSQL best practices including primary key selection, concurrency handling,
index creation, and transaction limits, see the
[Aurora DSQL documentation](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/working-with-postgresql-compatibility.html).
```

## Motivation

Part of a broader effort to reduce maintenance burden across DSQL repos by having connector/sample READMEs link to official docs rather than maintaining their own limitation lists.