### PR TITLE
feat(jdbc): add OCC retry with exponential backoff

### DIFF
--- a/.github/workflows/java-jdbc-ci.yml
+++ b/.github/workflows/java-jdbc-ci.yml
@@ -106,11 +106,16 @@ jobs:
           CLUSTER_USER: "admin"
         run: ./gradlew integrationTest
 
+      - name: Publish connector to Maven Local
+        run: ./gradlew publishToMavenLocal
+
       - name: Run example smoke tests
         working-directory: java/jdbc/examples/pgjdbc
         env:
           CLUSTER_ENDPOINT: ${{ needs.create-cluster.outputs.cluster-endpoint }}
           CLUSTER_USER: "admin"
+          USE_MAVEN_LOCAL: "true"
+          CONNECTOR_VERSION: "0.0.0-SNAPSHOT"
         run: ../../gradlew test
 
   integration-tests:

--- a/java/jdbc/README.md
+++ b/java/jdbc/README.md
@@ -160,6 +160,115 @@ java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
 java.util.logging.SimpleFormatter.format = %1$tH:%1$tM:%1$tS.%1$tL [%4$s] %3$s - %5$s%n
 ```
 
+## OCC Retry
+
+Aurora DSQL uses Optimistic Concurrency Control (OCC) — conflicts are detected at commit time. When two transactions modify the same data, the second to commit receives an OCC error. This connector provides utilities for automatic retry with exponential backoff.
+
+### Quick Start
+
+```java
+// Bind once, reuse across call sites
+DataSource ds = new HikariDataSource(config);
+OCCTransactionRunner runner = OCCTransactionRunner.create(ds);
+
+int count = runner.run(conn -> {
+    Statement stmt = conn.createStatement();
+    stmt.executeUpdate("UPDATE accounts SET balance = balance - 100 WHERE id = 1");
+    stmt.executeUpdate("UPDATE accounts SET balance = balance + 100 WHERE id = 2");
+    return 2;
+});
+
+// Void variant — no need to return null
+runner.runVoid(conn -> {
+    conn.createStatement().executeUpdate("DELETE FROM expired_sessions");
+});
+```
+
+### Custom Configuration
+
+```java
+OCCRetryConfig config = OCCRetryConfig.builder()
+    .maxRetries(5)
+    .baseDelayMs(200)
+    .maxDelayMs(10000)
+    .multiplier(2.0)
+    .jitterFactor(0.5)
+    .build();
+
+OCCTransactionRunner runner = OCCTransactionRunner.create(ds, config);
+```
+
+### Static API (for one-off use)
+
+```java
+OCCRetry.execute(dataSource, OCCRetryConfig.defaults(), conn -> {
+    // transaction work
+    return result;
+});
+
+// With an existing connection (rolled back between attempts, not closed)
+OCCRetry.execute(connection, OCCRetryConfig.defaults(), conn -> {
+    // transaction work
+    return result;
+});
+```
+
+### Integration with Retry Frameworks
+
+Use `OCCRetry.isOCCError(SQLException)` as the predicate for any retry framework:
+
+**Spring Retry:**
+```java
+RetryTemplate template = RetryTemplate.builder()
+    .maxAttempts(4)
+    .exponentialBackoff(100, 2.0, 5000)
+    .retryOn(SQLException.class)
+    .traversingCauses()
+    .build();
+
+template.execute(ctx -> {
+    try (Connection conn = ds.getConnection()) {
+        conn.setAutoCommit(false);
+        // ... transaction work ...
+        conn.commit();
+        return null;
+    }
+});
+```
+
+**Resilience4j:**
+```java
+RetryConfig retryConfig = RetryConfig.custom()
+    .maxAttempts(4)
+    .retryOnException(e -> e instanceof SQLException && OCCRetry.isOCCError((SQLException) e))
+    .build();
+```
+
+**Failsafe:**
+```java
+RetryPolicy<Object> policy = RetryPolicy.builder()
+    .handleIf(e -> e instanceof SQLException && OCCRetry.isOCCError((SQLException) e))
+    .withMaxAttempts(4)
+    .withBackoff(Duration.ofMillis(100), Duration.ofSeconds(5))
+    .build();
+```
+
+**Plain loop:**
+```java
+SQLException lastErr = null;
+for (int i = 0; i <= maxRetries; i++) {
+    try {
+        doTransaction(ds);
+        return;
+    } catch (SQLException e) {
+        if (!OCCRetry.isOCCError(e)) throw e;
+        lastErr = e;
+        Thread.sleep(backoff(i));
+    }
+}
+throw lastErr;
+```
+
 ## Examples
 
 | Description | Examples |

--- a/java/jdbc/examples/pgjdbc/README.md
+++ b/java/jdbc/examples/pgjdbc/README.md
@@ -73,6 +73,7 @@ The example demonstrates the following operations:
 - Opening a connection to an Aurora DSQL cluster
 - Creating a table
 - Inserting and querying data
+- Automatic OCC (Optimistic Concurrency Control) retry for write operations
 
 The example is designed to work with both admin and non-admin users:
 

--- a/java/jdbc/examples/pgjdbc/build.gradle.kts
+++ b/java/jdbc/examples/pgjdbc/build.gradle.kts
@@ -15,13 +15,18 @@ application {
 group = "software.amazon.dsql.examples"
 version = "1.0-SNAPSHOT"
 
+val connectorVersion: String = providers.environmentVariable("CONNECTOR_VERSION").getOrElse("1.4.0")
+
 repositories {
+    if (providers.environmentVariable("USE_MAVEN_LOCAL").isPresent) {
+        mavenLocal()
+    }
     mavenCentral()
 }
 
 dependencies {
     implementation("com.zaxxer:HikariCP:7.0.2")
-    implementation("software.amazon.dsql:aurora-dsql-jdbc-connector:1.4.0")
+    implementation("software.amazon.dsql:aurora-dsql-jdbc-connector:$connectorVersion")
 
     testImplementation(platform("org.junit:junit-bom:6.1.0"))
     testImplementation("org.junit.jupiter:junit-jupiter")

--- a/java/jdbc/examples/pgjdbc/src/main/java/software/amazon/dsql/examples/ExamplePreferred.java
+++ b/java/jdbc/examples/pgjdbc/src/main/java/software/amazon/dsql/examples/ExamplePreferred.java
@@ -14,6 +14,8 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 
+import software.amazon.dsql.jdbc.OCCTransactionRunner;
+
 /**
  * Aurora DSQL example using HikariCP with Aurora DSQL JDBC Connector
  * <p>
@@ -30,9 +32,11 @@ import java.sql.Statement;
 public class ExamplePreferred {
 
     private final HikariDataSource dataSource;
+    private final OCCTransactionRunner transactionRunner;
 
     public ExamplePreferred(String endpoint, String user) {
         this.dataSource = initializeConnectionPool(endpoint, user);
+        this.transactionRunner = OCCTransactionRunner.create(dataSource);
     }
 
     private HikariDataSource initializeConnectionPool(String endpoint, String username) {
@@ -82,30 +86,35 @@ public class ExamplePreferred {
         return this.dataSource.getConnection();
     }
 
-    private void executeExample(Connection conn, int connectionNumber) throws SQLException {
+    private void executeExample(int connectionNumber) throws SQLException {
         // Create a new table named owner
-        try (Statement create = conn.createStatement()) {
-            create.executeUpdate("""
-                    CREATE TABLE IF NOT EXISTS owner(
-                    id uuid NOT NULL DEFAULT gen_random_uuid(),
-                    name varchar(30) NOT NULL,
-                    city varchar(80) NOT NULL,
-                    telephone varchar(20) DEFAULT NULL,
-                    PRIMARY KEY (id))""");
-        }
+        transactionRunner.runVoid(conn -> {
+            try (Statement create = conn.createStatement()) {
+                create.executeUpdate("""
+                        CREATE TABLE IF NOT EXISTS owner(
+                        id uuid NOT NULL DEFAULT gen_random_uuid(),
+                        name varchar(30) NOT NULL,
+                        city varchar(80) NOT NULL,
+                        telephone varchar(20) DEFAULT NULL,
+                        PRIMARY KEY (id))""");
+            }
+        });
 
         // Insert some data with a unique identifier
         String uniqueName = "John Doe " + System.currentTimeMillis() + "_" + connectionNumber;
-        try (PreparedStatement insert = conn.prepareStatement(
-                "INSERT INTO owner (name, city, telephone) VALUES (?, ?, ?)")) {
-            insert.setString(1, uniqueName);
-            insert.setString(2, "Anytown");
-            insert.setString(3, "555-555-1991");
-            insert.executeUpdate();
-        }
+        transactionRunner.runVoid(conn -> {
+            try (PreparedStatement insert = conn.prepareStatement(
+                    "INSERT INTO owner (name, city, telephone) VALUES (?, ?, ?)")) {
+                insert.setString(1, uniqueName);
+                insert.setString(2, "Anytown");
+                insert.setString(3, "555-555-1991");
+                insert.executeUpdate();
+            }
+        });
 
         // Read back the data and verify
-        try (PreparedStatement read = conn.prepareStatement("SELECT * FROM owner WHERE name = ?")) {
+        try (Connection conn = dataSource.getConnection();
+             PreparedStatement read = conn.prepareStatement("SELECT * FROM owner WHERE name = ?")) {
             read.setString(1, uniqueName);
             try (ResultSet rs = read.executeQuery()) {
                 while (rs.next()) {
@@ -136,30 +145,26 @@ public class ExamplePreferred {
 
         try {
 
-            // Demonstrate connection pooling with multiple concurrent connections
-            System.out.println("Testing connection pool with multiple connections...");
+            // Demonstrate connection pooling with OCC retry
+            System.out.println("Testing connection pool with OCC retry...");
 
-            try (Connection conn1 = example.getConnection();
-                 Connection conn2 = example.getConnection();
-                 Connection conn3 = example.getConnection()) {
+            System.out.println("Connection 1 obtained from pool");
+            example.executeExample(1);
 
-                System.out.println("Connection 1 obtained from pool");
-                example.executeExample(conn1, 1);
+            System.out.println("Connection 2 obtained from pool");
+            example.executeExample(2);
 
-                System.out.println("Connection 2 obtained from pool");
-                example.executeExample(conn2, 2);
+            System.out.println("Connection 3 obtained from pool");
+            example.executeExample(3);
 
-                System.out.println("Connection 3 obtained from pool");
-                example.executeExample(conn3, 3);
-            }
-
-            try (Connection conn = example.getConnection();
-                 PreparedStatement cleanup = conn.prepareStatement("DELETE FROM owner WHERE name LIKE ?")) {
-                cleanup.setString(1, "%John Doe%");
-                int deletedRows = cleanup.executeUpdate();
-
-                System.out.println("Cleaned up " + deletedRows + " test records");
-            }
+            // Cleanup
+            example.transactionRunner.runVoid(conn -> {
+                try (PreparedStatement cleanup = conn.prepareStatement("DELETE FROM owner WHERE name LIKE ?")) {
+                    cleanup.setString(1, "%John Doe%");
+                    int deletedRows = cleanup.executeUpdate();
+                    System.out.println("Cleaned up " + deletedRows + " test records");
+                }
+            });
 
         } finally {
             // Graceful shutdown

--- a/java/jdbc/examples/pgjdbc/src/main/java/software/amazon/dsql/examples/alternatives/README.md
+++ b/java/jdbc/examples/pgjdbc/src/main/java/software/amazon/dsql/examples/alternatives/README.md
@@ -18,4 +18,4 @@ The connector + pool combination handles this automatically:
 
 ### `no_connection_pool/`
 Examples without pooling:
-- `ExampleWithNoConnectionPool.java` - Single connection with connector
+- `ExampleWithNoConnectionPool.java` - Single connection with connector and OCC retry

--- a/java/jdbc/examples/pgjdbc/src/main/java/software/amazon/dsql/examples/alternatives/no_connection_pool/ExampleWithNoConnectionPool.java
+++ b/java/jdbc/examples/pgjdbc/src/main/java/software/amazon/dsql/examples/alternatives/no_connection_pool/ExampleWithNoConnectionPool.java
@@ -14,6 +14,9 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Properties;
 
+import software.amazon.dsql.jdbc.OCCRetry;
+import software.amazon.dsql.jdbc.OCCRetryConfig;
+
 public class ExampleWithNoConnectionPool {
 
     // Get a connection to Aurora DSQL.
@@ -42,25 +45,35 @@ public class ExampleWithNoConnectionPool {
                     setSchema.execute("SET search_path=myschema");
                 }
             }
+
+            // Use OCC retry with existing connection for write operations
+            OCCRetryConfig retryConfig = OCCRetryConfig.defaults();
+
             // Create a new table named owner
-            try (Statement create = conn.createStatement()) {
-                create.executeUpdate("""
-                        CREATE TABLE IF NOT EXISTS owner(
-                        id uuid NOT NULL DEFAULT gen_random_uuid(),
-                        name varchar(30) NOT NULL,
-                        city varchar(80) NOT NULL,
-                        telephone varchar(20) DEFAULT NULL,
-                        PRIMARY KEY (id))""");
-            }
+            OCCRetry.execute(conn, retryConfig, c -> {
+                try (Statement create = c.createStatement()) {
+                    create.executeUpdate("""
+                            CREATE TABLE IF NOT EXISTS owner(
+                            id uuid NOT NULL DEFAULT gen_random_uuid(),
+                            name varchar(30) NOT NULL,
+                            city varchar(80) NOT NULL,
+                            telephone varchar(20) DEFAULT NULL,
+                            PRIMARY KEY (id))""");
+                }
+                return null;
+            });
 
             // Insert some data
-            try (PreparedStatement insert = conn.prepareStatement(
-                    "INSERT INTO owner (name, city, telephone) VALUES (?, ?, ?)")) {
-                insert.setString(1, "John Doe");
-                insert.setString(2, "Anytown");
-                insert.setString(3, "555-555-1999");
-                insert.executeUpdate();
-            }
+            OCCRetry.execute(conn, retryConfig, c -> {
+                try (PreparedStatement insert = c.prepareStatement(
+                        "INSERT INTO owner (name, city, telephone) VALUES (?, ?, ?)")) {
+                    insert.setString(1, "John Doe");
+                    insert.setString(2, "Anytown");
+                    insert.setString(3, "555-555-1999");
+                    insert.executeUpdate();
+                }
+                return null;
+            });
 
             // Read back the data and assert they are present
             try (PreparedStatement read = conn.prepareStatement("SELECT * FROM owner WHERE name = ?")) {
@@ -76,10 +89,13 @@ public class ExampleWithNoConnectionPool {
             }
 
             // Delete some data
-            try (PreparedStatement delete = conn.prepareStatement("DELETE FROM owner WHERE name = ?")) {
-                delete.setString(1, "John Doe");
-                delete.executeUpdate();
-            }
+            OCCRetry.execute(conn, retryConfig, c -> {
+                try (PreparedStatement delete = c.prepareStatement("DELETE FROM owner WHERE name = ?")) {
+                    delete.setString(1, "John Doe");
+                    delete.executeUpdate();
+                }
+                return null;
+            });
         }
         System.out.println("Connection exercised successfully");
     }

--- a/java/jdbc/integration-tests/src/test/java/software/amazon/dsql/jdbc/integration/BasicConnectionIntegrationTest.java
+++ b/java/jdbc/integration-tests/src/test/java/software/amazon/dsql/jdbc/integration/BasicConnectionIntegrationTest.java
@@ -182,6 +182,7 @@ public class BasicConnectionIntegrationTest {
 
     @Test
     void testTransactionHandling() throws SQLException {
+        String tableName = "test_txn_" + System.currentTimeMillis();
         try (Connection conn = createConnection()) {
             assertNotNull(conn, "Connection should not be null");
 
@@ -190,33 +191,32 @@ public class BasicConnectionIntegrationTest {
             assertFalse(conn.getAutoCommit(), "Auto-commit should be disabled");
 
             try (Statement stmt = conn.createStatement()) {
-                // Create a temporary table for testing
-                stmt.executeUpdate("DROP TABLE IF EXISTS test_table");
-                // Commit the transaction
-                conn.commit();
-            }
-
-            try (Statement stmt = conn.createStatement()) {
-                // Create a temporary table for testing
                 stmt.executeUpdate(
-                        "CREATE TABLE IF NOT EXISTS test_table (id INTEGER, name VARCHAR(50))");
-                // Commit the transaction
+                        "CREATE TABLE IF NOT EXISTS "
+                                + tableName
+                                + " (id INTEGER, name VARCHAR(50))");
                 conn.commit();
             }
 
             try (Statement stmt = conn.createStatement()) {
                 // Insert test data
-                stmt.executeUpdate("INSERT INTO test_table (id, name) VALUES (1, 'test1')");
-                stmt.executeUpdate("INSERT INTO test_table (id, name) VALUES (2, 'test2')");
+                stmt.executeUpdate("INSERT INTO " + tableName + " (id, name) VALUES (1, 'test1')");
+                stmt.executeUpdate("INSERT INTO " + tableName + " (id, name) VALUES (2, 'test2')");
 
                 // Commit the transaction
                 conn.commit();
 
                 // Verify data was committed
-                try (ResultSet rs = stmt.executeQuery("SELECT COUNT(*) FROM test_table")) {
+                try (ResultSet rs = stmt.executeQuery("SELECT COUNT(*) FROM " + tableName)) {
                     assertTrue(rs.next(), "Result set should have at least one row");
                     assertEquals(2, rs.getInt(1), "Should have 2 rows in test table");
                 }
+            }
+
+            // Cleanup
+            try (Statement stmt = conn.createStatement()) {
+                stmt.executeUpdate("DROP TABLE IF EXISTS " + tableName);
+                conn.commit();
             }
 
             // Reset auto-commit

--- a/java/jdbc/integration-tests/src/test/java/software/amazon/dsql/jdbc/integration/OCCRetryIntegrationTest.java
+++ b/java/jdbc/integration-tests/src/test/java/software/amazon/dsql/jdbc/integration/OCCRetryIntegrationTest.java
@@ -1,0 +1,470 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.dsql.jdbc.integration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.PrintWriter;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Properties;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Logger;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import software.amazon.dsql.jdbc.OCCRetry;
+import software.amazon.dsql.jdbc.OCCRetryConfig;
+import software.amazon.dsql.jdbc.OCCTransactionRunner;
+
+/**
+ * Integration tests for OCC retry against a live Aurora DSQL cluster.
+ *
+ * <p>Environment variables required:
+ * <li>CLUSTER_ENDPOINT: Aurora DSQL cluster endpoint
+ * <li>CLUSTER_USER: Database user (default: admin)
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class OCCRetryIntegrationTest {
+
+    private static final String CLUSTER_ENDPOINT = System.getenv("CLUSTER_ENDPOINT");
+    private static final String CLUSTER_USER = System.getenv("CLUSTER_USER");
+    private final String tableName = "occ_retry_" + Long.toHexString(System.nanoTime());
+
+    private static final OCCRetryConfig SETUP_CONFIG =
+            OCCRetryConfig.builder().maxRetries(10).baseDelayMs(100).maxDelayMs(2000).build();
+
+    @BeforeAll
+    void setUp() throws SQLException {
+        assertNotNull(CLUSTER_ENDPOINT, "CLUSTER_ENDPOINT environment variable must be set");
+
+        try (Connection conn = createConnection()) {
+            conn.setAutoCommit(true);
+            try (Statement stmt = conn.createStatement()) {
+                stmt.executeUpdate(
+                        "CREATE TABLE IF NOT EXISTS "
+                                + tableName
+                                + " (id INT PRIMARY KEY, value INT)");
+            }
+        }
+    }
+
+    @AfterAll
+    void tearDown() {
+        try (Connection conn = createConnection()) {
+            conn.setAutoCommit(true);
+            try (Statement stmt = conn.createStatement()) {
+                stmt.executeUpdate("DROP TABLE IF EXISTS " + tableName);
+            }
+        } catch (SQLException e) {
+            // best-effort cleanup
+        }
+    }
+
+    private Connection createConnection() throws SQLException {
+        String user = CLUSTER_USER != null ? CLUSTER_USER : "admin";
+        String url = "jdbc:aws-dsql:postgresql://" + CLUSTER_ENDPOINT + "/postgres";
+        Properties props = new Properties();
+        props.setProperty("user", user);
+        return DriverManager.getConnection(url, props);
+    }
+
+    private DataSource createDataSource() {
+        return new DataSource() {
+            public Connection getConnection() throws SQLException {
+                return createConnection();
+            }
+
+            public Connection getConnection(String username, String password) throws SQLException {
+                return createConnection();
+            }
+
+            public PrintWriter getLogWriter() {
+                return null;
+            }
+
+            public void setLogWriter(PrintWriter out) {}
+
+            public void setLoginTimeout(int seconds) {}
+
+            public int getLoginTimeout() {
+                return 0;
+            }
+
+            public Logger getParentLogger() {
+                return Logger.getLogger("software.amazon.dsql.jdbc");
+            }
+
+            public <T> T unwrap(Class<T> iface) throws SQLException {
+                throw new SQLException("not a wrapper");
+            }
+
+            public boolean isWrapperFor(Class<?> iface) {
+                return false;
+            }
+        };
+    }
+
+    private void resetRow(int id, int value) throws SQLException {
+        OCCRetry.execute(
+                createDataSource(),
+                SETUP_CONFIG,
+                conn -> {
+                    try (Statement stmt = conn.createStatement()) {
+                        stmt.executeUpdate(
+                                "INSERT INTO "
+                                        + tableName
+                                        + " (id, value) VALUES ("
+                                        + id
+                                        + ", "
+                                        + value
+                                        + ")"
+                                        + " ON CONFLICT (id) DO UPDATE SET value = "
+                                        + value);
+                    }
+                    return null;
+                });
+    }
+
+    @Test
+    void testOCCRetryDeterministicConflict() throws Exception {
+        OCCRetryConfig config =
+                OCCRetryConfig.builder().maxRetries(10).baseDelayMs(50).maxDelayMs(1000).build();
+
+        resetRow(1, 0);
+
+        CountDownLatch t1HasRead = new CountDownLatch(1);
+        CountDownLatch t2HasCommitted = new CountDownLatch(1);
+        AtomicInteger t1Attempts = new AtomicInteger(0);
+        AtomicReference<Exception> t2Error = new AtomicReference<>();
+
+        Thread t2 =
+                new Thread(
+                        () -> {
+                            try {
+                                assertTrue(
+                                        t1HasRead.await(30, TimeUnit.SECONDS),
+                                        "T1 should have read");
+                                OCCRetry.execute(
+                                        createDataSource(),
+                                        SETUP_CONFIG,
+                                        conn -> {
+                                            try (Statement stmt = conn.createStatement()) {
+                                                stmt.executeUpdate(
+                                                        "UPDATE "
+                                                                + tableName
+                                                                + " SET value = 100 WHERE id = 1");
+                                            }
+                                            return null;
+                                        });
+                            } catch (Exception e) {
+                                t2Error.set(e);
+                            } finally {
+                                t2HasCommitted.countDown();
+                            }
+                        });
+        t2.start();
+
+        try (Connection conn = createConnection()) {
+            Integer result =
+                    OCCRetry.execute(
+                            conn,
+                            config,
+                            c -> {
+                                int attempt = t1Attempts.incrementAndGet();
+                                int currentValue;
+                                try (Statement stmt = c.createStatement();
+                                        ResultSet rs =
+                                                stmt.executeQuery(
+                                                        "SELECT value FROM "
+                                                                + tableName
+                                                                + " WHERE id = 1")) {
+                                    assertTrue(rs.next());
+                                    currentValue = rs.getInt("value");
+                                }
+
+                                if (attempt == 1) {
+                                    t1HasRead.countDown();
+                                    try {
+                                        assertTrue(
+                                                t2HasCommitted.await(30, TimeUnit.SECONDS),
+                                                "T2 should have committed");
+                                    } catch (InterruptedException ie) {
+                                        Thread.currentThread().interrupt();
+                                        throw new SQLException("interrupted", ie);
+                                    }
+                                }
+
+                                try (Statement stmt = c.createStatement()) {
+                                    stmt.executeUpdate(
+                                            "UPDATE "
+                                                    + tableName
+                                                    + " SET value = "
+                                                    + (currentValue + 10)
+                                                    + " WHERE id = 1");
+                                }
+                                return currentValue + 10;
+                            });
+
+            assertNotNull(result);
+        }
+
+        t2.join(30_000);
+        assertFalse(t2.isAlive(), "T2 should have finished");
+        if (t2Error.get() != null) {
+            throw t2Error.get();
+        }
+
+        assertTrue(
+                t1Attempts.get() >= 2,
+                "Expected OCC retry but T1 ran only " + t1Attempts.get() + " time(s)");
+
+        try (Connection conn = createConnection();
+                Statement stmt = conn.createStatement();
+                ResultSet rs =
+                        stmt.executeQuery("SELECT value FROM " + tableName + " WHERE id = 1")) {
+            assertTrue(rs.next());
+            assertEquals(110, rs.getInt("value"));
+        }
+    }
+
+    @Test
+    void testOCCRetryConcurrentIncrements() throws Exception {
+        OCCRetryConfig config =
+                OCCRetryConfig.builder().maxRetries(10).baseDelayMs(50).maxDelayMs(1000).build();
+
+        resetRow(2, 0);
+
+        int numThreads = 3;
+        AtomicInteger totalAttempts = new AtomicInteger(0);
+        AtomicReference<Exception> firstError = new AtomicReference<>();
+        Thread[] threads = new Thread[numThreads];
+
+        for (int i = 0; i < numThreads; i++) {
+            threads[i] =
+                    new Thread(
+                            () -> {
+                                try (Connection conn = createConnection()) {
+                                    OCCRetry.execute(
+                                            conn,
+                                            config,
+                                            c -> {
+                                                totalAttempts.incrementAndGet();
+                                                int current;
+                                                try (Statement stmt = c.createStatement();
+                                                        ResultSet rs =
+                                                                stmt.executeQuery(
+                                                                        "SELECT value FROM "
+                                                                                + tableName
+                                                                                + " WHERE id = 2")) {
+                                                    assertTrue(rs.next());
+                                                    current = rs.getInt("value");
+                                                }
+                                                try (Statement stmt = c.createStatement()) {
+                                                    stmt.executeUpdate(
+                                                            "UPDATE "
+                                                                    + tableName
+                                                                    + " SET value = "
+                                                                    + (current + 1)
+                                                                    + " WHERE id = 2");
+                                                }
+                                                return null;
+                                            });
+                                } catch (Exception e) {
+                                    firstError.compareAndSet(null, e);
+                                }
+                            });
+            threads[i].start();
+        }
+
+        for (Thread t : threads) {
+            t.join(60_000);
+            assertFalse(t.isAlive(), "Thread should have finished");
+        }
+
+        if (firstError.get() != null) {
+            throw firstError.get();
+        }
+
+        assertTrue(
+                totalAttempts.get() > numThreads,
+                "Expected OCC retries but total attempts ("
+                        + totalAttempts.get()
+                        + ") equals thread count — no contention occurred");
+
+        try (Connection conn = createConnection();
+                Statement stmt = conn.createStatement();
+                ResultSet rs =
+                        stmt.executeQuery("SELECT value FROM " + tableName + " WHERE id = 2")) {
+            assertTrue(rs.next());
+            assertEquals(numThreads, rs.getInt("value"));
+        }
+    }
+
+    @Test
+    void testOCCRetryWithDataSource() throws Exception {
+        OCCRetryConfig config =
+                OCCRetryConfig.builder().maxRetries(10).baseDelayMs(50).maxDelayMs(1000).build();
+        DataSource ds = createDataSource();
+
+        resetRow(3, 0);
+
+        CountDownLatch t1HasRead = new CountDownLatch(1);
+        CountDownLatch t2HasCommitted = new CountDownLatch(1);
+        AtomicInteger t1Attempts = new AtomicInteger(0);
+        AtomicReference<Exception> t2Error = new AtomicReference<>();
+
+        Thread t2 =
+                new Thread(
+                        () -> {
+                            try {
+                                assertTrue(
+                                        t1HasRead.await(30, TimeUnit.SECONDS),
+                                        "T1 should have read");
+                                OCCRetry.execute(
+                                        createDataSource(),
+                                        SETUP_CONFIG,
+                                        conn -> {
+                                            try (Statement stmt = conn.createStatement()) {
+                                                stmt.executeUpdate(
+                                                        "UPDATE "
+                                                                + tableName
+                                                                + " SET value = 50 WHERE id = 3");
+                                            }
+                                            return null;
+                                        });
+                            } catch (Exception e) {
+                                t2Error.set(e);
+                            } finally {
+                                t2HasCommitted.countDown();
+                            }
+                        });
+        t2.start();
+
+        Integer result =
+                OCCRetry.execute(
+                        ds,
+                        config,
+                        c -> {
+                            int attempt = t1Attempts.incrementAndGet();
+                            int currentValue;
+                            try (Statement stmt = c.createStatement();
+                                    ResultSet rs =
+                                            stmt.executeQuery(
+                                                    "SELECT value FROM "
+                                                            + tableName
+                                                            + " WHERE id = 3")) {
+                                assertTrue(rs.next());
+                                currentValue = rs.getInt("value");
+                            }
+
+                            if (attempt == 1) {
+                                t1HasRead.countDown();
+                                try {
+                                    assertTrue(
+                                            t2HasCommitted.await(30, TimeUnit.SECONDS),
+                                            "T2 should have committed");
+                                } catch (InterruptedException ie) {
+                                    Thread.currentThread().interrupt();
+                                    throw new SQLException("interrupted", ie);
+                                }
+                            }
+
+                            try (Statement stmt = c.createStatement()) {
+                                stmt.executeUpdate(
+                                        "UPDATE "
+                                                + tableName
+                                                + " SET value = "
+                                                + (currentValue + 5)
+                                                + " WHERE id = 3");
+                            }
+                            return currentValue + 5;
+                        });
+
+        t2.join(30_000);
+        assertFalse(t2.isAlive(), "T2 should have finished");
+        if (t2Error.get() != null) {
+            throw t2Error.get();
+        }
+
+        assertTrue(t1Attempts.get() >= 2, "Expected OCC retry via DataSource");
+        assertEquals(55, result);
+    }
+
+    @Test
+    void testOCCTransactionRunnerVoid() throws SQLException {
+        DataSource ds = createDataSource();
+        OCCTransactionRunner runner = OCCTransactionRunner.create(ds, SETUP_CONFIG);
+
+        resetRow(4, 0);
+
+        runner.runVoid(
+                c -> {
+                    try (Statement stmt = c.createStatement()) {
+                        stmt.executeUpdate("UPDATE " + tableName + " SET value = 42 WHERE id = 4");
+                    }
+                });
+
+        try (Connection conn = createConnection();
+                Statement stmt = conn.createStatement();
+                ResultSet rs =
+                        stmt.executeQuery("SELECT value FROM " + tableName + " WHERE id = 4")) {
+            assertTrue(rs.next());
+            assertEquals(42, rs.getInt("value"));
+        }
+    }
+
+    @Test
+    void testNonOCCErrorPropagatesImmediately() throws SQLException {
+        OCCRetryConfig config =
+                OCCRetryConfig.builder().maxRetries(5).baseDelayMs(10).maxDelayMs(200).build();
+        AtomicInteger attempts = new AtomicInteger(0);
+
+        try (Connection conn = createConnection()) {
+            SQLException thrown =
+                    assertThrows(
+                            SQLException.class,
+                            () ->
+                                    OCCRetry.execute(
+                                            conn,
+                                            config,
+                                            c -> {
+                                                attempts.incrementAndGet();
+                                                try (Statement stmt = c.createStatement()) {
+                                                    stmt.executeQuery(
+                                                            "SELECT * FROM nonexistent_table_xyz");
+                                                }
+                                                return null;
+                                            }));
+
+            assertEquals(1, attempts.get(), "Non-OCC error should not trigger retry");
+            assertFalse(OCCRetry.isOCCError(thrown), "Error should not be classified as OCC");
+        }
+    }
+}

--- a/java/jdbc/src/main/java/software/amazon/dsql/jdbc/OCCRetry.java
+++ b/java/jdbc/src/main/java/software/amazon/dsql/jdbc/OCCRetry.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.dsql.jdbc;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Objects;
+import java.util.concurrent.ThreadLocalRandom;
+import javax.sql.DataSource;
+
+/**
+ * Executes a transaction callback with automatic retry on OCC (Optimistic Concurrency Control)
+ * conflicts.
+ *
+ * <p>Aurora DSQL uses OCC where conflicts are detected at commit time. When two transactions modify
+ * the same data concurrently, the second to commit receives an OCC error. This utility
+ * automatically retries the transaction with exponential backoff.
+ *
+ * <h3>Usage with connection pool (recommended)</h3>
+ *
+ * <pre>{@code
+ * DataSource ds = new HikariDataSource(config);
+ * OCCRetryConfig retryConfig = OCCRetryConfig.defaults();
+ *
+ * int result = OCCRetry.execute(ds, retryConfig, conn -> {
+ *     Statement stmt = conn.createStatement();
+ *     stmt.executeUpdate("UPDATE accounts SET balance = balance - 100 WHERE id = 1");
+ *     stmt.executeUpdate("UPDATE accounts SET balance = balance + 100 WHERE id = 2");
+ *     return 2;
+ * });
+ * }</pre>
+ *
+ * <h3>Usage with direct connection</h3>
+ *
+ * <pre>{@code
+ * Connection conn = DriverManager.getConnection(url, props);
+ * OCCRetry.execute(conn, retryConfig, c -> {
+ *     c.createStatement().executeUpdate("UPDATE accounts SET ...");
+ *     return null;
+ * });
+ * }</pre>
+ *
+ * <p><b>Idempotency warning:</b> The callback may be called multiple times on OCC conflicts. Ensure
+ * it has no side effects that should not be repeated (e.g., sending emails, incrementing external
+ * counters).
+ */
+public final class OCCRetry {
+
+    private static final String OCC_CODE_MUTATION = "OC000";
+    private static final String OCC_CODE_SCHEMA = "OC001";
+    private static final String OCC_CODE_SERIALIZATION = "40001";
+
+    private OCCRetry() {
+        throw new UnsupportedOperationException(
+                "This is a utility class and cannot be instantiated");
+    }
+
+    /**
+     * Callback interface for transaction work to be executed with OCC retry.
+     *
+     * @param <T> the return type of the transaction
+     */
+    @FunctionalInterface
+    public interface TransactionCallback<T> {
+        /**
+         * Executes transaction work on the provided connection.
+         *
+         * <p>The connection has auto-commit disabled. Do not call {@code commit()} or {@code
+         * rollback()} — the retry utility manages the transaction boundaries.
+         *
+         * @param connection the connection to execute work on
+         * @return the result of the transaction
+         * @throws SQLException if a database error occurs
+         */
+        T execute(Connection connection) throws SQLException;
+    }
+
+    /**
+     * Executes a transaction with OCC retry, acquiring a fresh connection from the DataSource on
+     * each attempt.
+     *
+     * @param <T> the return type of the transaction
+     * @param dataSource the DataSource to acquire connections from
+     * @param config retry configuration
+     * @param callback the transaction work to execute
+     * @return the result of the successful transaction
+     * @throws SQLException if a non-OCC error occurs or retries are exhausted
+     */
+    public static <T> T execute(
+            DataSource dataSource, OCCRetryConfig config, TransactionCallback<T> callback)
+            throws SQLException {
+        Objects.requireNonNull(dataSource, "dataSource must not be null");
+        Objects.requireNonNull(config, "config must not be null");
+        Objects.requireNonNull(callback, "callback must not be null");
+
+        SQLException lastError = null;
+        for (int attempt = 0; attempt <= config.getMaxRetries(); attempt++) {
+            try (Connection conn = dataSource.getConnection()) {
+                conn.setAutoCommit(false);
+                T result = callback.execute(conn);
+                conn.commit();
+                return result;
+            } catch (SQLException e) {
+                if (!isOCCError(e)) {
+                    throw e;
+                }
+                lastError = e;
+                if (attempt < config.getMaxRetries()) {
+                    sleep(calculateBackoff(config, attempt));
+                }
+            }
+        }
+        throw lastError;
+    }
+
+    /**
+     * Executes a transaction with OCC retry on an existing connection.
+     *
+     * <p>The connection is reused across retry attempts (rolled back between attempts). The caller
+     * retains ownership — the connection is not closed by this method.
+     *
+     * @param <T> the return type of the transaction
+     * @param connection the connection to execute on
+     * @param config retry configuration
+     * @param callback the transaction work to execute
+     * @return the result of the successful transaction
+     * @throws SQLException if a non-OCC error occurs or retries are exhausted
+     */
+    public static <T> T execute(
+            Connection connection, OCCRetryConfig config, TransactionCallback<T> callback)
+            throws SQLException {
+        Objects.requireNonNull(connection, "connection must not be null");
+        Objects.requireNonNull(config, "config must not be null");
+        Objects.requireNonNull(callback, "callback must not be null");
+
+        connection.setAutoCommit(false);
+        SQLException lastError = null;
+        for (int attempt = 0; attempt <= config.getMaxRetries(); attempt++) {
+            try {
+                T result = callback.execute(connection);
+                connection.commit();
+                return result;
+            } catch (SQLException e) {
+                try {
+                    connection.rollback();
+                } catch (SQLException rollbackEx) {
+                    e.addSuppressed(rollbackEx);
+                }
+                if (!isOCCError(e)) {
+                    throw e;
+                }
+                lastError = e;
+                if (attempt < config.getMaxRetries()) {
+                    sleep(calculateBackoff(config, attempt));
+                }
+            }
+        }
+        throw lastError;
+    }
+
+    static long calculateBackoff(OCCRetryConfig config, int attempt) {
+        int exponent = Math.min(attempt, 31);
+        double delay =
+                Math.min(
+                        config.getBaseDelayMs() * Math.pow(config.getMultiplier(), exponent),
+                        config.getMaxDelayMs());
+        double jitter = delay * ThreadLocalRandom.current().nextDouble() * config.getJitterFactor();
+        return (long) (delay + jitter);
+    }
+
+    private static void sleep(long millis) throws SQLException {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            throw new SQLException("Retry interrupted", ie);
+        }
+    }
+
+    /**
+     * Checks if a SQLException is an OCC conflict error.
+     *
+     * <p>Returns true for SQLState OC000 (mutation conflict), OC001 (schema conflict), or 40001
+     * (serialization failure). SQLState 40001 is matched unconditionally because Aurora DSQL
+     * surfaces OCC conflicts with this code. Also inspects the exception message for OC000/OC001
+     * codes, as pgJDBC may surface these in the message text with 40001 as the envelope SQLState.
+     *
+     * @param e the exception to check
+     * @return true if the error is an OCC conflict
+     */
+    public static boolean isOCCError(SQLException e) {
+        if (e == null) {
+            return false;
+        }
+        String sqlState = e.getSQLState();
+        if (OCC_CODE_MUTATION.equals(sqlState) || OCC_CODE_SCHEMA.equals(sqlState)) {
+            return true;
+        }
+        String message = e.getMessage();
+        if (message != null
+                && (message.contains(OCC_CODE_MUTATION) || message.contains(OCC_CODE_SCHEMA))) {
+            return true;
+        }
+        return OCC_CODE_SERIALIZATION.equals(sqlState);
+    }
+}

--- a/java/jdbc/src/main/java/software/amazon/dsql/jdbc/OCCRetryConfig.java
+++ b/java/jdbc/src/main/java/software/amazon/dsql/jdbc/OCCRetryConfig.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.dsql.jdbc;
+
+/**
+ * Immutable configuration for OCC (Optimistic Concurrency Control) retry behavior.
+ *
+ * <p>Use {@link #defaults()} for standard settings or {@link #builder()} for custom configuration.
+ *
+ * <pre>{@code
+ * // Use defaults (see DEFAULT_* constants)
+ * OCCRetryConfig config = OCCRetryConfig.defaults();
+ *
+ * // Custom configuration
+ * OCCRetryConfig config = OCCRetryConfig.builder()
+ *     .maxRetries(5)
+ *     .baseDelayMs(200)
+ *     .build();
+ * }</pre>
+ */
+public final class OCCRetryConfig {
+
+    private static final int DEFAULT_MAX_RETRIES = 3;
+    private static final long DEFAULT_BASE_DELAY_MS = 100;
+    private static final long DEFAULT_MAX_DELAY_MS = 5000;
+    private static final double DEFAULT_MULTIPLIER = 2.0;
+    private static final double DEFAULT_JITTER_FACTOR = 0.25;
+
+    private final int maxRetries;
+    private final long baseDelayMs;
+    private final long maxDelayMs;
+    private final double multiplier;
+    private final double jitterFactor;
+
+    private static final OCCRetryConfig DEFAULT = new Builder().build();
+
+    private OCCRetryConfig(Builder builder) {
+        this.maxRetries = builder.maxRetries;
+        this.baseDelayMs = builder.baseDelayMs;
+        this.maxDelayMs = builder.maxDelayMs;
+        this.multiplier = builder.multiplier;
+        this.jitterFactor = builder.jitterFactor;
+    }
+
+    /**
+     * Returns a configuration with default values.
+     *
+     * @return default configuration
+     */
+    public static OCCRetryConfig defaults() {
+        return DEFAULT;
+    }
+
+    /**
+     * Returns a new builder for custom configuration.
+     *
+     * @return a new builder instance
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public int getMaxRetries() {
+        return maxRetries;
+    }
+
+    public long getBaseDelayMs() {
+        return baseDelayMs;
+    }
+
+    public long getMaxDelayMs() {
+        return maxDelayMs;
+    }
+
+    public double getMultiplier() {
+        return multiplier;
+    }
+
+    public double getJitterFactor() {
+        return jitterFactor;
+    }
+
+    /**
+     * Builder for {@link OCCRetryConfig}.
+     *
+     * <p>Validates all parameters at {@link #build()} time.
+     */
+    public static final class Builder {
+
+        private int maxRetries = DEFAULT_MAX_RETRIES;
+        private long baseDelayMs = DEFAULT_BASE_DELAY_MS;
+        private long maxDelayMs = DEFAULT_MAX_DELAY_MS;
+        private double multiplier = DEFAULT_MULTIPLIER;
+        private double jitterFactor = DEFAULT_JITTER_FACTOR;
+
+        private Builder() {}
+
+        /**
+         * Maximum number of retry attempts. Range: 0–100. A value of 0 means execute once with no
+         * retry.
+         */
+        public Builder maxRetries(int maxRetries) {
+            this.maxRetries = maxRetries;
+            return this;
+        }
+
+        /** Base delay in milliseconds before the first retry. Must be greater than 0. */
+        public Builder baseDelayMs(long baseDelayMs) {
+            this.baseDelayMs = baseDelayMs;
+            return this;
+        }
+
+        /** Maximum delay in milliseconds between retries. Must be >= baseDelayMs. */
+        public Builder maxDelayMs(long maxDelayMs) {
+            this.maxDelayMs = maxDelayMs;
+            return this;
+        }
+
+        /** Exponential backoff multiplier. Must be >= 1.0. */
+        public Builder multiplier(double multiplier) {
+            this.multiplier = multiplier;
+            return this;
+        }
+
+        /** Jitter factor applied to backoff delay. Range: 0.0–1.0. */
+        public Builder jitterFactor(double jitterFactor) {
+            this.jitterFactor = jitterFactor;
+            return this;
+        }
+
+        /**
+         * Builds the configuration, validating all parameters.
+         *
+         * @return validated configuration
+         * @throws IllegalArgumentException if any parameter is out of range
+         */
+        public OCCRetryConfig build() {
+            if (maxRetries < 0 || maxRetries > 100) {
+                throw new IllegalArgumentException(
+                        "maxRetries must be between 0 and 100, got: " + maxRetries);
+            }
+            if (baseDelayMs <= 0) {
+                throw new IllegalArgumentException(
+                        "baseDelayMs must be greater than 0, got: " + baseDelayMs);
+            }
+            if (maxDelayMs < baseDelayMs) {
+                throw new IllegalArgumentException(
+                        "maxDelayMs must be >= baseDelayMs, got maxDelayMs="
+                                + maxDelayMs
+                                + " baseDelayMs="
+                                + baseDelayMs);
+            }
+            if (!Double.isFinite(multiplier) || multiplier < 1.0) {
+                throw new IllegalArgumentException("multiplier must be >= 1.0, got: " + multiplier);
+            }
+            if (!Double.isFinite(jitterFactor) || jitterFactor < 0.0 || jitterFactor > 1.0) {
+                throw new IllegalArgumentException(
+                        "jitterFactor must be between 0.0 and 1.0, got: " + jitterFactor);
+            }
+            return new OCCRetryConfig(this);
+        }
+    }
+}

--- a/java/jdbc/src/main/java/software/amazon/dsql/jdbc/OCCTransactionRunner.java
+++ b/java/jdbc/src/main/java/software/amazon/dsql/jdbc/OCCTransactionRunner.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.dsql.jdbc;
+
+import java.sql.SQLException;
+import java.util.Objects;
+import javax.sql.DataSource;
+
+/**
+ * A reusable transaction runner that binds a DataSource and retry configuration once, then executes
+ * transaction callbacks with OCC retry on each call.
+ *
+ * <p>Intentionally thin convenience over {@link OCCRetry#execute(DataSource, OCCRetryConfig,
+ * OCCRetry.TransactionCallback)}.
+ *
+ * <pre>{@code
+ * OCCTransactionRunner runner = OCCTransactionRunner.create(dataSource);
+ *
+ * int count = runner.run(conn -> {
+ *     Statement stmt = conn.createStatement();
+ *     return stmt.executeUpdate("UPDATE accounts SET balance = balance - 100 WHERE id = 1");
+ * });
+ *
+ * runner.runVoid(conn -> {
+ *     conn.createStatement().executeUpdate("DELETE FROM expired_sessions");
+ * });
+ * }</pre>
+ */
+public final class OCCTransactionRunner {
+
+    private final DataSource dataSource;
+    private final OCCRetryConfig config;
+
+    private OCCTransactionRunner(DataSource dataSource, OCCRetryConfig config) {
+        this.dataSource = Objects.requireNonNull(dataSource, "dataSource must not be null");
+        this.config = Objects.requireNonNull(config, "config must not be null");
+    }
+
+    /**
+     * Creates a runner with default retry configuration.
+     *
+     * @param dataSource the DataSource to acquire connections from
+     * @return a new runner instance
+     */
+    public static OCCTransactionRunner create(DataSource dataSource) {
+        return new OCCTransactionRunner(dataSource, OCCRetryConfig.defaults());
+    }
+
+    /**
+     * Creates a runner with custom retry configuration.
+     *
+     * @param dataSource the DataSource to acquire connections from
+     * @param config retry configuration
+     * @return a new runner instance
+     */
+    public static OCCTransactionRunner create(DataSource dataSource, OCCRetryConfig config) {
+        return new OCCTransactionRunner(dataSource, config);
+    }
+
+    /**
+     * Executes a transaction callback with OCC retry.
+     *
+     * @param <T> the return type of the transaction
+     * @param callback the transaction work to execute
+     * @return the result of the successful transaction
+     * @throws SQLException if a non-OCC error occurs or retries are exhausted
+     */
+    public <T> T run(OCCRetry.TransactionCallback<T> callback) throws SQLException {
+        return OCCRetry.execute(dataSource, config, callback);
+    }
+
+    /**
+     * Executes a void transaction callback with OCC retry.
+     *
+     * @param callback the transaction work to execute
+     * @throws SQLException if a non-OCC error occurs or retries are exhausted
+     */
+    public void runVoid(VoidTransactionCallback callback) throws SQLException {
+        OCCRetry.execute(
+                dataSource,
+                config,
+                conn -> {
+                    callback.execute(conn);
+                    return null;
+                });
+    }
+}

--- a/java/jdbc/src/main/java/software/amazon/dsql/jdbc/VoidTransactionCallback.java
+++ b/java/jdbc/src/main/java/software/amazon/dsql/jdbc/VoidTransactionCallback.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.dsql.jdbc;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+/**
+ * Callback interface for transaction work that does not return a value.
+ *
+ * @see OCCTransactionRunner#runVoid(VoidTransactionCallback)
+ */
+@FunctionalInterface
+public interface VoidTransactionCallback {
+    /**
+     * Executes transaction work on the provided connection.
+     *
+     * <p>The connection has auto-commit disabled. Do not call {@code commit()} or {@code
+     * rollback()} — the retry utility manages the transaction boundaries.
+     *
+     * @param connection the connection to execute work on
+     * @throws SQLException if a database error occurs
+     */
+    void execute(Connection connection) throws SQLException;
+}

--- a/java/jdbc/src/test/java/software/amazon/dsql/jdbc/OCCRetryConfigTest.java
+++ b/java/jdbc/src/test/java/software/amazon/dsql/jdbc/OCCRetryConfigTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.dsql.jdbc;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+class OCCRetryConfigTest {
+
+    @Test
+    void defaults_returnsExpectedValues() {
+        OCCRetryConfig config = OCCRetryConfig.defaults();
+
+        assertEquals(3, config.getMaxRetries());
+        assertEquals(100, config.getBaseDelayMs());
+        assertEquals(5000, config.getMaxDelayMs());
+        assertEquals(2.0, config.getMultiplier());
+        assertEquals(0.25, config.getJitterFactor());
+    }
+
+    @Test
+    void builder_customValues() {
+        OCCRetryConfig config =
+                OCCRetryConfig.builder()
+                        .maxRetries(5)
+                        .baseDelayMs(200)
+                        .maxDelayMs(10000)
+                        .multiplier(3.0)
+                        .jitterFactor(0.5)
+                        .build();
+
+        assertEquals(5, config.getMaxRetries());
+        assertEquals(200, config.getBaseDelayMs());
+        assertEquals(10000, config.getMaxDelayMs());
+        assertEquals(3.0, config.getMultiplier());
+        assertEquals(0.5, config.getJitterFactor());
+    }
+
+    @Test
+    void builder_maxRetriesZero_allowed() {
+        OCCRetryConfig config = OCCRetryConfig.builder().maxRetries(0).build();
+        assertEquals(0, config.getMaxRetries());
+    }
+
+    @Test
+    void builder_maxRetriesNegative_throws() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> OCCRetryConfig.builder().maxRetries(-1).build());
+    }
+
+    @Test
+    void builder_maxRetriesExceeds100_throws() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> OCCRetryConfig.builder().maxRetries(101).build());
+    }
+
+    @Test
+    void builder_baseDelayMsZero_throws() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> OCCRetryConfig.builder().baseDelayMs(0).build());
+    }
+
+    @Test
+    void builder_baseDelayMsNegative_throws() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> OCCRetryConfig.builder().baseDelayMs(-1).build());
+    }
+
+    @Test
+    void builder_maxDelayLessThanBase_throws() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> OCCRetryConfig.builder().baseDelayMs(200).maxDelayMs(50).build());
+    }
+
+    @Test
+    void builder_multiplierLessThanOne_throws() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> OCCRetryConfig.builder().multiplier(0.5).build());
+    }
+
+    @Test
+    void builder_jitterFactorNegative_throws() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> OCCRetryConfig.builder().jitterFactor(-0.1).build());
+    }
+
+    @Test
+    void builder_jitterFactorAboveOne_throws() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> OCCRetryConfig.builder().jitterFactor(1.1).build());
+    }
+
+    @Test
+    void builder_jitterFactorBoundaries_allowed() {
+        OCCRetryConfig zero = OCCRetryConfig.builder().jitterFactor(0.0).build();
+        assertEquals(0.0, zero.getJitterFactor());
+
+        OCCRetryConfig one = OCCRetryConfig.builder().jitterFactor(1.0).build();
+        assertEquals(1.0, one.getJitterFactor());
+    }
+
+    @Test
+    void builder_multiplierNaN_throws() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> OCCRetryConfig.builder().multiplier(Double.NaN).build());
+    }
+
+    @Test
+    void builder_multiplierInfinity_throws() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> OCCRetryConfig.builder().multiplier(Double.POSITIVE_INFINITY).build());
+    }
+
+    @Test
+    void builder_jitterFactorNaN_throws() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> OCCRetryConfig.builder().jitterFactor(Double.NaN).build());
+    }
+}

--- a/java/jdbc/src/test/java/software/amazon/dsql/jdbc/OCCRetryTest.java
+++ b/java/jdbc/src/test/java/software/amazon/dsql/jdbc/OCCRetryTest.java
@@ -1,0 +1,496 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.dsql.jdbc;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.Test;
+
+class OCCRetryTest {
+
+    @Test
+    void isOCCError_null_returnsFalse() {
+        assertFalse(OCCRetry.isOCCError(null));
+    }
+
+    @Test
+    void isOCCError_nullSqlState_returnsFalse() {
+        SQLException e = new SQLException("some error", (String) null);
+        assertFalse(OCCRetry.isOCCError(e));
+    }
+
+    @Test
+    void isOCCError_mutationConflict_returnsTrue() {
+        SQLException e = new SQLException("conflict", "OC000");
+        assertTrue(OCCRetry.isOCCError(e));
+    }
+
+    @Test
+    void isOCCError_schemaConflict_returnsTrue() {
+        SQLException e = new SQLException("conflict", "OC001");
+        assertTrue(OCCRetry.isOCCError(e));
+    }
+
+    @Test
+    void isOCCError_serializationFailure_returnsTrue() {
+        SQLException e = new SQLException("conflict", "40001");
+        assertTrue(OCCRetry.isOCCError(e));
+    }
+
+    @Test
+    void isOCCError_unrecognizedState_returnsFalse() {
+        SQLException e = new SQLException("something else", "42000");
+        assertFalse(OCCRetry.isOCCError(e));
+    }
+
+    @Test
+    void isOCCError_messageContainsOC000_returnsTrue() {
+        SQLException e = new SQLException("ERROR: OC000 mutation conflict detected", "XX000");
+        assertTrue(OCCRetry.isOCCError(e));
+    }
+
+    @Test
+    void isOCCError_messageContainsOC001_returnsTrue() {
+        SQLException e = new SQLException("ERROR: OC001 schema conflict", "XX000");
+        assertTrue(OCCRetry.isOCCError(e));
+    }
+
+    @Test
+    void isOCCError_serialization_withOC000InMessage_returnsTrue() {
+        SQLException e = new SQLException("ERROR: OC000 mutation conflict detected", "40001");
+        assertTrue(OCCRetry.isOCCError(e));
+    }
+
+    @Test
+    void isOCCError_serialization_withOC001InMessage_returnsTrue() {
+        SQLException e = new SQLException("ERROR: OC001 schema conflict", "40001");
+        assertTrue(OCCRetry.isOCCError(e));
+    }
+
+    @Test
+    void isOCCError_serialization_withoutOCCInMessage_returnsTrue() {
+        SQLException e = new SQLException("serialization failure", "40001");
+        assertTrue(OCCRetry.isOCCError(e));
+    }
+
+    @Test
+    void isOCCError_nullMessage_returnsFalse() {
+        SQLException e = new SQLException(null, "XX000");
+        assertFalse(OCCRetry.isOCCError(e));
+    }
+
+    // --- execute(DataSource, config, callback) tests ---
+
+    @Test
+    void executeDataSource_successOnFirstAttempt() throws SQLException {
+        DataSource ds = mock(DataSource.class);
+        Connection conn = mock(Connection.class);
+        when(ds.getConnection()).thenReturn(conn);
+
+        String result = OCCRetry.execute(ds, OCCRetryConfig.defaults(), c -> "hello");
+
+        assertEquals("hello", result);
+        verify(conn).setAutoCommit(false);
+        verify(conn).commit();
+        verify(conn).close();
+    }
+
+    @Test
+    void executeDataSource_retriesOnOCCThenSucceeds() throws SQLException {
+        DataSource ds = mock(DataSource.class);
+        Connection conn1 = mock(Connection.class);
+        Connection conn2 = mock(Connection.class);
+        when(ds.getConnection()).thenReturn(conn1, conn2);
+
+        AtomicInteger attempts = new AtomicInteger();
+        OCCRetryConfig config =
+                OCCRetryConfig.builder().maxRetries(3).baseDelayMs(1).maxDelayMs(10).build();
+
+        String result =
+                OCCRetry.execute(
+                        ds,
+                        config,
+                        c -> {
+                            if (attempts.getAndIncrement() == 0) {
+                                throw new SQLException("conflict", "OC000");
+                            }
+                            return "recovered";
+                        });
+
+        assertEquals("recovered", result);
+        assertEquals(2, attempts.get());
+        verify(conn1).close();
+        verify(conn2).close();
+    }
+
+    @Test
+    void executeDataSource_throwsNonOCCImmediately() throws SQLException {
+        DataSource ds = mock(DataSource.class);
+        Connection conn = mock(Connection.class);
+        when(ds.getConnection()).thenReturn(conn);
+
+        SQLException nonOcc = new SQLException("syntax error", "42601");
+        OCCRetryConfig config = OCCRetryConfig.builder().baseDelayMs(1).maxDelayMs(10).build();
+
+        SQLException thrown =
+                assertThrows(
+                        SQLException.class,
+                        () ->
+                                OCCRetry.execute(
+                                        ds,
+                                        config,
+                                        c -> {
+                                            throw nonOcc;
+                                        }));
+
+        assertEquals(nonOcc, thrown);
+        verify(conn).close();
+    }
+
+    @Test
+    void executeDataSource_exhaustsRetries() throws SQLException {
+        DataSource ds = mock(DataSource.class);
+        Connection conn = mock(Connection.class);
+        when(ds.getConnection()).thenReturn(conn);
+
+        AtomicInteger attempts = new AtomicInteger();
+        OCCRetryConfig config =
+                OCCRetryConfig.builder().maxRetries(2).baseDelayMs(1).maxDelayMs(10).build();
+
+        SQLException thrown =
+                assertThrows(
+                        SQLException.class,
+                        () ->
+                                OCCRetry.execute(
+                                        ds,
+                                        config,
+                                        c -> {
+                                            attempts.incrementAndGet();
+                                            throw new SQLException("conflict", "OC000");
+                                        }));
+
+        assertEquals(3, attempts.get()); // initial + 2 retries
+        assertEquals("OC000", thrown.getSQLState());
+    }
+
+    // --- execute(Connection, config, callback) tests ---
+
+    @Test
+    void executeConnection_successOnFirstAttempt() throws SQLException {
+        Connection conn = mock(Connection.class);
+
+        int result = OCCRetry.execute(conn, OCCRetryConfig.defaults(), c -> 42);
+
+        assertEquals(42, result);
+        verify(conn).setAutoCommit(false);
+        verify(conn).commit();
+        verify(conn, never()).rollback();
+        verify(conn, never()).close();
+    }
+
+    @Test
+    void executeConnection_retriesOnOCCThenSucceeds() throws SQLException {
+        Connection conn = mock(Connection.class);
+        AtomicInteger attempts = new AtomicInteger();
+        OCCRetryConfig config =
+                OCCRetryConfig.builder().maxRetries(3).baseDelayMs(1).maxDelayMs(10).build();
+
+        String result =
+                OCCRetry.execute(
+                        conn,
+                        config,
+                        c -> {
+                            if (attempts.getAndIncrement() < 2) {
+                                throw new SQLException("conflict", "OC000");
+                            }
+                            return "ok";
+                        });
+
+        assertEquals("ok", result);
+        assertEquals(3, attempts.get());
+        verify(conn, times(2)).rollback();
+        verify(conn).commit();
+        verify(conn, never()).close();
+    }
+
+    @Test
+    void executeConnection_throwsNonOCCImmediately() throws SQLException {
+        Connection conn = mock(Connection.class);
+        SQLException nonOcc = new SQLException("constraint", "23505");
+        OCCRetryConfig config = OCCRetryConfig.builder().baseDelayMs(1).maxDelayMs(10).build();
+
+        SQLException thrown =
+                assertThrows(
+                        SQLException.class,
+                        () ->
+                                OCCRetry.execute(
+                                        conn,
+                                        config,
+                                        c -> {
+                                            throw nonOcc;
+                                        }));
+
+        assertEquals(nonOcc, thrown);
+        verify(conn).rollback();
+        verify(conn, never()).commit();
+    }
+
+    @Test
+    void executeConnection_exhaustsRetries() throws SQLException {
+        Connection conn = mock(Connection.class);
+        AtomicInteger attempts = new AtomicInteger();
+        OCCRetryConfig config =
+                OCCRetryConfig.builder().maxRetries(1).baseDelayMs(1).maxDelayMs(10).build();
+
+        SQLException thrown =
+                assertThrows(
+                        SQLException.class,
+                        () ->
+                                OCCRetry.execute(
+                                        conn,
+                                        config,
+                                        c -> {
+                                            attempts.incrementAndGet();
+                                            throw new SQLException("conflict", "OC001");
+                                        }));
+
+        assertEquals(2, attempts.get()); // initial + 1 retry
+        assertEquals("OC001", thrown.getSQLState());
+        verify(conn, times(2)).rollback();
+    }
+
+    // --- commit-throwing-OCC tests ---
+
+    @Test
+    void executeDataSource_commitThrowsOCC_retries() throws SQLException {
+        DataSource ds = mock(DataSource.class);
+        Connection conn1 = mock(Connection.class);
+        Connection conn2 = mock(Connection.class);
+        when(ds.getConnection()).thenReturn(conn1, conn2);
+        org.mockito.Mockito.doThrow(new SQLException("conflict", "OC000")).when(conn1).commit();
+
+        OCCRetryConfig config =
+                OCCRetryConfig.builder().maxRetries(3).baseDelayMs(1).maxDelayMs(10).build();
+
+        String result = OCCRetry.execute(ds, config, c -> "done");
+
+        assertEquals("done", result);
+        verify(conn1).commit();
+        verify(conn2).commit();
+    }
+
+    @Test
+    void executeConnection_commitThrowsOCC_retries() throws SQLException {
+        Connection conn = mock(Connection.class);
+        AtomicInteger attempts = new AtomicInteger();
+        org.mockito.Mockito.doAnswer(
+                        invocation -> {
+                            if (attempts.get() == 1) {
+                                throw new SQLException("conflict", "40001");
+                            }
+                            return null;
+                        })
+                .when(conn)
+                .commit();
+
+        OCCRetryConfig config =
+                OCCRetryConfig.builder().maxRetries(3).baseDelayMs(1).maxDelayMs(10).build();
+
+        String result =
+                OCCRetry.execute(
+                        conn,
+                        config,
+                        c -> {
+                            attempts.incrementAndGet();
+                            return "ok";
+                        });
+
+        assertEquals("ok", result);
+        assertEquals(2, attempts.get());
+        verify(conn).rollback();
+        verify(conn, times(2)).commit();
+    }
+
+    // --- InterruptedException test ---
+
+    @Test
+    void executeConnection_interruptedDuringSleep_throwsSQLException() throws SQLException {
+        Connection conn = mock(Connection.class);
+        OCCRetryConfig config =
+                OCCRetryConfig.builder().maxRetries(3).baseDelayMs(50).maxDelayMs(200).build();
+
+        Thread.currentThread().interrupt();
+
+        SQLException thrown =
+                assertThrows(
+                        SQLException.class,
+                        () ->
+                                OCCRetry.execute(
+                                        conn,
+                                        config,
+                                        c -> {
+                                            throw new SQLException("conflict", "OC000");
+                                        }));
+
+        assertTrue(thrown.getMessage().contains("interrupted"));
+        assertTrue(Thread.interrupted());
+    }
+
+    // --- DataSource.getConnection() failure test ---
+
+    @Test
+    void executeDataSource_getConnectionThrows_propagatesImmediately() throws SQLException {
+        DataSource ds = mock(DataSource.class);
+        SQLException poolExhausted = new SQLException("pool exhausted", "08001");
+        when(ds.getConnection()).thenThrow(poolExhausted);
+
+        OCCRetryConfig config =
+                OCCRetryConfig.builder().maxRetries(3).baseDelayMs(1).maxDelayMs(10).build();
+
+        SQLException thrown =
+                assertThrows(SQLException.class, () -> OCCRetry.execute(ds, config, c -> "never"));
+
+        assertEquals(poolExhausted, thrown);
+    }
+
+    // --- rollback failure tests ---
+
+    @Test
+    void executeConnection_rollbackFailure_suppressedOnOriginalException() throws SQLException {
+        Connection conn = mock(Connection.class);
+        SQLException rollbackEx = new SQLException("connection reset");
+        org.mockito.Mockito.doThrow(rollbackEx).when(conn).rollback();
+
+        SQLException original = new SQLException("constraint", "23505");
+        OCCRetryConfig config = OCCRetryConfig.builder().baseDelayMs(1).maxDelayMs(10).build();
+
+        SQLException thrown =
+                assertThrows(
+                        SQLException.class,
+                        () ->
+                                OCCRetry.execute(
+                                        conn,
+                                        config,
+                                        c -> {
+                                            throw original;
+                                        }));
+
+        assertEquals(original, thrown);
+        assertEquals(1, thrown.getSuppressed().length);
+        assertEquals(rollbackEx, thrown.getSuppressed()[0]);
+    }
+
+    @Test
+    void executeConnection_rollbackFailure_onOCC_continuesRetry() throws SQLException {
+        Connection conn = mock(Connection.class);
+        SQLException rollbackEx = new SQLException("connection reset");
+        org.mockito.Mockito.doThrow(rollbackEx).when(conn).rollback();
+
+        AtomicInteger attempts = new AtomicInteger();
+        OCCRetryConfig config =
+                OCCRetryConfig.builder().maxRetries(1).baseDelayMs(1).maxDelayMs(10).build();
+
+        SQLException thrown =
+                assertThrows(
+                        SQLException.class,
+                        () ->
+                                OCCRetry.execute(
+                                        conn,
+                                        config,
+                                        c -> {
+                                            attempts.incrementAndGet();
+                                            throw new SQLException("conflict", "OC000");
+                                        }));
+
+        assertEquals(2, attempts.get());
+        assertEquals("OC000", thrown.getSQLState());
+        assertTrue(thrown.getSuppressed().length > 0);
+    }
+
+    // --- calculateBackoff tests ---
+
+    @Test
+    void calculateBackoff_firstAttempt_returnsBaseDelay() {
+        OCCRetryConfig config =
+                OCCRetryConfig.builder()
+                        .baseDelayMs(100)
+                        .maxDelayMs(5000)
+                        .multiplier(2.0)
+                        .jitterFactor(0.0)
+                        .build();
+
+        long backoff = OCCRetry.calculateBackoff(config, 0);
+        assertEquals(100, backoff);
+    }
+
+    @Test
+    void calculateBackoff_secondAttempt_appliesMultiplier() {
+        OCCRetryConfig config =
+                OCCRetryConfig.builder()
+                        .baseDelayMs(100)
+                        .maxDelayMs(5000)
+                        .multiplier(2.0)
+                        .jitterFactor(0.0)
+                        .build();
+
+        long backoff = OCCRetry.calculateBackoff(config, 1);
+        assertEquals(200, backoff);
+    }
+
+    @Test
+    void calculateBackoff_cappedAtMaxDelay() {
+        OCCRetryConfig config =
+                OCCRetryConfig.builder()
+                        .baseDelayMs(100)
+                        .maxDelayMs(500)
+                        .multiplier(2.0)
+                        .jitterFactor(0.0)
+                        .build();
+
+        long backoff = OCCRetry.calculateBackoff(config, 10);
+        assertEquals(500, backoff);
+    }
+
+    @Test
+    void calculateBackoff_withJitter_doesNotExceedMaxPlusJitter() {
+        OCCRetryConfig config =
+                OCCRetryConfig.builder()
+                        .baseDelayMs(100)
+                        .maxDelayMs(500)
+                        .multiplier(2.0)
+                        .jitterFactor(1.0)
+                        .build();
+
+        for (int i = 0; i < 100; i++) {
+            long backoff = OCCRetry.calculateBackoff(config, 10);
+            assertTrue(backoff >= 500, "backoff should be at least maxDelay");
+            assertTrue(backoff <= 1000, "backoff should not exceed maxDelay + maxDelay*jitter");
+        }
+    }
+}

--- a/java/jdbc/src/test/java/software/amazon/dsql/jdbc/OCCTransactionRunnerTest.java
+++ b/java/jdbc/src/test/java/software/amazon/dsql/jdbc/OCCTransactionRunnerTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.dsql.jdbc;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.Test;
+
+class OCCTransactionRunnerTest {
+
+    @Test
+    void run_delegatesToOCCRetryExecute() throws SQLException {
+        DataSource ds = mock(DataSource.class);
+        Connection conn = mock(Connection.class);
+        when(ds.getConnection()).thenReturn(conn);
+
+        OCCTransactionRunner runner = OCCTransactionRunner.create(ds);
+        String result = runner.run(c -> "value");
+
+        assertEquals("value", result);
+        verify(conn).setAutoCommit(false);
+        verify(conn).commit();
+    }
+
+    @Test
+    void runVoid_delegatesToOCCRetryExecute() throws SQLException {
+        DataSource ds = mock(DataSource.class);
+        Connection conn = mock(Connection.class);
+        when(ds.getConnection()).thenReturn(conn);
+
+        OCCTransactionRunner runner = OCCTransactionRunner.create(ds);
+        AtomicInteger called = new AtomicInteger();
+        runner.runVoid(c -> called.incrementAndGet());
+
+        assertEquals(1, called.get());
+        verify(conn).commit();
+    }
+
+    @Test
+    void run_retriesOnOCC() throws SQLException {
+        DataSource ds = mock(DataSource.class);
+        Connection conn = mock(Connection.class);
+        when(ds.getConnection()).thenReturn(conn);
+
+        OCCRetryConfig config =
+                OCCRetryConfig.builder().maxRetries(2).baseDelayMs(1).maxDelayMs(10).build();
+        OCCTransactionRunner runner = OCCTransactionRunner.create(ds, config);
+
+        AtomicInteger attempts = new AtomicInteger();
+        String result =
+                runner.run(
+                        c -> {
+                            if (attempts.getAndIncrement() == 0) {
+                                throw new SQLException("conflict", "OC000");
+                            }
+                            return "recovered";
+                        });
+
+        assertEquals("recovered", result);
+        assertEquals(2, attempts.get());
+    }
+
+    @Test
+    void create_nullDataSource_throws() {
+        assertThrows(NullPointerException.class, () -> OCCTransactionRunner.create(null));
+    }
+
+    @Test
+    void create_nullConfig_throws() {
+        DataSource ds = mock(DataSource.class);
+        assertThrows(NullPointerException.class, () -> OCCTransactionRunner.create(ds, null));
+    }
+}


### PR DESCRIPTION
Add retry utilities for Aurora DSQL OCC conflicts with exponential backoff and jitter. Includes DataSource (fresh connection per attempt) and Connection (reuse with rollback) overloads, immutable config with builder pattern, and OCCTransactionRunner convenience wrapper.

- OCCRetry: static execute() methods, isOCCError() detection, backoff
- OCCRetryConfig: validated builder (maxRetries, baseDelay, jitter, etc)
- OCCTransactionRunner: bind-once wrapper with run()/runVoid()
- VoidTransactionCallback: ergonomic void lambda interface
- Unit tests covering all retry paths and edge cases
- Integration tests with deterministic OCC conflict scenarios
- Update examples to demonstrate OCC retry usage
- Add README documentation with integration framework examples

*Issue #, if available:*
N/A
*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
