### PR TITLE
fix(ci): add changelog permissions to release workflows

### DIFF
--- a/.github/workflows/node-postgres-release.yml
+++ b/.github/workflows/node-postgres-release.yml
@@ -52,6 +52,9 @@ jobs:
 
   update-changelog:
     needs: publish
+    permissions:
+      contents: write
+      pull-requests: write
     uses: ./.github/workflows/update-changelog.yml
     with:
       tag: ${{ github.ref_name }}

--- a/.github/workflows/postgres-js-release.yml
+++ b/.github/workflows/postgres-js-release.yml
@@ -52,6 +52,9 @@ jobs:
 
   update-changelog:
     needs: publish
+    permissions:
+      contents: write
+      pull-requests: write
     uses: ./.github/workflows/update-changelog.yml
     with:
       tag: ${{ github.ref_name }}

--- a/.github/workflows/python-connector-release.yml
+++ b/.github/workflows/python-connector-release.yml
@@ -66,6 +66,9 @@ jobs:
 
   update-changelog:
     needs: publish-to-pypi
+    permissions:
+      contents: write
+      pull-requests: write
     uses: ./.github/workflows/update-changelog.yml
     with:
       tag: ${{ github.ref_name }}


### PR DESCRIPTION
## Summary
- The `update-changelog` reusable workflow requires `contents: write` and `pull-requests: write`
- Three release workflows had top-level `permissions: {}` but never granted these to the `update-changelog` job
- GitHub rejects the entire workflow at parse time, preventing even the publish job from running

## Affected workflows
- `node-postgres-release.yml`
- `postgres-js-release.yml`
- `python-connector-release.yml`

## Test plan
- [x] Verified other release workflows (dotnet, go, java, ruby, rust) already have this fix
- [ ] Trigger a release after merge to confirm the workflow passes