### PR TITLE
fix(pgjdbc): use PreparedStatement in example code

### DIFF
--- a/java/jdbc/examples/pgjdbc/src/main/java/software/amazon/dsql/examples/ExamplePreferred.java
+++ b/java/jdbc/examples/pgjdbc/src/main/java/software/amazon/dsql/examples/ExamplePreferred.java
@@ -9,6 +9,7 @@ import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 
 import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -83,35 +84,39 @@ public class ExamplePreferred {
 
     private void executeExample(Connection conn, int connectionNumber) throws SQLException {
         // Create a new table named owner
-        Statement create = conn.createStatement();
-        create.executeUpdate("""
-                CREATE TABLE IF NOT EXISTS owner(
-                id uuid NOT NULL DEFAULT gen_random_uuid(),
-                name varchar(30) NOT NULL,
-                city varchar(80) NOT NULL,
-                telephone varchar(20) DEFAULT NULL,
-                PRIMARY KEY (id))""");
-        create.close();
+        try (Statement create = conn.createStatement()) {
+            create.executeUpdate("""
+                    CREATE TABLE IF NOT EXISTS owner(
+                    id uuid NOT NULL DEFAULT gen_random_uuid(),
+                    name varchar(30) NOT NULL,
+                    city varchar(80) NOT NULL,
+                    telephone varchar(20) DEFAULT NULL,
+                    PRIMARY KEY (id))""");
+        }
 
         // Insert some data with a unique identifier
         String uniqueName = "John Doe " + System.currentTimeMillis() + "_" + connectionNumber;
-        Statement insert = conn.createStatement();
-        insert.executeUpdate(
-                "INSERT INTO owner (name, city, telephone) VALUES ('" + uniqueName + "', 'Anytown', '555-555-1991')");
-        insert.close();
+        try (PreparedStatement insert = conn.prepareStatement(
+                "INSERT INTO owner (name, city, telephone) VALUES (?, ?, ?)")) {
+            insert.setString(1, uniqueName);
+            insert.setString(2, "Anytown");
+            insert.setString(3, "555-555-1991");
+            insert.executeUpdate();
+        }
 
         // Read back the data and verify
-        String selectSQL = "SELECT * FROM owner WHERE name = '" + uniqueName + "'";
-        Statement read = conn.createStatement();
-        ResultSet rs = read.executeQuery(selectSQL);
-        while (rs.next()) {
-            assert rs.getString("id") != null;
-            assert rs.getString("name").equals(uniqueName);
-            assert rs.getString("city").equals("Anytown");
-            assert rs.getString("telephone").equals("555-555-1991");
-            System.out.println("Data verified: " + rs.getString("name") + " from " + rs.getString("city"));
+        try (PreparedStatement read = conn.prepareStatement("SELECT * FROM owner WHERE name = ?")) {
+            read.setString(1, uniqueName);
+            try (ResultSet rs = read.executeQuery()) {
+                while (rs.next()) {
+                    assert rs.getString("id") != null;
+                    assert rs.getString("name").equals(uniqueName);
+                    assert rs.getString("city").equals("Anytown");
+                    assert rs.getString("telephone").equals("555-555-1991");
+                    System.out.println("Data verified: " + rs.getString("name") + " from " + rs.getString("city"));
+                }
+            }
         }
-        read.close();
     }
 
     public static void main(String[] args) throws SQLException {
@@ -148,10 +153,10 @@ public class ExamplePreferred {
                 example.executeExample(conn3, 3);
             }
 
-            try (Connection conn = example.getConnection()) {
-                Statement cleanup = conn.createStatement();
-                int deletedRows = cleanup.executeUpdate("DELETE FROM owner WHERE name LIKE '%John Doe%'");
-                cleanup.close();
+            try (Connection conn = example.getConnection();
+                 PreparedStatement cleanup = conn.prepareStatement("DELETE FROM owner WHERE name LIKE ?")) {
+                cleanup.setString(1, "%John Doe%");
+                int deletedRows = cleanup.executeUpdate();
 
                 System.out.println("Cleaned up " + deletedRows + " test records");
             }

--- a/java/jdbc/examples/pgjdbc/src/main/java/software/amazon/dsql/examples/alternatives/no_connection_pool/ExampleWithNoConnectionPool.java
+++ b/java/jdbc/examples/pgjdbc/src/main/java/software/amazon/dsql/examples/alternatives/no_connection_pool/ExampleWithNoConnectionPool.java
@@ -8,6 +8,7 @@ package software.amazon.dsql.examples.alternatives.no_connection_pool;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -37,43 +38,48 @@ public class ExampleWithNoConnectionPool {
 
         try (Connection conn = ExampleWithNoConnectionPool.getConnection(clusterEndpoint, clusterUser)) {
             if (!clusterUser.equals("admin")) {
-                Statement setSchema = conn.createStatement();
-                setSchema.execute("SET search_path=myschema");
-                setSchema.close();
+                try (Statement setSchema = conn.createStatement()) {
+                    setSchema.execute("SET search_path=myschema");
+                }
             }
             // Create a new table named owner
-            Statement create = conn.createStatement();
-            create.executeUpdate("""
-                    CREATE TABLE IF NOT EXISTS owner(
-                    id uuid NOT NULL DEFAULT gen_random_uuid(),
-                    name varchar(30) NOT NULL,
-                    city varchar(80) NOT NULL,
-                    telephone varchar(20) DEFAULT NULL,
-                    PRIMARY KEY (id))""");
-            create.close();
+            try (Statement create = conn.createStatement()) {
+                create.executeUpdate("""
+                        CREATE TABLE IF NOT EXISTS owner(
+                        id uuid NOT NULL DEFAULT gen_random_uuid(),
+                        name varchar(30) NOT NULL,
+                        city varchar(80) NOT NULL,
+                        telephone varchar(20) DEFAULT NULL,
+                        PRIMARY KEY (id))""");
+            }
 
             // Insert some data
-            Statement insert = conn.createStatement();
-            insert.executeUpdate(
-                    "INSERT INTO owner (name, city, telephone) VALUES ('John Doe', 'Anytown', '555-555-1999')");
-            insert.close();
+            try (PreparedStatement insert = conn.prepareStatement(
+                    "INSERT INTO owner (name, city, telephone) VALUES (?, ?, ?)")) {
+                insert.setString(1, "John Doe");
+                insert.setString(2, "Anytown");
+                insert.setString(3, "555-555-1999");
+                insert.executeUpdate();
+            }
 
             // Read back the data and assert they are present
-            String selectSQL = "SELECT * FROM owner";
-            Statement read = conn.createStatement();
-            ResultSet rs = read.executeQuery(selectSQL);
-            while (rs.next()) {
-                assert rs.getString("id") != null;
-                assert rs.getString("name").equals("John Doe");
-                assert rs.getString("city").equals("Anytown");
-                assert rs.getString("telephone").equals("555-555-1999");
+            try (PreparedStatement read = conn.prepareStatement("SELECT * FROM owner WHERE name = ?")) {
+                read.setString(1, "John Doe");
+                try (ResultSet rs = read.executeQuery()) {
+                    while (rs.next()) {
+                        assert rs.getString("id") != null;
+                        assert rs.getString("name").equals("John Doe");
+                        assert rs.getString("city").equals("Anytown");
+                        assert rs.getString("telephone").equals("555-555-1999");
+                    }
+                }
             }
 
             // Delete some data
-            String deleteSql = String.format("DELETE FROM owner where name='John Doe'");
-            Statement delete = conn.createStatement();
-            delete.executeUpdate(deleteSql);
-            delete.close();
+            try (PreparedStatement delete = conn.prepareStatement("DELETE FROM owner WHERE name = ?")) {
+                delete.setString(1, "John Doe");
+                delete.executeUpdate();
+            }
         }
         System.out.println("Connection exercised successfully");
     }


### PR DESCRIPTION
## Summary
- Replace string concatenation with `PreparedStatement` parameterized queries in `ExamplePreferred.java` and `ExampleWithNoConnectionPool.java`
- Addresses a security finding flagging SQL injection patterns in sample code that developers copy into production

## Changes
- **ExamplePreferred.java**: Converted INSERT, SELECT, and DELETE from `Statement` + string concat to `PreparedStatement` with bind parameters
- **ExampleWithNoConnectionPool.java**: Converted INSERT, SELECT, and DELETE from `Statement`/`String.format` to `PreparedStatement` with bind parameters; added missing `read.close()`

## Notes
- DDL statements (`CREATE TABLE`, `SET search_path`) remain as `Statement` since they contain no dynamic data

## Test plan
- [x] `compileJava` and `compileTestJava` pass
- [x] Tests pass against live DSQL cluster
- [x] `../../gradlew run` executes successfully


*Issue #, if available:*
N/A

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.