### PR TITLE
feat(python): add OCC retry with exponential backoff

### DIFF
--- a/python/connector/README.md
+++ b/python/connector/README.md
@@ -39,6 +39,7 @@ The Aurora DSQL Connector for Python is designed to understand these requirement
 - **Region Auto-Discovery** - Extracts AWS region from DSQL cluster hostname
 - **AWS Credentials Support** - Supports various AWS credential providers (default, profile-based, custom)
 - **Connection Pooling Compatibility** - Works with psycopg, psycopg2, and asyncpg built-in connection pooling
+- **OCC Retry** - Built-in retry with exponential backoff for optimistic concurrency control (OCC) conflicts
 
 ## Quick start guide
 
@@ -412,6 +413,99 @@ For asyncpg, the connector provides a create_pool function that returns an insta
 ```
 
 
+
+### OCC Retry
+
+Aurora DSQL uses optimistic concurrency control (OCC). When concurrent transactions conflict, the database returns an OCC error (sqlstate `OC000`, `OC001`, or `40001`). The connector provides built-in retry with exponential backoff via `run_transaction()`.
+
+#### Enabling OCC retry
+
+Pass `retry=True` for default settings, or provide an `OCCRetryConfig` for custom backoff:
+
+```python
+    import aurora_dsql_psycopg as dsql
+
+    # Default retry (3 retries, 1-100ms backoff, 0.25 jitter)
+    pool = dsql.create_pool(conninfo, retry=True, kwargs=conn_params)
+
+    # Custom retry config
+    pool = dsql.create_pool(
+        conninfo,
+        retry=dsql.OCCRetryConfig(max_retries=5, base_delay_ms=10, max_delay_ms=200),
+        kwargs=conn_params,
+    )
+```
+
+#### Using run_transaction
+
+##### psycopg
+
+```python
+    import aurora_dsql_psycopg as dsql
+
+    pool = dsql.create_pool(conninfo, retry=True, kwargs=conn_params)
+    with pool:
+        result = pool.run_transaction(lambda conn: conn.execute("INSERT INTO ..."))
+```
+
+##### psycopg (async)
+
+```python
+    import aurora_dsql_psycopg as dsql
+
+    pool = dsql.create_async_pool(conninfo, retry=True, kwargs=conn_params)
+    async with pool:
+        result = await pool.run_transaction(
+            lambda conn: conn.execute("INSERT INTO ...")
+        )
+```
+
+##### psycopg2
+
+```python
+    import aurora_dsql_psycopg2 as dsql
+
+    pool = dsql.AuroraDSQLThreadedConnectionPool(
+        minconn=2, maxconn=8, retry=True, **conn_params
+    )
+    with pool:
+        result = pool.run_transaction(lambda conn: conn.cursor().execute("INSERT INTO ..."))
+```
+
+##### asyncpg
+
+```python
+    import aurora_dsql_asyncpg as dsql
+
+    pool = await dsql.create_pool(retry=True, **conn_params)
+    result = await pool.run_transaction(
+        lambda conn: conn.execute("INSERT INTO ...")
+    )
+```
+
+#### Per-call retry override
+
+You can override the pool-level retry config on each `run_transaction()` call:
+
+```python
+    # Use a different config for this call
+    result = pool.run_transaction(
+        callback,
+        retry=dsql.OCCRetryConfig(max_retries=10, base_delay_ms=5),
+    )
+
+    # Disable retry for this call
+    result = pool.run_transaction(callback, retry=False)
+```
+
+#### OCCRetryConfig options
+
+| Option          | Type    | Default | Description                                           |
+|-----------------|---------|---------|-------------------------------------------------------|
+| `max_retries`   | `int`   | 3       | Additional attempts after the initial try (0-100)     |
+| `base_delay_ms` | `int`   | 1       | Initial backoff delay in milliseconds                 |
+| `max_delay_ms`  | `int`   | 100     | Maximum backoff delay cap in milliseconds             |
+| `jitter_factor` | `float` | 0.25    | Fraction of delay added as random jitter (0.0-1.0)    |
 
 ## Authentication
 

--- a/python/connector/aurora_dsql_asyncpg/__init__.py
+++ b/python/connector/aurora_dsql_asyncpg/__init__.py
@@ -2,8 +2,16 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from dsql_core._version import __version__
+from dsql_core.occ_retry import OCCRetryConfig, is_occ_error
 
 from .connector import connect
-from .pool import create_pool
+from .pool import AuroraDSQLPool, create_pool
 
-__all__ = ["connect", "create_pool", "__version__"]
+__all__ = [
+    "connect",
+    "create_pool",
+    "AuroraDSQLPool",
+    "OCCRetryConfig",
+    "is_occ_error",
+    "__version__",
+]

--- a/python/connector/aurora_dsql_asyncpg/pool.py
+++ b/python/connector/aurora_dsql_asyncpg/pool.py
@@ -1,16 +1,67 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+from typing import Any, TypeVar
 
 import asyncpg
 
+from dsql_core.occ_retry import OCCRetryConfig, _retry_async, resolve_retry_config
+
 from .connector import connect as dsql_connect
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+
+class AuroraDSQLPool(asyncpg.Pool):
+    """Aurora DSQL connection pool with OCC retry support."""
+
+    __slots__ = ("_retry",)
+
+    def __init__(self, *connect_args, retry: OCCRetryConfig | bool | None = None, **kwargs):
+        self._retry = retry
+        super().__init__(*connect_args, **kwargs)
+
+    async def run_transaction(
+        self,
+        callback: Callable[[asyncpg.Connection], Awaitable[T]],
+        *,
+        retry: OCCRetryConfig | bool | None = None,
+    ) -> T:
+        """Execute callback in a transaction with optional OCC retry."""
+        config = resolve_retry_config(self._retry, retry)
+
+        async def execute() -> T:
+            conn = await self.acquire()
+            try:
+                await conn.execute("BEGIN")
+                try:
+                    result = await callback(conn)
+                    await conn.execute("COMMIT")
+                    return result
+                except BaseException:
+                    try:
+                        await conn.execute("ROLLBACK")
+                    except Exception as e:
+                        logger.debug("Rollback failed: %s", e)
+                    raise
+            finally:
+                await self.release(conn)
+
+        if config is None:
+            return await execute()
+        return await _retry_async(execute, config)
 
 
 async def create_pool(
     dsn=None,
     *,
+    retry: OCCRetryConfig | bool | None = None,
     min_size=10,
     max_size=10,
     max_queries=50000,
@@ -22,14 +73,15 @@ async def create_pool(
     connection_class=asyncpg.Connection,
     record_class=asyncpg.Record,
     **connect_kwargs: Any,
-):
+) -> AuroraDSQLPool:
     """Create Aurora DSQL connection pool with fresh token generation."""
 
     async def reset_connection(conn):
         await conn.execute("RESET ALL;")
 
-    pool = await asyncpg.create_pool(
+    return await AuroraDSQLPool(
         dsn,
+        retry=retry,
         min_size=min_size,
         max_size=max_size,
         max_queries=max_queries,
@@ -43,5 +95,3 @@ async def create_pool(
         record_class=record_class,
         **connect_kwargs,
     )
-
-    return pool

--- a/python/connector/aurora_dsql_psycopg/__init__.py
+++ b/python/connector/aurora_dsql_psycopg/__init__.py
@@ -2,8 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from dsql_core._version import __version__
+from dsql_core.occ_retry import OCCRetryConfig, is_occ_error
 
 from .connection_class import DSQLAsyncConnection, DSQLConnection
+from .pool import AuroraDSQLAsyncPool, AuroraDSQLPool, create_async_pool, create_pool
 
 # DBAPI compliance
 connect = DSQLConnection.connect
@@ -12,4 +14,15 @@ threadsafety = 2
 paramstyle = "pyformat"
 
 
-__all__ = ["connect", "DSQLConnection", "DSQLAsyncConnection", "__version__"]
+__all__ = [
+    "connect",
+    "DSQLConnection",
+    "DSQLAsyncConnection",
+    "AuroraDSQLPool",
+    "AuroraDSQLAsyncPool",
+    "create_pool",
+    "create_async_pool",
+    "OCCRetryConfig",
+    "is_occ_error",
+    "__version__",
+]

--- a/python/connector/aurora_dsql_psycopg/pool.py
+++ b/python/connector/aurora_dsql_psycopg/pool.py
@@ -1,0 +1,125 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+from typing import Any, TypeVar
+
+from psycopg import AsyncConnection, Connection
+from psycopg_pool import AsyncConnectionPool, ConnectionPool
+
+from dsql_core.occ_retry import OCCRetryConfig, _retry_async, _retry_sync, resolve_retry_config
+
+from .connection_class import DSQLAsyncConnection, DSQLConnection
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+
+class AuroraDSQLPool(ConnectionPool):
+    """Aurora DSQL connection pool with OCC retry support."""
+
+    def __init__(self, *args, retry: OCCRetryConfig | bool | None = None, **kwargs):
+        self._retry = retry
+        super().__init__(*args, **kwargs)
+
+    def run_transaction(
+        self,
+        callback: Callable[[Connection], T],
+        *,
+        retry: OCCRetryConfig | bool | None = None,
+    ) -> T:
+        """Execute callback in a transaction with optional OCC retry."""
+        config = resolve_retry_config(self._retry, retry)
+
+        def execute() -> T:
+            with self.connection() as conn:
+                try:
+                    result = callback(conn)
+                    conn.commit()
+                    return result
+                except BaseException:
+                    try:
+                        conn.rollback()
+                    except Exception as e:
+                        logger.debug("Rollback failed: %s", e)
+                    raise
+
+        if config is None:
+            return execute()
+        return _retry_sync(execute, config)
+
+
+class AuroraDSQLAsyncPool(AsyncConnectionPool):
+    """Aurora DSQL async connection pool with OCC retry support."""
+
+    def __init__(self, *args, retry: OCCRetryConfig | bool | None = None, **kwargs):
+        self._retry = retry
+        super().__init__(*args, **kwargs)
+
+    async def run_transaction(
+        self,
+        callback: Callable[[AsyncConnection], Awaitable[T]],
+        *,
+        retry: OCCRetryConfig | bool | None = None,
+    ) -> T:
+        """Execute callback in a transaction with optional OCC retry."""
+        config = resolve_retry_config(self._retry, retry)
+
+        async def execute() -> T:
+            async with self.connection() as conn:
+                try:
+                    result = await callback(conn)
+                    await conn.commit()
+                    return result
+                except BaseException:
+                    try:
+                        await conn.rollback()
+                    except Exception as e:
+                        logger.debug("Rollback failed: %s", e)
+                    raise
+
+        if config is None:
+            return await execute()
+        return await _retry_async(execute, config)
+
+
+def create_pool(
+    conninfo: str = "",
+    *,
+    retry: OCCRetryConfig | bool | None = None,
+    **kwargs: Any,
+) -> AuroraDSQLPool:
+    """Create Aurora DSQL connection pool with IAM authentication.
+
+    Pool is returned unopened; use ``with pool:`` or call ``pool.open()``.
+    """
+    if "connection_class" in kwargs:
+        if not issubclass(kwargs["connection_class"], DSQLConnection):
+            raise TypeError("connection_class must be a subclass of DSQLConnection for IAM auth")
+    else:
+        kwargs["connection_class"] = DSQLConnection
+    return AuroraDSQLPool(conninfo, retry=retry, **kwargs)
+
+
+def create_async_pool(
+    conninfo: str = "",
+    *,
+    retry: OCCRetryConfig | bool | None = None,
+    **kwargs: Any,
+) -> AuroraDSQLAsyncPool:
+    """Create Aurora DSQL async connection pool with IAM authentication.
+
+    Pool is returned unopened; use ``async with pool:`` or call ``await pool.open()``.
+    """
+    if "connection_class" in kwargs:
+        if not issubclass(kwargs["connection_class"], DSQLAsyncConnection):
+            raise TypeError(
+                "connection_class must be a subclass of DSQLAsyncConnection for IAM auth"
+            )
+    else:
+        kwargs["connection_class"] = DSQLAsyncConnection
+    return AuroraDSQLAsyncPool(conninfo, retry=retry, **kwargs)

--- a/python/connector/aurora_dsql_psycopg2/__init__.py
+++ b/python/connector/aurora_dsql_psycopg2/__init__.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from dsql_core._version import __version__
+from dsql_core.occ_retry import OCCRetryConfig, is_occ_error
 
 from .connector import connect
 from .pool import AuroraDSQLThreadedConnectionPool
@@ -10,4 +11,10 @@ apilevel = "2.0"
 threadsafety = 2
 paramstyle = "pyformat"
 
-__all__ = ["connect", "AuroraDSQLThreadedConnectionPool", "__version__"]
+__all__ = [
+    "connect",
+    "AuroraDSQLThreadedConnectionPool",
+    "OCCRetryConfig",
+    "is_occ_error",
+    "__version__",
+]

--- a/python/connector/aurora_dsql_psycopg2/pool.py
+++ b/python/connector/aurora_dsql_psycopg2/pool.py
@@ -1,46 +1,56 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from typing import TypeVar
+
 import psycopg2
 from botocore.credentials import CredentialProvider
 from psycopg2 import pool
+from psycopg2.extensions import connection
 
 from dsql_core.connection_properties import ConnectionProperties, build_application_name
+from dsql_core.occ_retry import OCCRetryConfig, _retry_sync, resolve_retry_config
 from dsql_core.token_manager import TokenManager
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
 
 
 class AuroraDSQLThreadedConnectionPool(pool.ThreadedConnectionPool):
-    """Custom ThreadedConnectionPool that generates fresh IAM tokens per connection."""
+    """Aurora DSQL connection pool with OCC retry support."""
 
     def __init__(
         self,
         minconn,
         maxconn,
         *args,
+        retry: OCCRetryConfig | bool | None = None,
         custom_credentials_provider: CredentialProvider | None = None,
         **kwargs,
     ):
+        self._retry = retry
+
         if custom_credentials_provider is not None:
             kwargs["custom_credentials_provider"] = custom_credentials_provider
 
         dsql_params, pool_params = ConnectionProperties.parse_properties(None, kwargs)
         self._dsql_params = dsql_params
 
-        # Set application_name with optional ORM prefix
         orm_prefix = pool_params.get("application_name")
         pool_params["application_name"] = build_application_name("psycopg2", orm_prefix)
 
-        # Initialize with dummy password, will be replaced per connection
         super().__init__(minconn, maxconn, *args, **pool_params)
 
     def _connect(self, key=None):
         """Create connection with fresh IAM token."""
         token = TokenManager.get_token(self._dsql_params)
-
-        # Update kwargs with fresh token
         self._kwargs["password"] = token
 
-        # Create connection
         conn = psycopg2.connect(*self._args, **self._kwargs)
         if key is not None:
             self._used[key] = conn
@@ -50,10 +60,37 @@ class AuroraDSQLThreadedConnectionPool(pool.ThreadedConnectionPool):
         return conn
 
     def __enter__(self):
-        """Enter context manager."""
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        """Exit context manager and close all connections."""
         self.closeall()
         return False
+
+    def run_transaction(
+        self,
+        callback: Callable[[connection], T],
+        *,
+        retry: OCCRetryConfig | bool | None = None,
+    ) -> T:
+        """Execute callback in a transaction with optional OCC retry."""
+        config = resolve_retry_config(self._retry, retry)
+
+        def execute() -> T:
+            conn = self.getconn()
+            try:
+                conn.autocommit = False
+                result = callback(conn)
+                conn.commit()
+                return result
+            except BaseException:
+                try:
+                    conn.rollback()
+                except Exception as e:
+                    logger.debug("Rollback failed: %s", e)
+                raise
+            finally:
+                self.putconn(conn)
+
+        if config is None:
+            return execute()
+        return _retry_sync(execute, config)

--- a/python/connector/dsql_core/occ_retry.py
+++ b/python/connector/dsql_core/occ_retry.py
@@ -1,0 +1,122 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import random
+import time
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import TypeVar
+
+T = TypeVar("T")
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class OCCRetryConfig:
+    """Retry configuration for OCC conflict handling.
+
+    Attributes:
+        max_retries: Additional attempts after the initial try (0-100).
+        base_delay_ms: Initial backoff delay in milliseconds (must be > 0).
+        max_delay_ms: Backoff delay cap in milliseconds (must be >= base_delay_ms).
+        jitter_factor: Fraction of delay added as random jitter (0.0-1.0).
+    """
+
+    max_retries: int = 3
+    base_delay_ms: int = 1
+    max_delay_ms: int = 100
+    jitter_factor: float = 0.25
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.max_retries, int):
+            raise ValueError("max_retries must be an integer")
+        if self.max_retries < 0:
+            raise ValueError("max_retries must be >= 0")
+        if self.max_retries > 100:
+            raise ValueError("max_retries must not exceed 100")
+        if self.base_delay_ms <= 0:
+            raise ValueError("base_delay_ms must be greater than 0")
+        if self.max_delay_ms < self.base_delay_ms:
+            raise ValueError("max_delay_ms must be >= base_delay_ms")
+        if self.jitter_factor < 0.0 or self.jitter_factor > 1.0:
+            raise ValueError("jitter_factor must be between 0.0 and 1.0")
+
+
+def resolve_retry_config(
+    pool_config: OCCRetryConfig | bool | None,
+    per_call: OCCRetryConfig | bool | None,
+) -> OCCRetryConfig | None:
+    """Resolve effective retry config from pool and per-call settings."""
+    if isinstance(per_call, OCCRetryConfig):
+        return per_call
+    if per_call is False:
+        return None
+    if per_call is True:
+        if isinstance(pool_config, OCCRetryConfig):
+            return pool_config
+        return OCCRetryConfig()
+    if isinstance(pool_config, OCCRetryConfig):
+        return pool_config
+    if pool_config is True:
+        return OCCRetryConfig()
+    return None
+
+
+def is_occ_error(error: Exception) -> bool:
+    """Detect OCC conflict by checking sqlstate or pgcode for OC000, OC001, or 40001."""
+    code = getattr(error, "sqlstate", None)
+    if code is None:
+        code = getattr(error, "pgcode", None)
+    if code is None:
+        return False
+    return code in ("OC000", "OC001", "40001")
+
+
+def _calculate_backoff(config: OCCRetryConfig, attempt: int) -> float:
+    """Compute backoff delay in ms: min(base * 2^(attempt-1), max) + jitter."""
+    exponent = min(attempt - 1, 31)
+    delay = min(config.base_delay_ms * (2.0**exponent), config.max_delay_ms)
+    jitter = delay * random.random() * config.jitter_factor
+    return delay + jitter
+
+
+def _retry_sync(execute: Callable[[], T], config: OCCRetryConfig) -> T:
+    """Sync retry loop. Retries the thunk on OCC errors with backoff."""
+    for attempt in range(config.max_retries + 1):
+        try:
+            return execute()
+        except Exception as e:
+            if not is_occ_error(e) or attempt == config.max_retries:
+                raise
+            delay = _calculate_backoff(config, attempt + 1)
+            logger.debug(
+                "OCC conflict on attempt %d/%d, retrying in %.1fms",
+                attempt + 1,
+                config.max_retries + 1,
+                delay,
+            )
+            time.sleep(delay / 1000.0)
+    raise AssertionError("unreachable")
+
+
+async def _retry_async(execute: Callable[[], Awaitable[T]], config: OCCRetryConfig) -> T:
+    """Async retry loop. Retries the thunk on OCC errors with backoff."""
+    for attempt in range(config.max_retries + 1):
+        try:
+            return await execute()
+        except Exception as e:
+            if not is_occ_error(e) or attempt == config.max_retries:
+                raise
+            delay = _calculate_backoff(config, attempt + 1)
+            logger.debug(
+                "OCC conflict on attempt %d/%d, retrying in %.1fms",
+                attempt + 1,
+                config.max_retries + 1,
+                delay,
+            )
+            await asyncio.sleep(delay / 1000.0)
+    raise AssertionError("unreachable")

--- a/python/connector/examples/asyncpg/pyproject.toml
+++ b/python/connector/examples/asyncpg/pyproject.toml
@@ -24,6 +24,9 @@ dependencies = [
     "asyncpg>=0.30.0",
 ]
 
+[tool.uv.sources]
+aurora-dsql-python-connector = { path = "../..", editable = true }
+
 [dependency-groups]
 dev = [
     "pytest>=8.0",

--- a/python/connector/examples/asyncpg/src/alternatives/no_connection_pool/example_with_no_connection_pool.py
+++ b/python/connector/examples/asyncpg/src/alternatives/no_connection_pool/example_with_no_connection_pool.py
@@ -48,6 +48,9 @@ async def exercise_connection(conn):
             """
     )
 
+    # Clean up any data from previous runs to avoid assertion failures
+    await conn.execute("DELETE FROM owner WHERE name = $1", "John Doe")
+
     # Insert some rows
     await conn.execute(
         "INSERT INTO owner(name, city, telephone) VALUES($1, $2, $3)",

--- a/python/connector/examples/asyncpg/src/alternatives/pool/example_with_nonconcurrent_connection_pool.py
+++ b/python/connector/examples/asyncpg/src/alternatives/pool/example_with_nonconcurrent_connection_pool.py
@@ -21,11 +21,21 @@ async def connect_with_pool(cluster_user, cluster_endpoint):
         "max_size": 5,
     }
 
-    pool = await dsql.create_pool(**pool_params)
+    pool = await dsql.create_pool(retry=True, **pool_params)
     try:
         async with pool.acquire() as conn:
             result = await conn.fetchval("SELECT 1")
             assert result == 1
+
+        async def insert_owner(conn):
+            await conn.execute(
+                "INSERT INTO owner(name, city, telephone) VALUES($1, $2, $3)",
+                "John Doe",
+                "Anytown",
+                "555-555-1900",
+            )
+
+        await pool.run_transaction(insert_owner)
     finally:
         await pool.close()
 

--- a/python/connector/examples/asyncpg/src/example_preferred.py
+++ b/python/connector/examples/asyncpg/src/example_preferred.py
@@ -31,13 +31,24 @@ async def connect_with_pool_concurrent_connections(cluster_user, cluster_endpoin
 
     pool = None
     try:
-        pool = await dsql.create_pool(**pool_params)
+        pool = await dsql.create_pool(retry=True, **pool_params)
+
         # Run multiple concurrent workers
         num_workers = 5
         tasks = [worker_task(pool, i) for i in range(num_workers)]
         results = await asyncio.gather(*tasks)
         for result in results:
             print(result)
+
+        async def insert_owner(conn):
+            await conn.execute(
+                "INSERT INTO owner(name, city, telephone) VALUES($1, $2, $3)",
+                "John Doe",
+                "Anytown",
+                "555-555-1900",
+            )
+
+        await pool.run_transaction(insert_owner)
     finally:
         if pool is not None:
             await pool.close()

--- a/python/connector/examples/psycopg/pyproject.toml
+++ b/python/connector/examples/psycopg/pyproject.toml
@@ -25,6 +25,9 @@ dependencies = [
     "psycopg-pool>=3.2.6",
 ]
 
+[tool.uv.sources]
+aurora-dsql-python-connector = { path = "../..", editable = true }
+
 [dependency-groups]
 dev = [
     "pytest>=8.0",

--- a/python/connector/examples/psycopg/src/alternatives/no_connection_pool/example_async_with_no_connection_pool.py
+++ b/python/connector/examples/psycopg/src/alternatives/no_connection_pool/example_async_with_no_connection_pool.py
@@ -58,6 +58,9 @@ async def exercise_connection(conn):
                 """
         )
 
+        # Clean up any data from previous runs to avoid assertion failures
+        await cur.execute("DELETE FROM owner WHERE name = 'John Doe'")
+
         # Insert some rows
         await cur.execute(
             "INSERT INTO owner(name, city, telephone) VALUES('John Doe', 'Anytown', '555-555-1999')"

--- a/python/connector/examples/psycopg/src/alternatives/no_connection_pool/example_with_no_connection_pool.py
+++ b/python/connector/examples/psycopg/src/alternatives/no_connection_pool/example_with_no_connection_pool.py
@@ -59,6 +59,9 @@ def exercise_connection(conn):
             """
     )
 
+    # Clean up any data from previous runs to avoid assertion failures
+    cur.execute("DELETE FROM owner WHERE name = 'John Doe'")
+
     # Insert some rows
     cur.execute(
         "INSERT INTO owner(name, city, telephone) VALUES('John Doe', 'Anytown', '555-555-1999')"

--- a/python/connector/examples/psycopg/src/alternatives/pool/example_with_async_connection_pool.py
+++ b/python/connector/examples/psycopg/src/alternatives/pool/example_with_async_connection_pool.py
@@ -3,8 +3,6 @@
 
 import os
 
-from psycopg_pool import AsyncConnectionPool as PsycopgPoolAsync
-
 import aurora_dsql_psycopg as dsql
 
 
@@ -20,20 +18,31 @@ async def connect_with_pool(cluster_user, cluster_endpoint):
         "sslrootcert": ssl_cert_path,
     }
 
-    async with PsycopgPoolAsync(
+    pool = dsql.create_async_pool(
         "",
-        connection_class=dsql.DSQLAsyncConnection,
-        kwargs=conn_params,  # Pass params as kwargs
+        kwargs=conn_params,
         min_size=2,
         max_size=10,
         max_lifetime=3300,
-    ) as pool:
+        retry=True,
+    )
+
+    async with pool:
         async with pool.connection() as conn:
             async with conn.cursor() as cur:
                 await cur.execute("SELECT 1")
                 result = await cur.fetchone()
                 print(f"Query result: {result}")
                 assert result[0] == 1
+
+        async def insert_owner(conn):
+            async with conn.cursor() as cur:
+                await cur.execute(
+                    "INSERT INTO owner(name, city, telephone) VALUES(%s, %s, %s)",
+                    ("John Doe", "Anytown", "555-555-1900"),
+                )
+
+        await pool.run_transaction(insert_owner)
 
 
 async def main():

--- a/python/connector/examples/psycopg/src/alternatives/pool/example_with_nonconcurrent_connection_pool.py
+++ b/python/connector/examples/psycopg/src/alternatives/pool/example_with_nonconcurrent_connection_pool.py
@@ -3,8 +3,6 @@
 
 import os
 
-from psycopg_pool import ConnectionPool as PsycopgPool
-
 import aurora_dsql_psycopg as dsql
 
 
@@ -20,25 +18,31 @@ def connect_with_pool(cluster_user, cluster_endpoint):
         "sslrootcert": ssl_cert_path,
     }
 
-    pool = PsycopgPool(
-        "",  # Empty conninfo
-        connection_class=dsql.DSQLConnection,
-        kwargs=conn_params,  # Pass params as kwargs
+    pool = dsql.create_pool(
+        "",
+        kwargs=conn_params,
         min_size=2,
         max_size=8,
         max_lifetime=3300,
+        retry=True,
     )
 
-    # Use the pool as a context manager
-    with pool as p:
-        # Request a connection from the pool
-        with p.connection() as conn:
-            # Execute a query
+    with pool:
+        with pool.connection() as conn:
             with conn.cursor() as cur:
                 cur.execute("SELECT 1")
                 result = cur.fetchone()
                 print(f"Query result: {result}")
                 assert result[0] == 1
+
+        def insert_owner(conn):
+            with conn.cursor() as cur:
+                cur.execute(
+                    "INSERT INTO owner(name, city, telephone) VALUES(%s, %s, %s)",
+                    ("John Doe", "Anytown", "555-555-1900"),
+                )
+
+        pool.run_transaction(insert_owner)
 
 
 def main():

--- a/python/connector/examples/psycopg/src/example_preferred.py
+++ b/python/connector/examples/psycopg/src/example_preferred.py
@@ -4,8 +4,6 @@
 import os
 import threading
 
-from psycopg_pool import ConnectionPool as PsycopgPool
-
 import aurora_dsql_psycopg as dsql
 
 
@@ -21,13 +19,13 @@ def connect_with_pool_concurrent_connections(cluster_user, cluster_endpoint):
         "sslrootcert": ssl_cert_path,
     }
 
-    pool = PsycopgPool(
-        "",  # Empty conninfo
-        connection_class=dsql.DSQLConnection,
-        kwargs=conn_params,  # Pass params as kwargs
+    pool = dsql.create_pool(
+        "",
+        kwargs=conn_params,
         min_size=2,
         max_size=8,
         max_lifetime=3300,
+        retry=True,
         open=True,
     )
 
@@ -64,6 +62,15 @@ def connect_with_pool_concurrent_connections(cluster_user, cluster_endpoint):
         for thread_id, exc in exceptions:
             print(f"  Thread {thread_id}: {exc}")
         raise RuntimeError(f"One or more worker threads failed: {exceptions}")
+
+    def insert_owner(conn):
+        with conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO owner(name, city, telephone) VALUES(%s, %s, %s)",
+                ("John Doe", "Anytown", "555-555-1900"),
+            )
+
+    pool.run_transaction(insert_owner)
 
 
 def main():

--- a/python/connector/examples/psycopg2/pyproject.toml
+++ b/python/connector/examples/psycopg2/pyproject.toml
@@ -24,6 +24,9 @@ dependencies = [
     "psycopg2-binary>=2.9.0",
 ]
 
+[tool.uv.sources]
+aurora-dsql-python-connector = { path = "../..", editable = true }
+
 [dependency-groups]
 dev = [
     "pytest>=8.0",

--- a/python/connector/examples/psycopg2/src/alternatives/pool/example_with_nonconcurrent_connection_pool.py
+++ b/python/connector/examples/psycopg2/src/alternatives/pool/example_with_nonconcurrent_connection_pool.py
@@ -21,6 +21,7 @@ def connect_with_pool(cluster_user, cluster_endpoint):
     pool = dsql.AuroraDSQLThreadedConnectionPool(
         minconn=2,
         maxconn=8,
+        retry=True,
         **conn_params,
     )
 
@@ -38,6 +39,15 @@ def connect_with_pool(cluster_user, cluster_endpoint):
         finally:
             # Return connection to pool
             p.putconn(conn)
+
+        def insert_owner(conn):
+            with conn.cursor() as cur:
+                cur.execute(
+                    "INSERT INTO owner(name, city, telephone) VALUES(%s, %s, %s)",
+                    ("John Doe", "Anytown", "555-555-1900"),
+                )
+
+        p.run_transaction(insert_owner)
 
 
 def main():

--- a/python/connector/examples/psycopg2/src/example_preferred.py
+++ b/python/connector/examples/psycopg2/src/example_preferred.py
@@ -22,6 +22,7 @@ def connect_with_pool_concurrent_connections(cluster_user, cluster_endpoint):
     pool = dsql.AuroraDSQLThreadedConnectionPool(
         minconn=2,
         maxconn=8,
+        retry=True,
         **conn_params,
     )
 
@@ -60,6 +61,15 @@ def connect_with_pool_concurrent_connections(cluster_user, cluster_endpoint):
         for thread_id, exc in exceptions:
             print(f"  Thread {thread_id}: {exc}")
         raise RuntimeError(f"One or more worker threads failed: {exceptions}")
+
+    def insert_owner(conn):
+        with conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO owner(name, city, telephone) VALUES(%s, %s, %s)",
+                ("John Doe", "Anytown", "555-555-1900"),
+            )
+
+    pool.run_transaction(insert_owner)
 
 
 def main():

--- a/python/connector/tests/integration/test_integration_asyncpg_pool.py
+++ b/python/connector/tests/integration/test_integration_asyncpg_pool.py
@@ -1,12 +1,14 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import asyncio
 import os
 import ssl
 
 import pytest
 
 import aurora_dsql_asyncpg as dsql
+from dsql_core.occ_retry import OCCRetryConfig
 
 from .common_integration_test_definitions import CustomCredentialProvider
 
@@ -223,7 +225,6 @@ class TestIntegrationAsyncpgPool:
     @pytest.mark.asyncio
     async def test_pool_concurrent_operations(self, cluster_config):
         """Test concurrent operations using pool."""
-        import asyncio
 
         pool = await dsql.create_pool(min_size=2, max_size=5, **cluster_config)
 
@@ -243,5 +244,102 @@ class TestIntegrationAsyncpgPool:
             # Verify all workers completed successfully
             assert results == list(range(5))
 
+        finally:
+            await pool.close()
+
+    @pytest.mark.asyncio
+    async def test_occ_retry_deterministic_conflict(self, cluster_config):
+        """Deterministic OCC test using T1/T2 interleaving:
+        T1: BEGIN, SELECT
+        T2: BEGIN, UPDATE, COMMIT  (forces the conflict)
+        T1: UPDATE, COMMIT         (guaranteed OCC, retry must work)
+        """
+        table_name = "test_occ_asyncpg_deterministic"
+
+        pool = await dsql.create_pool(
+            retry=OCCRetryConfig(max_retries=5),
+            min_size=3,
+            max_size=5,
+            **cluster_config,
+        )
+        try:
+            async with pool.acquire() as conn:
+                await conn.execute(f"""
+                    CREATE TABLE IF NOT EXISTS {table_name} (
+                        id INT PRIMARY KEY, value INT
+                    )
+                """)
+                await conn.execute(
+                    f"INSERT INTO {table_name} (id, value) VALUES (1, 0)"
+                    f" ON CONFLICT (id) DO UPDATE SET value = 0"
+                )
+
+            t1_has_read = asyncio.Event()
+            t2_has_committed = asyncio.Event()
+            t1_attempts = 0
+
+            async def t1(conn):
+                nonlocal t1_attempts
+                t1_attempts += 1
+                row = await conn.fetchrow(f"SELECT value FROM {table_name} WHERE id = 1")
+                t1_has_read.set()
+                await asyncio.wait_for(t2_has_committed.wait(), timeout=10)
+                await conn.execute(
+                    f"UPDATE {table_name} SET value = $1 WHERE id = 1",
+                    row["value"] + 1,
+                )
+
+            async def t2(conn):
+                await asyncio.wait_for(t1_has_read.wait(), timeout=10)
+                await conn.execute(f"UPDATE {table_name} SET value = 100 WHERE id = 1")
+
+            async def run_t2():
+                async with pool.acquire() as conn:
+                    await conn.execute("BEGIN")
+                    await t2(conn)
+                    await conn.execute("COMMIT")
+                t2_has_committed.set()
+
+            t2_task = asyncio.create_task(run_t2())
+            await pool.run_transaction(t1)
+            await t2_task
+
+            async with pool.acquire() as conn:
+                result = await conn.fetchval(f"SELECT value FROM {table_name} WHERE id = 1")
+                assert result == 101
+            assert t1_attempts >= 2, f"Expected retry but t1 ran only {t1_attempts} time(s)"
+        finally:
+            for attempt in range(5):
+                try:
+                    async with pool.acquire() as conn:
+                        await conn.execute(f"DROP TABLE IF EXISTS {table_name}")
+                    break
+                except Exception:
+                    if attempt == 4:
+                        raise
+                    await asyncio.sleep(1)
+            await pool.close()
+
+    @pytest.mark.asyncio
+    async def test_occ_non_occ_error_propagates_immediately(self, cluster_config):
+        """A non-OCC database error should propagate without retry."""
+        pool = await dsql.create_pool(
+            retry=OCCRetryConfig(max_retries=5),
+            min_size=2,
+            max_size=5,
+            **cluster_config,
+        )
+        try:
+            call_count = 0
+
+            async def bad_query(conn):
+                nonlocal call_count
+                call_count += 1
+                await conn.execute("SELECT * FROM nonexistent_table_xyz_12345")
+
+            with pytest.raises(Exception):
+                await pool.run_transaction(bad_query)
+
+            assert call_count == 1
         finally:
             await pool.close()

--- a/python/connector/tests/integration/test_integration_psycopg2.py
+++ b/python/connector/tests/integration/test_integration_psycopg2.py
@@ -2,8 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
+import threading
+import time
 
 import pytest
+
+import aurora_dsql_psycopg2 as dsql
+from dsql_core.occ_retry import OCCRetryConfig
 
 
 # @pytest.mark.integration
@@ -39,7 +44,119 @@ class TestIntegrationPsycopg2:
 
         return config
 
-    def test_empty(self, cluster_config):
-        """Test basic connection to Aurora DSQL."""
+    def test_occ_retry_deterministic_conflict(self, cluster_config):
+        """Deterministic OCC test using T1/T2 interleaving:
+        T1: BEGIN, SELECT
+        T2: BEGIN, UPDATE, COMMIT  (forces the conflict)
+        T1: UPDATE, COMMIT         (guaranteed OCC, retry must work)
+        """
+        table_name = "test_occ_psycopg2_deterministic"
 
-        pass
+        pool = dsql.AuroraDSQLThreadedConnectionPool(
+            minconn=3,
+            maxconn=5,
+            retry=OCCRetryConfig(max_retries=5),
+            **cluster_config,
+        )
+
+        try:
+            conn = pool.getconn()
+            try:
+                conn.autocommit = True
+                with conn.cursor() as cur:
+                    cur.execute(f"""
+                        CREATE TABLE IF NOT EXISTS {table_name} (
+                            id INT PRIMARY KEY, value INT
+                        )
+                    """)
+                    cur.execute(
+                        f"INSERT INTO {table_name} (id, value) VALUES (1, 0)"
+                        f" ON CONFLICT (id) DO UPDATE SET value = 0"
+                    )
+                conn.autocommit = False
+            finally:
+                pool.putconn(conn)
+
+            t1_has_read = threading.Event()
+            t2_has_committed = threading.Event()
+            t1_attempts = 0
+
+            def t1(conn):
+                nonlocal t1_attempts
+                t1_attempts += 1
+                with conn.cursor() as cur:
+                    cur.execute(f"SELECT value FROM {table_name} WHERE id = 1")
+                    row = cur.fetchone()
+                t1_has_read.set()
+                assert t2_has_committed.wait(timeout=10)
+                with conn.cursor() as cur:
+                    cur.execute(
+                        f"UPDATE {table_name} SET value = %s WHERE id = 1",
+                        (row[0] + 1,),
+                    )
+
+            def run_t2():
+                conn = pool.getconn()
+                try:
+                    assert t1_has_read.wait(timeout=10)
+                    with conn.cursor() as cur:
+                        cur.execute(f"UPDATE {table_name} SET value = 100 WHERE id = 1")
+                    conn.commit()
+                finally:
+                    pool.putconn(conn)
+                t2_has_committed.set()
+
+            t2_thread = threading.Thread(target=run_t2)
+            t2_thread.start()
+            pool.run_transaction(t1)
+            t2_thread.join()
+
+            conn = pool.getconn()
+            try:
+                with conn.cursor() as cur:
+                    cur.execute(f"SELECT value FROM {table_name} WHERE id = 1")
+                    result = cur.fetchone()
+                    assert result[0] == 101
+            finally:
+                pool.putconn(conn)
+            assert t1_attempts >= 2, f"Expected retry but t1 ran only {t1_attempts} time(s)"
+        finally:
+            for attempt in range(5):
+                conn = pool.getconn()
+                try:
+                    conn.autocommit = True
+                    with conn.cursor() as cur:
+                        cur.execute(f"DROP TABLE IF EXISTS {table_name}")
+                    break
+                except Exception:
+                    if attempt == 4:
+                        raise
+                    time.sleep(1)
+                finally:
+                    pool.putconn(conn)
+            pool.closeall()
+
+    def test_occ_non_occ_error_propagates_immediately(self, cluster_config):
+        """A non-OCC database error should propagate without retry."""
+        pool = dsql.AuroraDSQLThreadedConnectionPool(
+            minconn=2,
+            maxconn=5,
+            retry=OCCRetryConfig(max_retries=5),
+            **cluster_config,
+        )
+
+        try:
+            call_count = 0
+
+            def bad_query(conn):
+                nonlocal call_count
+                call_count += 1
+                with conn.cursor() as cur:
+                    cur.execute("SELECT * FROM nonexistent_table_xyz_12345")
+
+            with pytest.raises(Exception):
+                pool.run_transaction(bad_query)
+
+            assert call_count == 1
+        finally:
+            pool.closeall()

--- a/python/connector/tests/integration/test_integration_psycopg_pool.py
+++ b/python/connector/tests/integration/test_integration_psycopg_pool.py
@@ -2,11 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
+import threading
+import time
 
 import pytest
 from psycopg_pool import ConnectionPool as PsycopgPool
 
 import aurora_dsql_psycopg as dsql
+from dsql_core.occ_retry import OCCRetryConfig
 
 
 # @pytest.mark.integration
@@ -32,8 +35,10 @@ class TestIntegrationPool:
             "region": os.getenv("REGION", "us-east-1"),
             "user": os.getenv("CLUSTER_USER", "admin"),
             "dbname": os.getenv("DSQL_DATABASE", "postgres"),
-            # "profile": os.getenv("AWS_PROFILE", "default"),
         }
+        aws_profile = os.getenv("AWS_PROFILE")
+        if aws_profile:
+            config["profile"] = aws_profile
 
         if not config["host"]:
             raise ValueError("CLUSTER_ENDPOINT environment variable not set")
@@ -56,3 +61,114 @@ class TestIntegrationPool:
             # Request a connection from the pool
             with p.connection() as conn:
                 self._assert_connection_functional(conn)
+
+    def test_occ_retry_deterministic_conflict(self, cluster_config):
+        """Deterministic OCC test using T1/T2 interleaving:
+        T1: BEGIN, SELECT
+        T2: BEGIN, UPDATE, COMMIT  (forces the conflict)
+        T1: UPDATE, COMMIT         (guaranteed OCC, retry must work)
+        """
+        table_name = "test_occ_psycopg_deterministic"
+
+        pool = dsql.create_pool(
+            "",
+            kwargs=cluster_config,
+            retry=OCCRetryConfig(max_retries=5),
+            min_size=3,
+            max_size=5,
+            open=True,
+        )
+
+        try:
+            with pool.connection() as conn:
+                conn.autocommit = True
+                with conn.cursor() as cur:
+                    cur.execute(f"""
+                        CREATE TABLE IF NOT EXISTS {table_name} (
+                            id INT PRIMARY KEY, value INT
+                        )
+                    """)
+                    cur.execute(
+                        f"INSERT INTO {table_name} (id, value) VALUES (1, 0)"
+                        f" ON CONFLICT (id) DO UPDATE SET value = 0"
+                    )
+                conn.autocommit = False
+
+            t1_has_read = threading.Event()
+            t2_has_committed = threading.Event()
+            t1_attempts = 0
+
+            def t1(conn):
+                nonlocal t1_attempts
+                t1_attempts += 1
+                with conn.cursor() as cur:
+                    cur.execute(f"SELECT value FROM {table_name} WHERE id = 1")
+                    row = cur.fetchone()
+                t1_has_read.set()
+                assert t2_has_committed.wait(timeout=10)
+                with conn.cursor() as cur:
+                    cur.execute(
+                        f"UPDATE {table_name} SET value = %s WHERE id = 1",
+                        (row[0] + 1,),
+                    )
+
+            def run_t2():
+                with pool.connection() as conn:
+                    with conn.cursor() as cur:
+                        assert t1_has_read.wait(timeout=10)
+                        cur.execute(f"UPDATE {table_name} SET value = 100 WHERE id = 1")
+                    conn.commit()
+                t2_has_committed.set()
+
+            t2_thread = threading.Thread(target=run_t2)
+            t2_thread.start()
+            pool.run_transaction(t1)
+            t2_thread.join()
+
+            with pool.connection() as conn:
+                with conn.cursor() as cur:
+                    cur.execute(f"SELECT value FROM {table_name} WHERE id = 1")
+                    result = cur.fetchone()
+                    assert result[0] == 101
+            assert t1_attempts >= 2, f"Expected retry but t1 ran only {t1_attempts} time(s)"
+        finally:
+            for attempt in range(5):
+                try:
+                    with pool.connection() as conn:
+                        conn.autocommit = True
+                        with conn.cursor() as cur:
+                            cur.execute(f"DROP TABLE IF EXISTS {table_name}")
+                        conn.autocommit = False
+                    break
+                except Exception:
+                    if attempt == 4:
+                        raise
+                    time.sleep(1)
+            pool.close()
+
+    def test_occ_non_occ_error_propagates_immediately(self, cluster_config):
+        """A non-OCC database error should propagate without retry."""
+        pool = dsql.create_pool(
+            "",
+            kwargs=cluster_config,
+            retry=OCCRetryConfig(max_retries=5),
+            min_size=2,
+            max_size=5,
+            open=True,
+        )
+
+        try:
+            call_count = 0
+
+            def bad_query(conn):
+                nonlocal call_count
+                call_count += 1
+                with conn.cursor() as cur:
+                    cur.execute("SELECT * FROM nonexistent_table_xyz_12345")
+
+            with pytest.raises(Exception):
+                pool.run_transaction(bad_query)
+
+            assert call_count == 1
+        finally:
+            pool.close()

--- a/python/connector/tests/unit/test_occ_retry.py
+++ b/python/connector/tests/unit/test_occ_retry.py
@@ -1,0 +1,352 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest.mock import patch
+
+import pytest
+
+from dsql_core.occ_retry import (
+    OCCRetryConfig,
+    _calculate_backoff,
+    _retry_async,
+    _retry_sync,
+    is_occ_error,
+    resolve_retry_config,
+)
+
+
+@pytest.mark.unit
+class TestOCCRetryConfig:
+    def test_defaults(self):
+        config = OCCRetryConfig()
+        assert config.max_retries == 3
+        assert config.base_delay_ms == 1
+        assert config.max_delay_ms == 100
+        assert config.jitter_factor == 0.25
+
+    def test_custom_values(self):
+        config = OCCRetryConfig(max_retries=5, base_delay_ms=10, max_delay_ms=50, jitter_factor=0.5)
+        assert config.max_retries == 5
+        assert config.base_delay_ms == 10
+        assert config.max_delay_ms == 50
+        assert config.jitter_factor == 0.5
+
+    def test_rejects_negative_max_retries(self):
+        with pytest.raises(ValueError, match="max_retries must be >= 0"):
+            OCCRetryConfig(max_retries=-1)
+
+    def test_rejects_max_retries_over_100(self):
+        with pytest.raises(ValueError, match="max_retries must not exceed 100"):
+            OCCRetryConfig(max_retries=101)
+
+    def test_rejects_zero_base_delay(self):
+        with pytest.raises(ValueError, match="base_delay_ms must be greater than 0"):
+            OCCRetryConfig(base_delay_ms=0)
+
+    def test_rejects_negative_base_delay(self):
+        with pytest.raises(ValueError, match="base_delay_ms must be greater than 0"):
+            OCCRetryConfig(base_delay_ms=-1)
+
+    def test_rejects_max_delay_less_than_base(self):
+        with pytest.raises(ValueError, match="max_delay_ms must be >= base_delay_ms"):
+            OCCRetryConfig(base_delay_ms=50, max_delay_ms=10)
+
+    def test_rejects_negative_jitter(self):
+        with pytest.raises(ValueError, match="jitter_factor must be between 0.0 and 1.0"):
+            OCCRetryConfig(jitter_factor=-0.1)
+
+    def test_rejects_jitter_over_one(self):
+        with pytest.raises(ValueError, match="jitter_factor must be between 0.0 and 1.0"):
+            OCCRetryConfig(jitter_factor=1.5)
+
+    def test_accepts_zero_retries(self):
+        config = OCCRetryConfig(max_retries=0)
+        assert config.max_retries == 0
+
+    def test_accepts_boundary_values(self):
+        config = OCCRetryConfig(
+            max_retries=100, base_delay_ms=1, max_delay_ms=100, jitter_factor=1.0
+        )
+        assert config.max_retries == 100
+        assert config.jitter_factor == 1.0
+
+    def test_frozen(self):
+        config = OCCRetryConfig()
+        with pytest.raises(Exception):
+            config.max_retries = 5  # type: ignore[misc]
+
+
+@pytest.mark.unit
+class TestResolveRetryConfig:
+    def test_both_none(self):
+        assert resolve_retry_config(None, None) is None
+
+    def test_pool_config_none_per_call_none(self):
+        assert resolve_retry_config(None, None) is None
+
+    def test_pool_true_per_call_none(self):
+        result = resolve_retry_config(True, None)
+        assert isinstance(result, OCCRetryConfig)
+        assert result.max_retries == 3
+
+    def test_pool_config_per_call_none(self):
+        cfg = OCCRetryConfig(max_retries=5)
+        result = resolve_retry_config(cfg, None)
+        assert result is cfg
+
+    def test_pool_false_per_call_none(self):
+        assert resolve_retry_config(False, None) is None
+
+    def test_pool_any_per_call_false(self):
+        cfg = OCCRetryConfig(max_retries=5)
+        assert resolve_retry_config(cfg, False) is None
+        assert resolve_retry_config(True, False) is None
+        assert resolve_retry_config(None, False) is None
+
+    def test_pool_any_per_call_true(self):
+        cfg = OCCRetryConfig(max_retries=5)
+        result = resolve_retry_config(cfg, True)
+        assert result is cfg
+
+    def test_pool_true_per_call_true(self):
+        result = resolve_retry_config(True, True)
+        assert isinstance(result, OCCRetryConfig)
+
+    def test_pool_none_per_call_true(self):
+        result = resolve_retry_config(None, True)
+        assert isinstance(result, OCCRetryConfig)
+        assert result.max_retries == 3
+
+    def test_per_call_config_replaces_pool(self):
+        pool_cfg = OCCRetryConfig(max_retries=5)
+        call_cfg = OCCRetryConfig(max_retries=10)
+        result = resolve_retry_config(pool_cfg, call_cfg)
+        assert result is call_cfg
+
+
+@pytest.mark.unit
+class TestIsOCCError:
+    def test_oc000_via_sqlstate(self):
+        err = Exception()
+        err.sqlstate = "OC000"  # type: ignore[attr-defined]
+        assert is_occ_error(err) is True
+
+    def test_oc001_via_sqlstate(self):
+        err = Exception()
+        err.sqlstate = "OC001"  # type: ignore[attr-defined]
+        assert is_occ_error(err) is True
+
+    def test_40001_via_sqlstate(self):
+        err = Exception()
+        err.sqlstate = "40001"  # type: ignore[attr-defined]
+        assert is_occ_error(err) is True
+
+    def test_oc000_via_pgcode(self):
+        err = Exception()
+        err.pgcode = "OC000"  # type: ignore[attr-defined]
+        assert is_occ_error(err) is True
+
+    def test_oc001_via_pgcode(self):
+        err = Exception()
+        err.pgcode = "OC001"  # type: ignore[attr-defined]
+        assert is_occ_error(err) is True
+
+    def test_40001_via_pgcode(self):
+        err = Exception()
+        err.pgcode = "40001"  # type: ignore[attr-defined]
+        assert is_occ_error(err) is True
+
+    def test_non_occ_code(self):
+        err = Exception()
+        err.sqlstate = "23505"  # type: ignore[attr-defined]
+        assert is_occ_error(err) is False
+
+    def test_no_code_attribute(self):
+        err = Exception("generic error")
+        assert is_occ_error(err) is False
+
+    def test_none_code(self):
+        err = Exception()
+        err.sqlstate = None  # type: ignore[attr-defined]
+        assert is_occ_error(err) is False
+
+    def test_sqlstate_takes_precedence_over_pgcode(self):
+        err = Exception()
+        err.sqlstate = "OC000"  # type: ignore[attr-defined]
+        err.pgcode = "23505"  # type: ignore[attr-defined]
+        assert is_occ_error(err) is True
+
+
+@pytest.mark.unit
+class TestCalculateBackoff:
+    def test_first_attempt(self):
+        config = OCCRetryConfig(base_delay_ms=1, max_delay_ms=100, jitter_factor=0.0)
+        delay = _calculate_backoff(config, 1)
+        assert delay == 1.0
+
+    def test_second_attempt(self):
+        config = OCCRetryConfig(base_delay_ms=1, max_delay_ms=100, jitter_factor=0.0)
+        delay = _calculate_backoff(config, 2)
+        assert delay == 2.0
+
+    def test_third_attempt(self):
+        config = OCCRetryConfig(base_delay_ms=1, max_delay_ms=100, jitter_factor=0.0)
+        delay = _calculate_backoff(config, 3)
+        assert delay == 4.0
+
+    def test_caps_at_max_delay(self):
+        config = OCCRetryConfig(base_delay_ms=1, max_delay_ms=100, jitter_factor=0.0)
+        delay = _calculate_backoff(config, 10)
+        assert delay == 100.0
+
+    def test_jitter_adds_randomness(self):
+        config = OCCRetryConfig(base_delay_ms=10, max_delay_ms=100, jitter_factor=0.5)
+        delay = _calculate_backoff(config, 1)
+        assert delay >= 10.0
+        assert delay <= 15.0  # 10 + 10*0.5
+
+    def test_exponent_capped_at_31(self):
+        config = OCCRetryConfig(base_delay_ms=1, max_delay_ms=10**12, jitter_factor=0.0)
+        delay = _calculate_backoff(config, 50)
+        assert delay == 2**31
+
+
+@pytest.mark.unit
+class TestRetrySyncLoop:
+    def test_succeeds_first_try(self):
+        result = _retry_sync(lambda: "ok", OCCRetryConfig())
+        assert result == "ok"
+
+    @patch("dsql_core.occ_retry.time.sleep")
+    def test_retries_on_occ_then_succeeds(self, mock_sleep):
+        attempts = []
+
+        def execute():
+            attempts.append(1)
+            if len(attempts) < 3:
+                err = Exception()
+                err.sqlstate = "OC000"  # type: ignore[attr-defined]
+                raise err
+            return "recovered"
+
+        result = _retry_sync(execute, OCCRetryConfig())
+        assert result == "recovered"
+        assert len(attempts) == 3
+        assert mock_sleep.call_count == 2
+
+    @patch("dsql_core.occ_retry.time.sleep")
+    def test_exhausts_retries(self, mock_sleep):
+        attempts = []
+
+        def execute():
+            attempts.append(1)
+            err = Exception()
+            err.sqlstate = "OC000"  # type: ignore[attr-defined]
+            raise err
+
+        with pytest.raises(Exception) as exc_info:
+            _retry_sync(execute, OCCRetryConfig(max_retries=3))
+
+        assert hasattr(exc_info.value, "sqlstate")
+        assert len(attempts) == 4  # 1 initial + 3 retries
+
+    def test_non_occ_error_not_retried(self):
+        attempts = []
+
+        def execute():
+            attempts.append(1)
+            raise ValueError("not an OCC error")
+
+        with pytest.raises(ValueError, match="not an OCC error"):
+            _retry_sync(execute, OCCRetryConfig())
+
+        assert len(attempts) == 1
+
+    def test_zero_retries_executes_once(self):
+        attempts = []
+
+        def execute():
+            attempts.append(1)
+            err = Exception()
+            err.sqlstate = "OC000"  # type: ignore[attr-defined]
+            raise err
+
+        with pytest.raises(Exception):
+            _retry_sync(execute, OCCRetryConfig(max_retries=0))
+
+        assert len(attempts) == 1
+
+
+@pytest.mark.unit
+class TestRetryAsyncLoop:
+    @pytest.mark.asyncio
+    async def test_succeeds_first_try(self):
+        async def execute():
+            return "ok"
+
+        result = await _retry_async(execute, OCCRetryConfig())
+        assert result == "ok"
+
+    @pytest.mark.asyncio
+    @patch("dsql_core.occ_retry.asyncio.sleep")
+    async def test_retries_on_occ_then_succeeds(self, mock_sleep):
+        mock_sleep.return_value = None
+        attempts = []
+
+        async def execute():
+            attempts.append(1)
+            if len(attempts) < 3:
+                err = Exception()
+                err.sqlstate = "OC000"  # type: ignore[attr-defined]
+                raise err
+            return "recovered"
+
+        result = await _retry_async(execute, OCCRetryConfig())
+        assert result == "recovered"
+        assert len(attempts) == 3
+
+    @pytest.mark.asyncio
+    @patch("dsql_core.occ_retry.asyncio.sleep")
+    async def test_exhausts_retries(self, mock_sleep):
+        mock_sleep.return_value = None
+        attempts = []
+
+        async def execute():
+            attempts.append(1)
+            err = Exception()
+            err.sqlstate = "OC000"  # type: ignore[attr-defined]
+            raise err
+
+        with pytest.raises(Exception) as exc_info:
+            await _retry_async(execute, OCCRetryConfig(max_retries=3))
+
+        assert hasattr(exc_info.value, "sqlstate")
+        assert len(attempts) == 4
+
+    @pytest.mark.asyncio
+    async def test_non_occ_error_not_retried(self):
+        attempts = []
+
+        async def execute():
+            attempts.append(1)
+            raise ValueError("not an OCC error")
+
+        with pytest.raises(ValueError, match="not an OCC error"):
+            await _retry_async(execute, OCCRetryConfig())
+
+        assert len(attempts) == 1
+
+    @pytest.mark.asyncio
+    async def test_zero_retries_executes_once(self):
+        attempts = []
+
+        async def execute():
+            attempts.append(1)
+            err = Exception()
+            err.sqlstate = "OC000"  # type: ignore[attr-defined]
+            raise err
+
+        with pytest.raises(Exception):
+            await _retry_async(execute, OCCRetryConfig(max_retries=0))
+
+        assert len(attempts) == 1


### PR DESCRIPTION
## Summary
- Add `run_transaction()` API to all Python pool drivers (psycopg, psycopg2, asyncpg) with built-in retry for OCC conflicts (sqlstate OC000, OC001, 40001)
- Implement exponential backoff with configurable jitter via `OCCRetryConfig`
- Support pool-level and per-call retry configuration

## Test plan
- [x] Unit tests for OCC retry logic (`test_occ_retry.py`)
- [x] Integration tests for all pool drivers
- [x] Verify retry is triggered on OCC errors and respects max_retries

*Issue #, if available:*
N/A

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.