### PR TITLE
fix(postgres-js): graceful region fallback for unparseable hostnames

### DIFF
--- a/node/postgres-js/src/client.ts
+++ b/node/postgres-js/src/client.ts
@@ -55,11 +55,36 @@ function parseConnectionParams(
     throw new Error("Multi-host configurations are not supported for Aurora DSQL");
   }
 
-  if (!opts.region) {
-    opts.region = parseRegionFromHost(host);
+  if (!host) {
+    throw new Error("Host is required");
   }
 
-  if (isClusterID(host)) {
+  const isClusterId = !host.includes('.');
+
+  let parsedRegion: string | undefined;
+  if (!isClusterId) {
+    try {
+      parsedRegion = parseRegionFromHost(host);
+    } catch {
+      // Couldn't parse region from hostname.
+    }
+  }
+
+  opts.region =
+    opts.region ||
+    parsedRegion ||
+    process.env.AWS_REGION ||
+    process.env.AWS_DEFAULT_REGION;
+
+  if (!opts.region) {
+    if (isClusterId) {
+      throw new Error(`Region is not specified for cluster '${host}'`);
+    } else {
+      throw new Error(`Region is not specified and could not be parsed from hostname: '${host}'`);
+    }
+  }
+
+  if (isClusterId) {
     host = buildHostnameFromIdAndRegion(host, opts.region);
   }
 
@@ -318,22 +343,17 @@ function parseConnectionString(url: string): {
   };
 }
 
-function parseRegionFromHost(host: string): string | undefined {
+function parseRegionFromHost(host: string): string {
   if (!host) {
     throw new Error("Hostname is required to parse region");
   }
 
-  const match = host.match(
-    /^(?<instance>[^.]+)\.(?<dns>dsql(?:-[^.]+)?)\.(?<domain>(?<region>[a-zA-Z0-9-]+)\.on\.aws\.?)$/i
-  );
-  if (match?.groups) {
-    return match.groups.region;
+  const match = host.match(/\.dsql[^.]*\.([^.]+)\.on\.aws$/);
+  if (match) {
+    return match[1];
   }
-  throw new Error(`Unable to parse region from hostname: ${host}`);
-}
 
-function isClusterID(host: string) {
-  return !host.includes(".");
+  throw new Error(`Unable to parse region from hostname: '${host}'`);
 }
 
 function buildHostnameFromIdAndRegion(

--- a/node/postgres-js/test/client.test.ts
+++ b/node/postgres-js/test/client.test.ts
@@ -132,6 +132,74 @@ describe('AuroraDSQLPostgres', () => {
             const signerConfig = mockDsqlSigner.mock.calls[0][0];
             expect(signerConfig.region).toBe('us-east-1');
         });
+
+        test('should respect explicit region override even when hostname is parseable', () => {
+            AuroraDSQLPostgres({
+                host: 'cluster.dsql.us-east-1.on.aws',
+                username: 'admin',
+                region: 'eu-west-1'
+            });
+
+            expect(mockDsqlSigner).toHaveBeenCalledTimes(1);
+            const signerConfig = mockDsqlSigner.mock.calls[0][0];
+            expect(signerConfig.region).toBe('eu-west-1');
+        });
+
+        test('should use parsed region from hostname over env vars', () => {
+            process.env.AWS_REGION = 'eu-west-1';
+            process.env.AWS_DEFAULT_REGION = 'ap-south-1';
+
+            AuroraDSQLPostgres({
+                host: 'cluster.dsql.us-east-1.on.aws',
+                username: 'admin'
+            });
+
+            expect(mockDsqlSigner).toHaveBeenCalledTimes(1);
+            const signerConfig = mockDsqlSigner.mock.calls[0][0];
+            expect(signerConfig.region).toBe('us-east-1');
+
+            delete process.env.AWS_REGION;
+            delete process.env.AWS_DEFAULT_REGION;
+        });
+
+        test('should fall back to AWS_REGION for unknown host format', () => {
+            process.env.AWS_REGION = 'eu-west-1';
+
+            AuroraDSQLPostgres({
+                host: 'my-cluster.example.com',
+                username: 'admin'
+            });
+
+            expect(mockDsqlSigner).toHaveBeenCalledTimes(1);
+            const signerConfig = mockDsqlSigner.mock.calls[0][0];
+            expect(signerConfig.region).toBe('eu-west-1');
+
+            delete process.env.AWS_REGION;
+        });
+
+        test('should fall back to AWS_DEFAULT_REGION when AWS_REGION not set', () => {
+            process.env.AWS_DEFAULT_REGION = 'ap-south-1';
+
+            AuroraDSQLPostgres({
+                host: 'my-cluster.example.com',
+                username: 'admin'
+            });
+
+            expect(mockDsqlSigner).toHaveBeenCalledTimes(1);
+            const signerConfig = mockDsqlSigner.mock.calls[0][0];
+            expect(signerConfig.region).toBe('ap-south-1');
+
+            delete process.env.AWS_DEFAULT_REGION;
+        });
+
+        test('should throw when region cannot be determined for unknown host format', () => {
+            expect(() => {
+                AuroraDSQLPostgres({
+                    host: 'my-cluster.example.com',
+                    username: 'admin'
+                });
+            }).toThrow("Region is not specified and could not be parsed from hostname: 'my-cluster.example.com'");
+        });
     });
 
     describe('ClusterID as host', () => {
@@ -154,6 +222,30 @@ describe('AuroraDSQLPostgres', () => {
             expect(mockPostgres).toHaveBeenCalledTimes(1);
             const options = mockPostgres.mock.calls[0][0];
             expect(options.host).toBe('clusterID.dsql.us-east-1.on.aws')
+        });
+
+        test('should use AWS_REGION for cluster ID when region not in config', () => {
+            process.env.AWS_REGION = 'eu-west-1';
+
+            AuroraDSQLPostgres({
+                host: 'cluster123',
+                username: 'admin'
+            });
+
+            expect(mockPostgres).toHaveBeenCalledTimes(1);
+            const options = mockPostgres.mock.calls[0][0];
+            expect(options.host).toBe('cluster123.dsql.eu-west-1.on.aws');
+
+            delete process.env.AWS_REGION;
+        });
+
+        test('should throw when region cannot be determined for cluster ID', () => {
+            expect(() => {
+                AuroraDSQLPostgres({
+                    host: 'cluster123',
+                    username: 'admin'
+                });
+            }).toThrow("Region is not specified for cluster 'cluster123'");
         });
     });
 

--- a/node/postgres-js/test/client.test.ts
+++ b/node/postgres-js/test/client.test.ts
@@ -2,7 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { jest, describe, test, beforeAll, beforeEach, expect } from '@jest/globals';
+import { jest, describe, test, beforeAll, beforeEach, afterEach, expect } from '@jest/globals';
 import { auroraDSQLPostgres } from "../src";
 
 jest.mock('postgres', () => {
@@ -110,6 +110,11 @@ describe('AuroraDSQLPostgres', () => {
     });
 
     describe('parseRegionFromHost', () => {
+        afterEach(() => {
+            delete process.env.AWS_REGION;
+            delete process.env.AWS_DEFAULT_REGION;
+        });
+
         test('should extract region from DSQL hostname', () => {
             AuroraDSQLPostgres({
                 host: 'cluster.dsql.us-east-1.on.aws',
@@ -157,9 +162,6 @@ describe('AuroraDSQLPostgres', () => {
             expect(mockDsqlSigner).toHaveBeenCalledTimes(1);
             const signerConfig = mockDsqlSigner.mock.calls[0][0];
             expect(signerConfig.region).toBe('us-east-1');
-
-            delete process.env.AWS_REGION;
-            delete process.env.AWS_DEFAULT_REGION;
         });
 
         test('should fall back to AWS_REGION for unknown host format', () => {
@@ -173,8 +175,6 @@ describe('AuroraDSQLPostgres', () => {
             expect(mockDsqlSigner).toHaveBeenCalledTimes(1);
             const signerConfig = mockDsqlSigner.mock.calls[0][0];
             expect(signerConfig.region).toBe('eu-west-1');
-
-            delete process.env.AWS_REGION;
         });
 
         test('should fall back to AWS_DEFAULT_REGION when AWS_REGION not set', () => {
@@ -188,8 +188,6 @@ describe('AuroraDSQLPostgres', () => {
             expect(mockDsqlSigner).toHaveBeenCalledTimes(1);
             const signerConfig = mockDsqlSigner.mock.calls[0][0];
             expect(signerConfig.region).toBe('ap-south-1');
-
-            delete process.env.AWS_DEFAULT_REGION;
         });
 
         test('should throw when region cannot be determined for unknown host format', () => {
@@ -203,6 +201,11 @@ describe('AuroraDSQLPostgres', () => {
     });
 
     describe('ClusterID as host', () => {
+        afterEach(() => {
+            delete process.env.AWS_REGION;
+            delete process.env.AWS_DEFAULT_REGION;
+        });
+
         test('should handle cluster ID given as hostname in connection string', () => {
             AuroraDSQLPostgres('postgres://admin@clusterID/', {
                 region: 'us-east-1'
@@ -235,8 +238,6 @@ describe('AuroraDSQLPostgres', () => {
             expect(mockPostgres).toHaveBeenCalledTimes(1);
             const options = mockPostgres.mock.calls[0][0];
             expect(options.host).toBe('cluster123.dsql.eu-west-1.on.aws');
-
-            delete process.env.AWS_REGION;
         });
 
         test('should throw when region cannot be determined for cluster ID', () => {


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*

Previously, `parseRegionFromHost` would throw immediately on unrecognized hostname formats, causing connection failures even when the region was available via environment variables.

**Changes:**
- Region now resolves via priority chain: explicit config > parsed hostname > `AWS_REGION` > `AWS_DEFAULT_REGION`
- Graceful fallback with try-catch around `parseRegionFromHost` instead of immediate throw
- Simplified regex to `/\.dsql[^.]*\.([^.]+)\.on\.aws$/` to match the node-postgres connector. This drops case-insensitive matching and trailing-dot FQDN support from the previous pattern — intentional, for parity with node-postgres.
- Distinct error messages for cluster ID vs unknown hostname when region is undetermined
- Removed standalone `isClusterID` function (inlined one-liner)
- Added 7 unit tests covering all fallback paths

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.