### PR TITLE
fix(rust): disable aws-sdk-dsql default features to drop legacy rustls 0.21

### DIFF
--- a/rust/sqlx/Cargo.toml
+++ b/rust/sqlx/Cargo.toml
@@ -19,7 +19,7 @@ occ = ["dep:rand", "dep:tokio", "tokio/time", "dep:async-trait"]
 [dependencies]
 sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "tls-rustls-ring"] }
 aws-config = { version = "1.8", features = ["credentials-login"] }
-aws-sdk-dsql = "1.0"
+aws-sdk-dsql = { version = "1.0", default-features = false }
 aws-credential-types = "1"
 tokio = { version = "1", optional = true }
 thiserror = "2.0"


### PR DESCRIPTION
## Summary

`aws-sdk-dsql`'s default features include `rustls`, which activates `aws-smithy-runtime/tls-rustls` and pulls the legacy stack — `hyper-rustls 0.24` and `rustls 0.21` — into the dep graph. The older `rustls-webpki 0.101.7` it transitively depends on is the subject of [GHSA-82j2-j2ch-gfr8](https://github.com/advisories/GHSA-82j2-j2ch-gfr8).

Discussion: [smithy-lang/smithy-rs#4651](https://github.com/smithy-lang/smithy-rs/issues/4651). The smithy-rs maintainers' recommended mitigation for downstream crates is `default-features = false` on AWS SDK crates and only enabling what's actually needed.

This connector imports only `aws_sdk_dsql::auth_token` (`AuthTokenGenerator`, `Config`) for request signing — see `src/token.rs` and `src/pool.rs`. The SDK HTTP client and TLS features are never touched at runtime, so disabling defaults is safe and surgical.

After this change, `cargo tree --all-features` no longer lists `rustls 0.21`, `rustls-webpki 0.101`, `hyper-rustls 0.24`, or `tokio-rustls 0.24`.

## Test plan

- [x] `cargo build --all-features` — clean build
- [x] `cargo test --all-features --lib` — all 67 unit tests pass
- [x] `cargo tree --all-features | grep -E "rustls 0\.21|rustls-webpki 0\.101|hyper-rustls 0\.24"` — no matches
