### PR TITLE
feat(node-postgres): add OCC retry for transactions

### DIFF
--- a/node/node-postgres/README.md
+++ b/node/node-postgres/README.md
@@ -35,6 +35,7 @@ The Aurora DSQL Connector for node-postgres is designed to understand these requ
 - **Full TypeScript Support** - Provides full type safety
 - **AWS Credentials Support** - Supports various AWS credential providers (default, profile-based, custom)
 - **Connection Pooling Compatibility** - Works seamlessly with built-in connection pooling
+- **OCC Retry** - Automatic retry with exponential backoff on optimistic concurrency conflicts
 
 ## Example Application
 
@@ -122,18 +123,55 @@ const result = await client.query("SELECT NOW()");
 await client.end();
 ```
 
+### OCC Retry
+
+Aurora DSQL uses optimistic concurrency control (OCC). Transactions that conflict are rejected at
+commit time with error codes `OC000`, `OC001`, or `40001`. The connector provides a `transaction()`
+method that automatically retries on these conflicts with exponential backoff.
+
+```typescript
+import { AuroraDSQLPool } from "@aws/aurora-dsql-node-postgres-connector";
+
+const pool = new AuroraDSQLPool({
+  host: "<CLUSTER_ENDPOINT>",
+  user: "admin",
+  retry: { maxRetries: 5 },
+});
+
+await pool.transaction(async (client) => {
+  await client.query("INSERT INTO accounts(id, balance) VALUES($1, $2)", [1, 100]);
+});
+```
+
+The retry config accepts a partial object — unset fields use defaults:
+
+| Field          | Default | Description                        |
+| -------------- | ------- | ---------------------------------- |
+| `maxRetries`   | 3       | Number of retry attempts after the initial try (0 = no retry) |
+| `baseDelayMs`  | 1       | Initial backoff delay in ms        |
+| `maxDelayMs`   | 100     | Maximum base backoff delay in ms (jitter is added on top) |
+| `jitterFactor` | 0.25    | Jitter as a fraction of delay      |
+
+Per-call override:
+
+```typescript
+await pool.transaction(callback, { maxRetries: 0 }); // no retry for this call
+```
+
 ## Configuration Options
 
 | Option                      | Type                                                    | Required | Description                                              |
 | --------------------------- | ------------------------------------------------------- | -------- | -------------------------------------------------------- |
 | `host`                      | `string`                                                | Yes      | DSQL cluster hostname                                    |
-| `username`                  | `string`                                                | Yes      | DSQL username                                            |
+| `user`                      | `string`                                                | Yes      | DSQL username                                            |
 | `database`                  | `string`                                                | No       | Database name                                            |
 | `region`                    | `string`                                                | No       | AWS region (auto-detected from hostname if not provided) |
 | `port`                      | `number`                                                | No       | Default to 5432                                          |
 | `customCredentialsProvider` | `AwsCredentialIdentity / AwsCredentialIdentityProvider` | No       | Custom AWS credentials provider                          |
 | `profile`                   | `string`                                                | No       | The IAM profile name. Default to "default"               |
 | `tokenDurationSecs`         | `number`                                                | No       | Token expiration time in seconds                         |
+| `retry`                     | `Partial<OCCRetryConfig>`                               | No       | OCC retry configuration (see above)                      |
+| `logger`                    | `Logger`                                                | No       | Logger with `warn` and `error` methods (e.g. `console`)  |
 
 All other parameters from [Client](https://node-postgres.com/apis/client) / [Pool](https://node-postgres.com/apis/pool) are supported.
 

--- a/node/node-postgres/example/README.md
+++ b/node/node-postgres/example/README.md
@@ -59,6 +59,7 @@ The example demonstrates the following operations:
 
 - Opening a connection to an Aurora DSQL cluster
 - Creating a table
+- Transactional writes with automatic OCC retry
 - Inserting and querying data
 
 The example is designed to work with both admin and non-admin users:

--- a/node/node-postgres/example/src/alternatives/no_connection_pool/example_with_no_connection_pool.js
+++ b/node/node-postgres/example/src/alternatives/no_connection_pool/example_with_no_connection_pool.js
@@ -13,6 +13,7 @@ async function getConnection(clusterEndpoint, user) {
   const client = new AuroraDSQLClient({
     host: clusterEndpoint,
     user: user,
+    retry: { maxRetries: 5 },
   });
 
   await client.connect();
@@ -41,15 +42,17 @@ async function example() {
       telephone VARCHAR(20)
     )`);
 
-    // Insert some data
-    await client.query(
-      "INSERT INTO owner(name, city, telephone) VALUES($1, $2, $3)",
-      ["John Doe", "Anytown", "555-555-1900"]
-    );
+    // Transactional write with OCC retry
+    await client.transaction(async (c) => {
+      await c.query(
+        "INSERT INTO owner(name, city, telephone) VALUES($1, $2, $3)",
+        ["John Doe", "Anytown", "555-555-1900"],
+      );
+    });
 
     // Check that data is inserted by reading it back
     const result = await client.query(
-      "SELECT id, city FROM owner where name='John Doe'"
+      "SELECT id, city FROM owner where name='John Doe'",
     );
     assert.deepEqual(result.rows[0].city, "Anytown");
     assert.notEqual(result.rows[0].id, null);

--- a/node/node-postgres/example/src/example_preferred.js
+++ b/node/node-postgres/example/src/example_preferred.js
@@ -15,6 +15,7 @@ function createPool(clusterEndpoint, user) {
     max: 10,
     idleTimeoutMillis: 30000,
     connectionTimeoutMillis: 10000,
+    retry: { maxRetries: 5 },
   });
 }
 
@@ -43,6 +44,33 @@ async function example() {
     await Promise.all(workers);
 
     console.log("Connection pool with concurrent connections exercised successfully");
+
+    // Create table
+    await pool.query(`CREATE TABLE IF NOT EXISTS owner (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      name VARCHAR(30) NOT NULL,
+      city VARCHAR(80) NOT NULL,
+      telephone VARCHAR(20)
+    )`);
+
+    // Transactional write with OCC retry
+    await pool.transaction(async (client) => {
+      await client.query(
+        "INSERT INTO owner(name, city, telephone) VALUES($1, $2, $3)",
+        ["John Doe", "Anytown", "555-555-1900"],
+      );
+    });
+
+    // Verify the write
+    const result = await pool.query("SELECT name, city FROM owner WHERE name = $1", ["John Doe"]);
+    assert.strictEqual(result.rows[0].name, "John Doe");
+    assert.strictEqual(result.rows[0].city, "Anytown");
+    console.log(`Inserted: name=${result.rows[0].name}, city=${result.rows[0].city}`);
+
+    // Clean up
+    await pool.query("DELETE FROM owner WHERE name = $1", ["John Doe"]);
+
+    console.log("Transactional write with OCC retry exercised successfully");
   } catch (error) {
     console.error(error);
     throw error;

--- a/node/node-postgres/src/aurora-dsql-client.ts
+++ b/node/node-postgres/src/aurora-dsql-client.ts
@@ -5,6 +5,7 @@
 import { Client } from "pg";
 import { AuroraDSQLConfig } from "./config/aurora-dsql-config.js";
 import { AuroraDSQLUtil } from "./aurora-dsql-util.js";
+import { resolveRetryConfig, executeWithRetry } from "./occ-retry.js";
 
 class AuroraDSQLClient extends Client {
   private dsqlConfig?: AuroraDSQLConfig;
@@ -18,9 +19,12 @@ class AuroraDSQLClient extends Client {
     super(dsqlConfig);
 
     this.dsqlConfig = dsqlConfig;
+
+    if (dsqlConfig.retry) {
+      resolveRetryConfig(dsqlConfig.retry, undefined);
+    }
   }
 
-  // TypeScript doesn't allow multiple declarations of the same function name hence the following declaration was used
   override async connect(callback?: (err: Error) => void) {
     if (this.dsqlConfig !== undefined) {
       try {
@@ -44,6 +48,40 @@ class AuroraDSQLClient extends Client {
       return super.connect(callback);
     }
     return super.connect();
+  }
+
+  /**
+   * Execute a callback within a transaction with automatic OCC retry.
+   *
+   * The callback may be invoked multiple times on OCC conflicts — it must be
+   * idempotent (no side effects that should not be repeated, e.g. sending
+   * emails, enqueuing messages, incrementing external counters).
+   *
+   * Not safe for concurrent calls on the same AuroraDSQLClient instance.
+   * Use AuroraDSQLPool.transaction() for concurrent transactional work,
+   * where each call acquires its own connection.
+   */
+  async transaction<T>(
+    callback: (client: this) => Promise<T>,
+    options?: { maxRetries?: number },
+  ): Promise<T> {
+    const retryConfig = resolveRetryConfig(this.dsqlConfig?.retry, options?.maxRetries);
+
+    return executeWithRetry(async () => {
+      await this.query("BEGIN");
+      try {
+        const result = await callback(this);
+        await this.query("COMMIT");
+        return result;
+      } catch (error) {
+        try {
+          await this.query("ROLLBACK");
+        } catch (rollbackError) {
+          this.dsqlConfig?.logger?.error(`Failed to rollback transaction: ${rollbackError}`);
+        }
+        throw error;
+      }
+    }, retryConfig, this.dsqlConfig?.logger);
   }
 }
 

--- a/node/node-postgres/src/aurora-dsql-pool.ts
+++ b/node/node-postgres/src/aurora-dsql-pool.ts
@@ -5,6 +5,7 @@
 import { Pool, PoolClient } from "pg";
 import { AuroraDSQLPoolConfig } from "./config/aurora-dsql-pool-config.js";
 import { AuroraDSQLUtil } from "./aurora-dsql-util.js";
+import { resolveRetryConfig, executeWithRetry } from "./occ-retry.js";
 
 class AuroraDSQLPool extends Pool {
   private dsqlConfig?: AuroraDSQLPoolConfig;
@@ -18,9 +19,12 @@ class AuroraDSQLPool extends Pool {
     super(dsqlConfig);
 
     this.dsqlConfig = dsqlConfig;
+
+    if (dsqlConfig.retry) {
+      resolveRetryConfig(dsqlConfig.retry, undefined);
+    }
   }
 
-  // These declaration are needed as they have different returns otherwise a compile error will occur
   connect(): Promise<PoolClient>;
   connect(
     callback: (
@@ -30,7 +34,6 @@ class AuroraDSQLPool extends Pool {
     ) => void,
   ): void;
 
-  // TypeScript doesn't allow multiple declaration of the same name hence the following declaration was used
   override async connect(
     callback?: (
       err: Error | undefined,
@@ -62,6 +65,47 @@ class AuroraDSQLPool extends Pool {
       return super.connect(callback);
     }
     return super.connect();
+  }
+
+  /**
+   * Execute a callback within a transaction with automatic OCC retry.
+   *
+   * The callback may be invoked multiple times on OCC conflicts — it must be
+   * idempotent (no side effects that should not be repeated, e.g. sending
+   * emails, enqueuing messages, incrementing external counters).
+   */
+  async transaction<T>(
+    callback: (client: PoolClient) => Promise<T>,
+    options?: { maxRetries?: number },
+  ): Promise<T> {
+    const retryConfig = resolveRetryConfig(this.dsqlConfig?.retry, options?.maxRetries);
+
+    return executeWithRetry(async () => {
+      const client = await this.connect();
+      let destroyConnection = false;
+      try {
+        await client.query("BEGIN");
+        try {
+          const result = await callback(client);
+          await client.query("COMMIT");
+          return result;
+        } catch (error) {
+          try {
+            await client.query("ROLLBACK");
+          } catch (rollbackError) {
+            this.dsqlConfig?.logger?.error(`Failed to rollback transaction: ${rollbackError}`);
+            destroyConnection = true;
+          }
+          throw error;
+        }
+      } finally {
+        try {
+          client.release(destroyConnection);
+        } catch (releaseError) {
+          this.dsqlConfig?.logger?.error(`Failed to release pool connection: ${releaseError}`);
+        }
+      }
+    }, retryConfig, this.dsqlConfig?.logger);
   }
 }
 

--- a/node/node-postgres/src/config/aurora-dsql-config.ts
+++ b/node/node-postgres/src/config/aurora-dsql-config.ts
@@ -4,12 +4,15 @@
  */
 import { ClientConfig } from "pg";
 import { AwsCredentialIdentity, AwsCredentialIdentityProvider } from "@smithy/types";
+import { Logger, OCCRetryConfig } from "../occ-retry.js";
 
 interface AuroraDSQLConfig extends ClientConfig {
   profile?: string;
   region?: string;
   tokenDurationSecs?: number;
   customCredentialsProvider?: AwsCredentialIdentity | AwsCredentialIdentityProvider;
+  retry?: Partial<OCCRetryConfig>;
+  logger?: Logger;
 }
 
 export { AuroraDSQLConfig };

--- a/node/node-postgres/src/index.ts
+++ b/node/node-postgres/src/index.ts
@@ -4,5 +4,7 @@
  */
 export { AuroraDSQLClient } from "./aurora-dsql-client.js";
 export { AuroraDSQLPool } from "./aurora-dsql-pool.js";
+export { isOCCError } from "./occ-retry.js";
+export type { OCCRetryConfig, Logger } from "./occ-retry.js";
 export type { AuroraDSQLConfig } from './config/aurora-dsql-config.js';
 export type { AuroraDSQLPoolConfig } from './config/aurora-dsql-pool-config.js';

--- a/node/node-postgres/src/occ-retry.ts
+++ b/node/node-postgres/src/occ-retry.ts
@@ -1,0 +1,130 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { DatabaseError } from "pg";
+
+interface Logger {
+  debug?(msg: string, ...args: unknown[]): void;
+  warn(msg: string, ...args: unknown[]): void;
+  error(msg: string, ...args: unknown[]): void;
+}
+
+interface OCCRetryConfig {
+  maxRetries: number;
+  baseDelayMs: number;
+  maxDelayMs: number;
+  jitterFactor: number;
+}
+
+const DEFAULT_CONFIG: OCCRetryConfig = {
+  maxRetries: 3,
+  baseDelayMs: 1,
+  maxDelayMs: 100,
+  jitterFactor: 0.25,
+};
+
+function validateRetryConfig(config: OCCRetryConfig): void {
+  for (const [k, v] of Object.entries(config)) {
+    if (typeof v !== "number" || !Number.isFinite(v)) {
+      throw new Error(`${k} must be a finite number`);
+    }
+  }
+  if (!Number.isInteger(config.maxRetries)) {
+    throw new Error("maxRetries must be an integer");
+  }
+  if (config.maxRetries < 0) {
+    throw new Error("maxRetries must be >= 0");
+  }
+  if (config.maxRetries > 100) {
+    throw new Error("maxRetries must not exceed 100");
+  }
+  if (config.baseDelayMs <= 0) {
+    throw new Error("baseDelayMs must be greater than 0");
+  }
+  if (config.maxDelayMs < config.baseDelayMs) {
+    throw new Error("maxDelayMs must be >= baseDelayMs");
+  }
+  if (config.maxDelayMs > 100) {
+    throw new Error("maxDelayMs must not exceed 100");
+  }
+  if (config.jitterFactor < 0 || config.jitterFactor > 1) {
+    throw new Error("jitterFactor must be between 0.0 and 1.0");
+  }
+}
+
+function resolveRetryConfig(
+  constructorRetryConfig: Partial<OCCRetryConfig> | undefined,
+  callMaxRetries: number | undefined,
+): OCCRetryConfig {
+  const resolved: OCCRetryConfig = {
+    ...DEFAULT_CONFIG,
+    ...constructorRetryConfig,
+  };
+
+  if (callMaxRetries !== undefined) {
+    resolved.maxRetries = callMaxRetries;
+  }
+
+  validateRetryConfig(resolved);
+  return resolved;
+}
+
+function isOCCError(error: unknown): boolean {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+
+  const dbError = error as DatabaseError;
+  if (!dbError.code) {
+    return false;
+  }
+
+  return dbError.code === "OC000" || dbError.code === "OC001" || dbError.code === "40001";
+}
+
+function calculateBackoff(config: OCCRetryConfig, attempt: number): number {
+  const exponent = Math.min(attempt - 1, 31);
+  const delay = Math.min(config.baseDelayMs * Math.pow(2.0, exponent), config.maxDelayMs);
+  const jitter = delay * Math.random() * config.jitterFactor;
+  return delay + jitter;
+}
+
+async function executeWithRetry<T>(
+  executeCallback: () => Promise<T>,
+  config: OCCRetryConfig,
+  logger?: Logger,
+): Promise<T> {
+  if (config.maxRetries <= 0) {
+    return executeCallback();
+  }
+
+  let lastError: Error | undefined;
+
+  for (let attempt = 1; attempt <= config.maxRetries + 1; attempt++) {
+    try {
+      return await executeCallback();
+    } catch (error) {
+      if (!isOCCError(error)) {
+        throw error;
+      }
+
+      lastError = error as Error;
+
+      if (attempt <= config.maxRetries) {
+        const delay = calculateBackoff(config, attempt);
+        logger?.debug?.(
+          `OCC conflict on attempt ${attempt}/${config.maxRetries + 1}, retrying in ${delay.toFixed(1)}ms`,
+        );
+
+        await new Promise<void>((resolve) => setTimeout(resolve, delay));
+      }
+    }
+  }
+
+  logger?.error(`OCC retry exhausted after ${config.maxRetries + 1} attempts`);
+  throw lastError!;
+}
+
+export { Logger, OCCRetryConfig, resolveRetryConfig, executeWithRetry, isOCCError };
+

--- a/node/node-postgres/test/integration/dsql.integration.test.ts
+++ b/node/node-postgres/test/integration/dsql.integration.test.ts
@@ -125,7 +125,6 @@ describe("DSQL Integration Tests", () => {
       await verifySuccessfulConnection(client);
     });
 
-    // Verifies the provider takes precedence over any other credentials source.
     test("should fail with invalid custom credentials provider", async () => {
       const invalidProvider = async () => ({
         accessKeyId: "INVALID_ACCESS_KEY",
@@ -141,7 +140,6 @@ describe("DSQL Integration Tests", () => {
       await expect(client.connect()).rejects.toThrow();
     });
 
-    // Verifies the identity takes precedence over any other credentials source.
     test("should fail with invalid custom credentials identity", async () => {
       const client = new AuroraDSQLClient({
         host: clusterEndpoint,
@@ -233,7 +231,6 @@ describe("DSQL Integration Tests", () => {
       }
     });
 
-    // Verifies the provider takes precedence over any other credentials source.
     test("should fail with invalid custom credentials provider", async () => {
       const invalidProvider = async () => ({
         accessKeyId: "INVALID_ACCESS_KEY",
@@ -249,7 +246,6 @@ describe("DSQL Integration Tests", () => {
       await expect(pool.query("SELECT 1")).rejects.toThrow();
     });
 
-    // Verifies the identity takes precedence over any other credentials source.
     test("should fail with invalid custom credentials identity", async () => {
       const pool = new AuroraDSQLPool({
         host: clusterEndpoint,
@@ -299,6 +295,114 @@ describe("DSQL Integration Tests", () => {
         expect(appName).toBeTruthy();
         expect(appName).toMatch(/^prisma:aurora-dsql-nodejs-pg\/\d+\.\d+\.\d+/);
         console.log(`Application name with ORM prefix: ${appName}`);
+      } finally {
+        await client.end();
+      }
+    });
+  });
+
+  describe("OCC Retry", () => {
+    test("should retry OCC conflicts with Client", async () => {
+      const logger = {
+        warn: (msg: string) => console.log(`[client] ${msg}`),
+        error: (msg: string) => console.error(`[client] ${msg}`),
+      };
+
+      const client1 = new AuroraDSQLClient({
+        host: clusterEndpoint,
+        user: "admin",
+        retry: { maxRetries: 5 },
+        logger,
+      });
+
+      const client2 = new AuroraDSQLClient({
+        host: clusterEndpoint,
+        user: "admin",
+        retry: { maxRetries: 5 },
+        logger,
+      });
+
+      try {
+        await client1.connect();
+        await client2.connect();
+        await client1.query("CREATE TABLE IF NOT EXISTS occ_test_client (id INT PRIMARY KEY, value INT)");
+        await client1.query("INSERT INTO occ_test_client (id, value) VALUES (1, 0) ON CONFLICT (id) DO UPDATE SET value = 0");
+
+        const updatePromises = [
+          client1.transaction(async (c) => {
+            const result = await c.query("SELECT value FROM occ_test_client WHERE id = 1");
+            const currentValue = result.rows[0].value;
+            await c.query("UPDATE occ_test_client SET value = $1 WHERE id = 1", [currentValue + 1]);
+          }),
+          client2.transaction(async (c) => {
+            const result = await c.query("SELECT value FROM occ_test_client WHERE id = 1");
+            const currentValue = result.rows[0].value;
+            await c.query("UPDATE occ_test_client SET value = $1 WHERE id = 1", [currentValue + 1]);
+          }),
+        ];
+
+        await Promise.all(updatePromises);
+
+        const finalResult = await client1.query("SELECT value FROM occ_test_client WHERE id = 1");
+        expect(finalResult.rows[0].value).toBe(2);
+      } finally {
+        await client1.query("DROP TABLE IF EXISTS occ_test_client");
+        await client1.end();
+        await client2.end();
+      }
+    });
+
+    test("should retry OCC conflicts with Pool", async () => {
+      const logger = {
+        warn: (msg: string) => console.log(`[pool] ${msg}`),
+        error: (msg: string) => console.error(`[pool] ${msg}`),
+      };
+
+      const pool = new AuroraDSQLPool({
+        host: clusterEndpoint,
+        user: "admin",
+        max: 5,
+        retry: { maxRetries: 10 },
+        logger,
+      });
+
+      try {
+        await pool.query("CREATE TABLE IF NOT EXISTS occ_test_pool (id INT PRIMARY KEY, value INT)");
+        await pool.query("INSERT INTO occ_test_pool (id, value) VALUES (1, 0) ON CONFLICT (id) DO UPDATE SET value = 0");
+
+        const updatePromises = Array.from({ length: 10 }, () =>
+          pool.transaction(async (client) => {
+            const result = await client.query("SELECT value FROM occ_test_pool WHERE id = 1");
+            const currentValue = result.rows[0].value;
+            await client.query("UPDATE occ_test_pool SET value = $1 WHERE id = 1", [currentValue + 1]);
+          })
+        );
+
+        await Promise.all(updatePromises);
+
+        const finalResult = await pool.query("SELECT value FROM occ_test_pool WHERE id = 1");
+        expect(finalResult.rows[0].value).toBe(10);
+      } finally {
+        await pool.query("DROP TABLE IF EXISTS occ_test_pool");
+        await pool.end();
+      }
+    });
+
+    test("should not retry non-OCC errors", async () => {
+      const client = new AuroraDSQLClient({
+        host: clusterEndpoint,
+        user: "admin",
+        retry: { maxRetries: 3 },
+      });
+
+      try {
+        await client.connect();
+
+        await expect(
+          client.transaction(async (c) => {
+            await c.query("SELECT * FROM nonexistent_table");
+          })
+        ).rejects.toThrow();
       } finally {
         await client.end();
       }

--- a/node/node-postgres/test/occ-retry.test.ts
+++ b/node/node-postgres/test/occ-retry.test.ts
@@ -1,0 +1,418 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { AuroraDSQLPool } from "../src/aurora-dsql-pool";
+import { AuroraDSQLClient } from "../src/aurora-dsql-client";
+import { AuroraDSQLUtil } from "../src/aurora-dsql-util";
+import { Pool, Client } from "pg";
+
+jest.mock("pg");
+jest.mock("../src/aurora-dsql-util");
+
+const mockPool = Pool as jest.MockedClass<typeof Pool>;
+const mockClient = Client as jest.MockedClass<typeof Client>;
+const mockAuroraDSQLUtil = AuroraDSQLUtil as jest.Mocked<typeof AuroraDSQLUtil>;
+
+describe("OCC Retry", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAuroraDSQLUtil.parsePgConfig.mockImplementation((config) => ({
+      host: "example.dsql.us-east-1.on.aws",
+      user: "admin",
+      port: 5432,
+      database: "postgres",
+      region: "us-east-1",
+      profile: "default",
+      ssl: { rejectUnauthorized: true },
+      ...(typeof config === "string" ? {} : config),
+    }));
+    mockAuroraDSQLUtil.getDSQLToken.mockResolvedValue("mock-token");
+  });
+
+  describe("Pool.transaction", () => {
+    let pool: AuroraDSQLPool;
+    let mockPoolClient: any;
+
+    beforeEach(() => {
+      mockPoolClient = {
+        query: jest.fn().mockResolvedValue({ rows: [] }),
+        release: jest.fn(),
+      };
+      mockPool.prototype.connect = jest.fn().mockResolvedValue(mockPoolClient);
+
+      pool = new AuroraDSQLPool({
+        host: "example.dsql.us-east-1.on.aws",
+        user: "admin",
+        retry: { maxRetries: 3 },
+      });
+
+      (pool as any).options = {
+        host: "example.dsql.us-east-1.on.aws",
+        user: "admin",
+      };
+    });
+
+    it("should execute transaction successfully without retry", async () => {
+      const callback = jest.fn().mockResolvedValue("result");
+
+      const result = await pool.transaction(callback);
+
+      expect(result).toBe("result");
+      expect(callback).toHaveBeenCalledTimes(1);
+      expect(mockPoolClient.query).toHaveBeenCalledWith("BEGIN");
+      expect(mockPoolClient.query).toHaveBeenCalledWith("COMMIT");
+      expect(mockPoolClient.release).toHaveBeenCalledWith(false);
+    });
+
+    it("should retry on OC000 data conflict", async () => {
+      const occError = Object.assign(new Error("OCC"), { code: "OC000" });
+      const callback = jest.fn()
+        .mockRejectedValueOnce(occError)
+        .mockResolvedValue("success");
+
+      const result = await pool.transaction(callback);
+
+      expect(result).toBe("success");
+      expect(callback).toHaveBeenCalledTimes(2);
+    });
+
+    it("should retry on OC001 schema conflict", async () => {
+      const occError = Object.assign(new Error("OCC"), { code: "OC001" });
+      const callback = jest.fn()
+        .mockRejectedValueOnce(occError)
+        .mockResolvedValue("success");
+
+      const result = await pool.transaction(callback);
+
+      expect(result).toBe("success");
+      expect(callback).toHaveBeenCalledTimes(2);
+    });
+
+    it("should retry on 40001 serialization failure", async () => {
+      const occError = Object.assign(
+        new Error("serialization failure"),
+        { code: "40001" },
+      );
+      const callback = jest.fn()
+        .mockRejectedValueOnce(occError)
+        .mockResolvedValue("success");
+
+      const result = await pool.transaction(callback);
+
+      expect(result).toBe("success");
+      expect(callback).toHaveBeenCalledTimes(2);
+    });
+
+    it("should not retry non-OCC errors", async () => {
+      const genericError = new Error("syntax error");
+      const callback = jest.fn().mockRejectedValue(genericError);
+
+      await expect(pool.transaction(callback)).rejects.toThrow("syntax error");
+      expect(callback).toHaveBeenCalledTimes(1);
+    });
+
+    it("should throw after max retries exhausted", async () => {
+      const occError = Object.assign(new Error("OCC"), { code: "OC000" });
+      const callback = jest.fn().mockRejectedValue(occError);
+
+      await expect(pool.transaction(callback)).rejects.toThrow("OCC");
+      // 3 retries + 1 initial = 4 total attempts
+      expect(callback).toHaveBeenCalledTimes(4);
+    });
+
+    it("should not retry when maxRetries is 0", async () => {
+      const occError = Object.assign(new Error("OCC"), { code: "OC000" });
+      const callback = jest.fn().mockRejectedValue(occError);
+
+      await expect(pool.transaction(callback, { maxRetries: 0 })).rejects.toThrow("OCC");
+      expect(callback).toHaveBeenCalledTimes(1);
+    });
+
+    it("should override constructor config with per-call maxRetries", async () => {
+      const occError = Object.assign(new Error("OCC"), { code: "OC000" });
+      const callback = jest.fn().mockRejectedValue(occError);
+
+      await expect(pool.transaction(callback, { maxRetries: 5 })).rejects.toThrow("OCC");
+      // 5 retries + 1 initial = 6 total attempts
+      expect(callback).toHaveBeenCalledTimes(6);
+    });
+
+    it("should release pool client after each attempt", async () => {
+      const occError = Object.assign(new Error("OCC"), { code: "OC000" });
+      const callback = jest.fn()
+        .mockRejectedValueOnce(occError)
+        .mockResolvedValue("success");
+
+      await pool.transaction(callback);
+
+      expect(mockPoolClient.release).toHaveBeenCalledTimes(2);
+      expect(mockPoolClient.release).toHaveBeenCalledWith(false);
+    });
+
+    it("should rollback on error before retrying", async () => {
+      const occError = Object.assign(new Error("OCC"), { code: "OC000" });
+      const callback = jest.fn()
+        .mockRejectedValueOnce(occError)
+        .mockResolvedValue("success");
+
+      await pool.transaction(callback);
+
+      expect(mockPoolClient.query).toHaveBeenCalledWith("ROLLBACK");
+    });
+
+    it("should still retry and release client when ROLLBACK fails", async () => {
+      const occError = Object.assign(new Error("OCC"), { code: "OC000" });
+      mockPoolClient.query = jest.fn().mockImplementation((sql: string) => {
+        if (sql === "ROLLBACK") return Promise.reject(new Error("connection lost"));
+        return Promise.resolve({ rows: [] });
+      });
+      const callback = jest.fn()
+        .mockRejectedValueOnce(occError)
+        .mockResolvedValue("success");
+
+      const result = await pool.transaction(callback);
+
+      expect(result).toBe("success");
+      expect(callback).toHaveBeenCalledTimes(2);
+      expect(mockPoolClient.release).toHaveBeenCalledTimes(2);
+      expect(mockPoolClient.release).toHaveBeenNthCalledWith(1, true);
+      expect(mockPoolClient.release).toHaveBeenNthCalledWith(2, false);
+    });
+
+  });
+
+  describe("Client.transaction", () => {
+    let client: AuroraDSQLClient;
+    let mockQuery: jest.Mock;
+
+    beforeEach(() => {
+      mockQuery = jest.fn().mockResolvedValue({ rows: [] });
+      mockClient.prototype.query = mockQuery;
+      mockClient.prototype.connect = jest.fn().mockResolvedValue(undefined);
+
+      client = new AuroraDSQLClient({
+        host: "example.dsql.us-east-1.on.aws",
+        user: "admin",
+        retry: { maxRetries: 3 },
+      });
+    });
+
+    it("should execute transaction successfully without retry", async () => {
+      const callback = jest.fn().mockResolvedValue("result");
+
+      const result = await client.transaction(callback);
+
+      expect(result).toBe("result");
+      expect(callback).toHaveBeenCalledTimes(1);
+      expect(mockQuery).toHaveBeenCalledWith("BEGIN");
+      expect(mockQuery).toHaveBeenCalledWith("COMMIT");
+    });
+
+    it("should retry on OC000 data conflict", async () => {
+      const occError = Object.assign(new Error("OCC"), { code: "OC000" });
+      const callback = jest.fn()
+        .mockRejectedValueOnce(occError)
+        .mockResolvedValue("success");
+
+      const result = await client.transaction(callback);
+
+      expect(result).toBe("success");
+      expect(callback).toHaveBeenCalledTimes(2);
+    });
+
+    it("should retry on OC001 schema conflict", async () => {
+      const occError = Object.assign(new Error("OCC"), { code: "OC001" });
+      const callback = jest.fn()
+        .mockRejectedValueOnce(occError)
+        .mockResolvedValue("success");
+
+      const result = await client.transaction(callback);
+
+      expect(result).toBe("success");
+      expect(callback).toHaveBeenCalledTimes(2);
+    });
+
+    it("should not retry non-OCC errors", async () => {
+      const genericError = new Error("syntax error");
+      const callback = jest.fn().mockRejectedValue(genericError);
+
+      await expect(client.transaction(callback)).rejects.toThrow("syntax error");
+      expect(callback).toHaveBeenCalledTimes(1);
+    });
+
+    it("should throw after max retries exhausted", async () => {
+      const occError = Object.assign(new Error("OCC"), { code: "OC000" });
+      const callback = jest.fn().mockRejectedValue(occError);
+
+      await expect(client.transaction(callback)).rejects.toThrow("OCC");
+      // 3 retries + 1 initial = 4 total attempts
+      expect(callback).toHaveBeenCalledTimes(4);
+    });
+
+    it("should not retry when maxRetries is 0", async () => {
+      const occError = Object.assign(new Error("OCC"), { code: "OC000" });
+      const callback = jest.fn().mockRejectedValue(occError);
+
+      await expect(client.transaction(callback, { maxRetries: 0 })).rejects.toThrow("OCC");
+      expect(callback).toHaveBeenCalledTimes(1);
+    });
+
+    it("should override constructor config with per-call maxRetries", async () => {
+      const occError = Object.assign(new Error("OCC"), { code: "OC000" });
+      const callback = jest.fn().mockRejectedValue(occError);
+
+      await expect(client.transaction(callback, { maxRetries: 5 })).rejects.toThrow("OCC");
+      // 5 retries + 1 initial = 6 total attempts
+      expect(callback).toHaveBeenCalledTimes(6);
+    });
+
+    it("should rollback on error before retrying", async () => {
+      const occError = Object.assign(new Error("OCC"), { code: "OC000" });
+      const callback = jest.fn()
+        .mockRejectedValueOnce(occError)
+        .mockResolvedValue("success");
+
+      await client.transaction(callback);
+
+      expect(mockQuery).toHaveBeenCalledWith("ROLLBACK");
+    });
+  });
+
+  describe("retry config resolution", () => {
+    it("should use default 3 retries when no retry config set", async () => {
+      const mockPoolClient: any = {
+        query: jest.fn().mockResolvedValue({ rows: [] }),
+        release: jest.fn(),
+      };
+      mockPool.prototype.connect = jest.fn().mockResolvedValue(mockPoolClient);
+
+      const pool = new AuroraDSQLPool({
+        host: "example.dsql.us-east-1.on.aws",
+        user: "admin",
+      });
+
+      (pool as any).options = {
+        host: "example.dsql.us-east-1.on.aws",
+        user: "admin",
+      };
+
+      const occError = Object.assign(new Error("OCC"), { code: "OC000" });
+      const callback = jest.fn().mockRejectedValue(occError);
+
+      await expect(pool.transaction(callback)).rejects.toThrow("OCC");
+      // default 3 retries + 1 initial = 4 total attempts
+      expect(callback).toHaveBeenCalledTimes(4);
+    });
+
+    it("should use custom retry config from constructor", async () => {
+      const mockPoolClient: any = {
+        query: jest.fn().mockResolvedValue({ rows: [] }),
+        release: jest.fn(),
+      };
+      mockPool.prototype.connect = jest.fn().mockResolvedValue(mockPoolClient);
+
+      const pool = new AuroraDSQLPool({
+        host: "example.dsql.us-east-1.on.aws",
+        user: "admin",
+        retry: { maxRetries: 5, baseDelayMs: 10, maxDelayMs: 50 },
+      });
+
+      (pool as any).options = {
+        host: "example.dsql.us-east-1.on.aws",
+        user: "admin",
+      };
+
+      const occError = Object.assign(new Error("OCC"), { code: "OC000" });
+      const callback = jest.fn().mockRejectedValue(occError);
+
+      await expect(pool.transaction(callback)).rejects.toThrow("OCC");
+      // 5 retries + 1 initial = 6 total attempts
+      expect(callback).toHaveBeenCalledTimes(6);
+    });
+
+    it("should merge partial retry config with defaults", async () => {
+      const mockPoolClient: any = {
+        query: jest.fn().mockResolvedValue({ rows: [] }),
+        release: jest.fn(),
+      };
+      mockPool.prototype.connect = jest.fn().mockResolvedValue(mockPoolClient);
+
+      const pool = new AuroraDSQLPool({
+        host: "example.dsql.us-east-1.on.aws",
+        user: "admin",
+        retry: { maxRetries: 2 },
+      });
+
+      (pool as any).options = {
+        host: "example.dsql.us-east-1.on.aws",
+        user: "admin",
+      };
+
+      const occError = Object.assign(new Error("OCC"), { code: "OC000" });
+      const callback = jest.fn().mockRejectedValue(occError);
+
+      await expect(pool.transaction(callback)).rejects.toThrow("OCC");
+      // 2 retries + 1 initial = 3 total attempts
+      expect(callback).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe("retry config validation", () => {
+    it("should reject negative maxRetries at construction", () => {
+      expect(() => new AuroraDSQLPool({
+        host: "example.dsql.us-east-1.on.aws",
+        user: "admin",
+        retry: { maxRetries: -1 },
+      })).toThrow("maxRetries must be >= 0");
+    });
+
+    it("should reject baseDelayMs <= 0 at construction", () => {
+      expect(() => new AuroraDSQLPool({
+        host: "example.dsql.us-east-1.on.aws",
+        user: "admin",
+        retry: { baseDelayMs: 0 },
+      })).toThrow("baseDelayMs must be greater than 0");
+    });
+
+    it("should reject maxDelayMs < baseDelayMs at construction", () => {
+      expect(() => new AuroraDSQLPool({
+        host: "example.dsql.us-east-1.on.aws",
+        user: "admin",
+        retry: { baseDelayMs: 100, maxDelayMs: 10 },
+      })).toThrow("maxDelayMs must be >= baseDelayMs");
+    });
+
+    it("should reject jitterFactor < 0 at construction", () => {
+      expect(() => new AuroraDSQLPool({
+        host: "example.dsql.us-east-1.on.aws",
+        user: "admin",
+        retry: { jitterFactor: -0.5 },
+      })).toThrow("jitterFactor must be between 0.0 and 1.0");
+    });
+
+    it("should reject jitterFactor > 1 at construction", () => {
+      expect(() => new AuroraDSQLPool({
+        host: "example.dsql.us-east-1.on.aws",
+        user: "admin",
+        retry: { jitterFactor: 1.5 },
+      })).toThrow("jitterFactor must be between 0.0 and 1.0");
+    });
+
+    it("should reject maxRetries > 100 at construction", () => {
+      expect(() => new AuroraDSQLPool({
+        host: "example.dsql.us-east-1.on.aws",
+        user: "admin",
+        retry: { maxRetries: 101 },
+      })).toThrow("maxRetries must not exceed 100");
+    });
+
+    it("should reject maxDelayMs > 100 at construction", () => {
+      expect(() => new AuroraDSQLPool({
+        host: "example.dsql.us-east-1.on.aws",
+        user: "admin",
+        retry: { maxDelayMs: 101 },
+      })).toThrow("maxDelayMs must not exceed 100");
+    });
+  });
+});


### PR DESCRIPTION
Adds a transaction() method to Pool and Client that automatically retries failed transactions caused by OCC conflicts. Uses exponential backoff with jitter. Retry behavior is configurable at construction and per-call. Includes unit tests, integration tests, and documentation updates. 

*Issue #, if available:*
N/A

*Description of changes:*
- New `occ-retry.ts` module with retry engine (`isOCCError`, `calculateBackoff`, `executeWithRetry`, config validation)
- `transaction()` on `AuroraDSQLPool` and `AuroraDSQLClient` with OCC retry (OC000, OC001, 40001)
- Exponential backoff with jitter matching Rust connector defaults (3 retries, 1ms base, 100ms max, 0.25 jitter)
- `retry: Partial<OCCRetryConfig>` on constructor, per-call `maxRetries` override
- Opt-in `Logger` interface for retry observability
- Pool acquires fresh connection per attempt (IAM token refresh)
- Concurrent OCC integration tests
- README and example updates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
