### PR TITLE
feat(node-postgres): support full retry config override per call

### DIFF
--- a/node/node-postgres/src/aurora-dsql-client.ts
+++ b/node/node-postgres/src/aurora-dsql-client.ts
@@ -5,7 +5,7 @@
 import { Client } from "pg";
 import { AuroraDSQLConfig } from "./config/aurora-dsql-config.js";
 import { AuroraDSQLUtil } from "./aurora-dsql-util.js";
-import { resolveRetryConfig, executeWithRetry } from "./occ-retry.js";
+import { resolveRetryConfig, executeWithRetry, type OCCRetryConfig } from "./occ-retry.js";
 
 class AuroraDSQLClient extends Client {
   private dsqlConfig?: AuroraDSQLConfig;
@@ -63,9 +63,9 @@ class AuroraDSQLClient extends Client {
    */
   async transaction<T>(
     callback: (client: this) => Promise<T>,
-    options?: { maxRetries?: number },
+    options?: Partial<OCCRetryConfig>,
   ): Promise<T> {
-    const retryConfig = resolveRetryConfig(this.dsqlConfig?.retry, options?.maxRetries);
+    const retryConfig = resolveRetryConfig(this.dsqlConfig?.retry, options);
 
     return executeWithRetry(async () => {
       await this.query("BEGIN");

--- a/node/node-postgres/src/aurora-dsql-pool.ts
+++ b/node/node-postgres/src/aurora-dsql-pool.ts
@@ -5,7 +5,7 @@
 import { Pool, PoolClient } from "pg";
 import { AuroraDSQLPoolConfig } from "./config/aurora-dsql-pool-config.js";
 import { AuroraDSQLUtil } from "./aurora-dsql-util.js";
-import { resolveRetryConfig, executeWithRetry } from "./occ-retry.js";
+import { resolveRetryConfig, executeWithRetry, type OCCRetryConfig } from "./occ-retry.js";
 
 class AuroraDSQLPool extends Pool {
   private dsqlConfig?: AuroraDSQLPoolConfig;
@@ -76,9 +76,9 @@ class AuroraDSQLPool extends Pool {
    */
   async transaction<T>(
     callback: (client: PoolClient) => Promise<T>,
-    options?: { maxRetries?: number },
+    options?: Partial<OCCRetryConfig>,
   ): Promise<T> {
-    const retryConfig = resolveRetryConfig(this.dsqlConfig?.retry, options?.maxRetries);
+    const retryConfig = resolveRetryConfig(this.dsqlConfig?.retry, options);
 
     return executeWithRetry(async () => {
       const client = await this.connect();

--- a/node/node-postgres/src/occ-retry.ts
+++ b/node/node-postgres/src/occ-retry.ts
@@ -54,17 +54,14 @@ function validateRetryConfig(config: OCCRetryConfig): void {
 }
 
 function resolveRetryConfig(
-  constructorRetryConfig: Partial<OCCRetryConfig> | undefined,
-  callMaxRetries: number | undefined,
+  retryConfig: Partial<OCCRetryConfig> | undefined,
+  overrideConfig: Partial<OCCRetryConfig> | undefined,
 ): OCCRetryConfig {
   const resolved: OCCRetryConfig = {
     ...DEFAULT_CONFIG,
-    ...constructorRetryConfig,
+    ...retryConfig,
+    ...overrideConfig,
   };
-
-  if (callMaxRetries !== undefined) {
-    resolved.maxRetries = callMaxRetries;
-  }
 
   validateRetryConfig(resolved);
   return resolved;


### PR DESCRIPTION
## Summary
- Allow `transaction()` to accept any `Partial<OCCRetryConfig>` fields as the second argument, not just `maxRetries`
- Enables per-call tuning of `baseDelayMs`, `maxDelayMs`, and `jitterFactor`
- Merge order: defaults → constructor config → per-call config

### Usage
```typescript
await pool.transaction(callback, { maxRetries: 10, baseDelayMs: 5 });
```

## Test plan
- [x] All 99 unit tests and 22 integration tests passed
- [x] TypeScript compiles cleanly