### PR TITLE
feat(sqlx): add sqlx 0.9 support via feature flags

### DIFF
--- a/.github/workflows/rust-sqlx-ci.yml
+++ b/.github/workflows/rust-sqlx-ci.yml
@@ -27,6 +27,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write # required by aws-actions/configure-aws-credentials
+    strategy:
+      fail-fast: false
+      matrix:
+        sqlx-version: [sqlx-0_8, sqlx-0_9]
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -43,16 +47,16 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             rust/sqlx/target
-          key: rust-sqlx-${{ runner.os }}-${{ hashFiles('rust/sqlx/Cargo.lock') }}
+          key: rust-sqlx-${{ matrix.sqlx-version }}-${{ runner.os }}-${{ hashFiles('rust/sqlx/Cargo.lock') }}
 
       - name: Check formatting
         run: cargo fmt --check
 
       - name: Run clippy
-        run: cargo clippy --features pool,occ -- -D warnings
+        run: cargo clippy --no-default-features --features ${{ matrix.sqlx-version }},pool,occ -- -D warnings
 
       - name: Run connector unit tests
-        run: "cargo test --features pool,occ --lib"
+        run: "cargo test --no-default-features --features ${{ matrix.sqlx-version }},pool,occ --lib"
 
       - name: Download Amazon root certificate
         run: |
@@ -70,13 +74,15 @@ jobs:
           CLUSTER_USER: "admin"
           CLUSTER_ENDPOINT: ${{ needs.create-cluster.outputs.cluster-endpoint }}
           REGION: ${{ needs.create-cluster.outputs.region }}
-        run: "cargo test --features pool,occ --test tests"
+        run: "cargo test --no-default-features --features ${{ matrix.sqlx-version }},pool,occ --test tests"
 
       - name: Build examples
+        if: matrix.sqlx-version == 'sqlx-0_8'
         working-directory: rust/sqlx/example
         run: cargo build
 
       - name: Run example integration tests
+        if: matrix.sqlx-version == 'sqlx-0_8'
         working-directory: rust/sqlx/example
         env:
           CLUSTER_USER: "admin"

--- a/rust/sqlx/Cargo.toml
+++ b/rust/sqlx/Cargo.toml
@@ -12,12 +12,15 @@ keywords = ["aws", "aurora", "dsql", "postgres", "sqlx"]
 categories = ["database", "authentication"]
 
 [features]
-default = []
+default = ["sqlx-0_8"]
+sqlx-0_8 = ["dep:sqlx-0_8"]
+sqlx-0_9 = ["dep:sqlx-0_9"]
 pool = ["dep:tokio", "tokio/rt", "tokio/time", "tokio/macros"]
 occ = ["dep:rand", "dep:tokio", "tokio/time", "dep:async-trait"]
 
 [dependencies]
-sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "tls-rustls-ring"] }
+sqlx-0_8 = { package = "sqlx", version = "0.8", optional = true, features = ["runtime-tokio", "postgres", "tls-rustls-ring"] }
+sqlx-0_9 = { package = "sqlx", version = "0.9", optional = true, features = ["runtime-tokio", "postgres", "tls-rustls-ring"] }
 aws-config = { version = "1.8", features = ["credentials-login"] }
 aws-sdk-dsql = "1.0"
 aws-credential-types = "1"
@@ -35,4 +38,4 @@ tokio = { version = "1", features = ["macros", "rt"] }
 tokio-test = "0.4"
 
 [package.metadata.docs.rs]
-all-features = true
+features = ["sqlx-0_8", "pool", "occ"]

--- a/rust/sqlx/README.md
+++ b/rust/sqlx/README.md
@@ -46,16 +46,25 @@ aurora-dsql-sqlx-connector = "0.1.2"
 
 | Feature | Default | Description |
 |---------|---------|-------------|
+| `sqlx-0_8` | **Yes** | Use SQLx 0.8 (stable, broad ecosystem compatibility) |
+| `sqlx-0_9` | No | Use SQLx 0.9 (for projects already on sqlx 0.9) |
 | `occ` | No | OCC retry helpers (`retry_on_occ`, `is_occ_error`, `OCCType`, `OCCRetryExt` trait for `PgConnection`) |
 | `pool` | No | sqlx pool helper with background token refresh |
 
-**Note:** To use `OCCRetryExt` on `PgPool`, enable both `occ` and `pool` features.
+**Note:** `sqlx-0_8` and `sqlx-0_9` are mutually exclusive. To use `OCCRetryExt` on `PgPool`, enable both `occ` and `pool` features.
 
-For most applications, enable both features:
+For most applications using SQLx 0.8 (default):
 
 ```toml
 [dependencies]
 aurora-dsql-sqlx-connector = { version = "0.1.2", features = ["pool", "occ"] }
+```
+
+For projects already on SQLx 0.9:
+
+```toml
+[dependencies]
+aurora-dsql-sqlx-connector = { version = "0.1.2", default-features = false, features = ["sqlx-0_9", "pool", "occ"] }
 ```
 
 ## Configuration Options
@@ -74,11 +83,21 @@ These options are parsed from the connection string or set via the builder:
 | `tokenDurationSecs` | `u64` | `900` (15 minutes) | Token validity duration in seconds |
 | `ormPrefix` | `Option<String>` | `None` | ORM prefix for application_name (e.g. `"diesel"` → `"diesel:aurora-dsql-rust-sqlx/{version}"`) |
 
+### Accessing SQLx Types
+
+The connector re-exports the selected SQLx version via `sqlx_compat::sqlx`. Use this instead of depending on `sqlx` directly to avoid version conflicts:
+
+```rust
+use aurora_dsql_sqlx_connector::sqlx_compat::sqlx;
+use sqlx::Row;
+```
+
 ## Quick Start
 
 Enable the `pool` feature, then:
 
 ```rust
+use aurora_dsql_sqlx_connector::sqlx_compat::sqlx;
 use sqlx::Row;
 
 #[tokio::main]
@@ -161,6 +180,7 @@ let opts = DsqlConnectOptions::from_connection_string(
 For simple scripts or when connection pooling is not needed:
 
 ```rust
+use aurora_dsql_sqlx_connector::sqlx_compat::sqlx;
 use sqlx::Row;
 
 #[tokio::main]
@@ -188,6 +208,7 @@ The `pool` feature provides `pool::connect()` helpers that return a standard `sq
 For custom pool settings, pass `PgPoolOptions` to `connect_with()` to get both pool tuning and the background token refresh task:
 
 ```rust
+use aurora_dsql_sqlx_connector::sqlx_compat::sqlx;
 use aurora_dsql_sqlx_connector::DsqlConnectOptions;
 use sqlx::postgres::PgPoolOptions;
 
@@ -214,6 +235,7 @@ let pool = aurora_dsql_sqlx_connector::pool::connect(
 Use `DsqlConnectOptionsBuilder` for programmatic configuration:
 
 ```rust
+use aurora_dsql_sqlx_connector::sqlx_compat::sqlx;
 use aurora_dsql_sqlx_connector::{DsqlConnectOptionsBuilder, Region};
 use sqlx::postgres::PgConnectOptions;
 
@@ -235,6 +257,7 @@ let mut conn = aurora_dsql_sqlx_connector::connection::connect_with(&opts).await
 For environments where the default credential chain doesn't apply (e.g., Lambda with assumed roles), pass a custom `SharedCredentialsProvider`:
 
 ```rust
+use aurora_dsql_sqlx_connector::sqlx_compat::sqlx;
 use aurora_dsql_sqlx_connector::{DsqlConnectOptionsBuilder, SharedCredentialsProvider};
 use aws_credential_types::Credentials;
 use sqlx::postgres::{PgConnectOptions, PgPoolOptions};

--- a/rust/sqlx/src/config.rs
+++ b/rust/sqlx/src/config.rs
@@ -1,11 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::sqlx_compat::sqlx::postgres::{PgConnectOptions, PgSslMode};
 use crate::{util::ClusterId, DsqlError, Result};
 use aws_config::{Region, SdkConfig};
 use aws_credential_types::provider::SharedCredentialsProvider;
 use derive_builder::Builder;
-use sqlx::postgres::{PgConnectOptions, PgSslMode};
 #[cfg(feature = "pool")]
 use std::time::Duration;
 use url::Url;

--- a/rust/sqlx/src/connection.rs
+++ b/rust/sqlx/src/connection.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::config::DsqlConnectOptions;
+use crate::sqlx_compat::sqlx;
 use crate::{DsqlError, Result};
 use sqlx::Connection;
 

--- a/rust/sqlx/src/error.rs
+++ b/rust/sqlx/src/error.rs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::sqlx_compat::sqlx;
 use thiserror::Error;
 
 #[cfg(feature = "occ")]

--- a/rust/sqlx/src/lib.rs
+++ b/rust/sqlx/src/lib.rs
@@ -5,6 +5,8 @@
 
 //! Aurora DSQL connector for SQLx.
 
+pub mod sqlx_compat;
+
 mod config;
 pub mod connection;
 mod error;

--- a/rust/sqlx/src/occ_retry.rs
+++ b/rust/sqlx/src/occ_retry.rs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::sqlx_compat::sqlx;
 use crate::{DsqlError, Result};
 use derive_builder::Builder;
 use sqlx::Acquire;

--- a/rust/sqlx/src/pool.rs
+++ b/rust/sqlx/src/pool.rs
@@ -4,8 +4,8 @@
 use aws_sdk_dsql::auth_token::AuthTokenGenerator;
 
 use crate::config::DsqlConnectOptions;
+use crate::sqlx_compat::sqlx::postgres::{PgPool, PgPoolOptions};
 use crate::{DsqlError, Result};
-use sqlx::postgres::{PgPool, PgPoolOptions};
 
 /// Parse a connection string, create a PgPool, verify connectivity,
 /// and spawn a background token refresh task.

--- a/rust/sqlx/src/sqlx_compat.rs
+++ b/rust/sqlx/src/sqlx_compat.rs
@@ -1,0 +1,14 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#[cfg(feature = "sqlx-0_8")]
+pub use sqlx_0_8 as sqlx;
+
+#[cfg(feature = "sqlx-0_9")]
+pub use sqlx_0_9 as sqlx;
+
+#[cfg(all(feature = "sqlx-0_8", feature = "sqlx-0_9"))]
+compile_error!("Features `sqlx-0_8` and `sqlx-0_9` are mutually exclusive.");
+
+#[cfg(not(any(feature = "sqlx-0_8", feature = "sqlx-0_9")))]
+compile_error!("Either `sqlx-0_8` or `sqlx-0_9` must be enabled.");

--- a/rust/sqlx/tests/integration/connection_integration_test.rs
+++ b/rust/sqlx/tests/integration/connection_integration_test.rs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use aurora_dsql_sqlx_connector::sqlx_compat::sqlx;
 use aurora_dsql_sqlx_connector::Result;
 use sqlx::Row;
 

--- a/rust/sqlx/tests/integration/pool_integration_test.rs
+++ b/rust/sqlx/tests/integration/pool_integration_test.rs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use aurora_dsql_sqlx_connector::sqlx_compat::sqlx;
 use aurora_dsql_sqlx_connector::{
     txn, DsqlConnectOptions, DsqlConnectOptionsBuilder, DsqlError, OCCRetryConfigBuilder,
     OCCRetryExt, Result,
@@ -11,7 +12,7 @@ use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
-use super::test_util::build_conn_str;
+use super::test_util::{build_conn_str, dyn_query};
 
 #[tokio::test]
 async fn test_pool_occ_retry_on_concurrent_conflict() -> Result<()> {
@@ -23,7 +24,7 @@ async fn test_pool_occ_retry_on_concurrent_conflict() -> Result<()> {
         aurora_dsql_sqlx_connector::pool::connect_with(&opts, PgPoolOptions::new()).await?;
 
     // Cleanup any leftover table from previous runs
-    sqlx::query(&format!("DROP TABLE IF EXISTS {}", table_name))
+    dyn_query!("DROP TABLE IF EXISTS {}", table_name)
         .execute(&pool)
         .await
         .map_err(DsqlError::DatabaseError)?;
@@ -32,10 +33,10 @@ async fn test_pool_occ_retry_on_concurrent_conflict() -> Result<()> {
     pool.transaction_with_retry(None, |tx| {
         let t = table_name.clone();
         txn!({
-            sqlx::query(&format!(
+            dyn_query!(
                 "CREATE TABLE IF NOT EXISTS {} (id INT PRIMARY KEY, counter INT NOT NULL)",
                 t
-            ))
+            )
             .execute(&mut **tx)
             .await?;
             Ok(())
@@ -47,7 +48,7 @@ async fn test_pool_occ_retry_on_concurrent_conflict() -> Result<()> {
     pool.transaction_with_retry(None, |tx| {
         let t = table_name.clone();
         txn!({
-            sqlx::query(&format!("INSERT INTO {} (id, counter) VALUES (1, 0)", t))
+            dyn_query!("INSERT INTO {} (id, counter) VALUES (1, 0)", t)
                 .execute(&mut **tx)
                 .await?;
             Ok(())
@@ -72,13 +73,13 @@ async fn test_pool_occ_retry_on_concurrent_conflict() -> Result<()> {
                 let t = table.clone();
                 txn!({
                     // Read current value
-                    let row = sqlx::query(&format!("SELECT counter FROM {} WHERE id = 1", t))
+                    let row = dyn_query!("SELECT counter FROM {} WHERE id = 1", t)
                         .fetch_one(&mut **tx)
                         .await?;
                     let current: i32 = row.get("counter");
 
                     // Increment (classic read-modify-write that triggers OCC)
-                    sqlx::query(&format!("UPDATE {} SET counter = $1 WHERE id = 1", t))
+                    dyn_query!("UPDATE {} SET counter = $1 WHERE id = 1", t)
                         .bind(current + 1)
                         .execute(&mut **tx)
                         .await?;
@@ -95,7 +96,7 @@ async fn test_pool_occ_retry_on_concurrent_conflict() -> Result<()> {
     }
 
     // Verify all increments succeeded - counter should be 10
-    let row = sqlx::query(&format!("SELECT counter FROM {} WHERE id = 1", table_name))
+    let row = dyn_query!("SELECT counter FROM {} WHERE id = 1", table_name)
         .fetch_one(&pool)
         .await
         .map_err(DsqlError::DatabaseError)?;
@@ -109,7 +110,7 @@ async fn test_pool_occ_retry_on_concurrent_conflict() -> Result<()> {
     pool.transaction_with_retry(None, |tx| {
         let t = table_name.clone();
         txn!({
-            sqlx::query(&format!("DROP TABLE IF EXISTS {}", t))
+            dyn_query!("DROP TABLE IF EXISTS {}", t)
                 .execute(&mut **tx)
                 .await?;
             Ok(())
@@ -171,10 +172,10 @@ async fn test_connection_occ_retry_with_conflict() -> Result<()> {
     pool.transaction_with_retry(None, |tx| {
         let t = table_name.clone();
         txn!({
-            sqlx::query(&format!(
+            dyn_query!(
                 "CREATE TABLE IF NOT EXISTS {} (id INT PRIMARY KEY, val INT)",
                 t
-            ))
+            )
             .execute(&mut **tx)
             .await?;
             Ok(())
@@ -185,7 +186,7 @@ async fn test_connection_occ_retry_with_conflict() -> Result<()> {
     pool.transaction_with_retry(None, |tx| {
         let t = table_name.clone();
         txn!({
-            sqlx::query(&format!("INSERT INTO {} VALUES (1, 0)", t))
+            dyn_query!("INSERT INTO {} VALUES (1, 0)", t)
                 .execute(&mut **tx)
                 .await?;
             Ok(())
@@ -212,7 +213,7 @@ async fn test_connection_occ_retry_with_conflict() -> Result<()> {
             .transaction_with_retry(None, |tx| {
                 let t = table_clone.clone();
                 txn!({
-                    sqlx::query(&format!("UPDATE {} SET val = 999 WHERE id = 1", t))
+                    dyn_query!("UPDATE {} SET val = 999 WHERE id = 1", t)
                         .execute(&mut **tx)
                         .await?;
                     Ok(())
@@ -228,11 +229,11 @@ async fn test_connection_occ_retry_with_conflict() -> Result<()> {
             let t = table_name.clone();
             txn!({
                 c.fetch_add(1, Ordering::SeqCst);
-                let row = sqlx::query(&format!("SELECT val FROM {} WHERE id = 1", t))
+                let row = dyn_query!("SELECT val FROM {} WHERE id = 1", t)
                     .fetch_one(&mut **tx)
                     .await?;
                 let current: i32 = row.get("val");
-                sqlx::query(&format!("UPDATE {} SET val = $1 WHERE id = 1", t))
+                dyn_query!("UPDATE {} SET val = $1 WHERE id = 1", t)
                     .bind(current + 1)
                     .execute(&mut **tx)
                     .await?;
@@ -256,7 +257,7 @@ async fn test_connection_occ_retry_with_conflict() -> Result<()> {
     pool.transaction_with_retry(None, |tx| {
         let t = table_name.clone();
         txn!({
-            sqlx::query(&format!("DROP TABLE IF EXISTS {}", t))
+            dyn_query!("DROP TABLE IF EXISTS {}", t)
                 .execute(&mut **tx)
                 .await?;
             Ok(())
@@ -306,7 +307,7 @@ async fn test_retry_exhaustion() -> Result<()> {
         aurora_dsql_sqlx_connector::pool::connect_with(&opts, PgPoolOptions::new()).await?;
 
     // Cleanup any leftover table from previous runs
-    sqlx::query(&format!("DROP TABLE IF EXISTS {}", table_name))
+    dyn_query!("DROP TABLE IF EXISTS {}", table_name)
         .execute(&pool)
         .await
         .map_err(DsqlError::DatabaseError)?;
@@ -315,10 +316,10 @@ async fn test_retry_exhaustion() -> Result<()> {
     pool.transaction_with_retry(None, |tx| {
         let t = table_name.clone();
         txn!({
-            sqlx::query(&format!(
+            dyn_query!(
                 "CREATE TABLE IF NOT EXISTS {} (id INT PRIMARY KEY, val INT)",
                 t
-            ))
+            )
             .execute(&mut **tx)
             .await?;
             Ok(())
@@ -329,7 +330,7 @@ async fn test_retry_exhaustion() -> Result<()> {
     pool.transaction_with_retry(None, |tx| {
         let t = table_name.clone();
         txn!({
-            sqlx::query(&format!("INSERT INTO {} VALUES (1, 0)", t))
+            dyn_query!("INSERT INTO {} VALUES (1, 0)", t)
                 .execute(&mut **tx)
                 .await?;
             Ok(())
@@ -359,12 +360,9 @@ async fn test_retry_exhaustion() -> Result<()> {
                         .transaction_with_retry(None, |tx| {
                             let tab = t.clone();
                             txn!({
-                                sqlx::query(&format!(
-                                    "UPDATE {} SET val = val + 1 WHERE id = 1",
-                                    tab
-                                ))
-                                .execute(&mut **tx)
-                                .await?;
+                                dyn_query!("UPDATE {} SET val = val + 1 WHERE id = 1", tab)
+                                    .execute(&mut **tx)
+                                    .await?;
                                 Ok(())
                             })
                         })
@@ -385,11 +383,11 @@ async fn test_retry_exhaustion() -> Result<()> {
             let t = table_name.clone();
             txn!({
                 c.fetch_add(1, Ordering::SeqCst);
-                let row = sqlx::query(&format!("SELECT val FROM {} WHERE id = 1", t))
+                let row = dyn_query!("SELECT val FROM {} WHERE id = 1", t)
                     .fetch_one(&mut **tx)
                     .await?;
                 let current: i32 = row.get("val");
-                sqlx::query(&format!("UPDATE {} SET val = $1 WHERE id = 1", t))
+                dyn_query!("UPDATE {} SET val = $1 WHERE id = 1", t)
                     .bind(current + 100)
                     .execute(&mut **tx)
                     .await?;
@@ -430,7 +428,7 @@ async fn test_retry_exhaustion() -> Result<()> {
     pool.transaction_with_retry(None, |tx| {
         let t = table_name.clone();
         txn!({
-            sqlx::query(&format!("DROP TABLE IF EXISTS {}", t))
+            dyn_query!("DROP TABLE IF EXISTS {}", t)
                 .execute(&mut **tx)
                 .await?;
             Ok(())
@@ -452,7 +450,7 @@ async fn test_return_value_preserved_across_retries() -> Result<()> {
         aurora_dsql_sqlx_connector::pool::connect_with(&opts, PgPoolOptions::new()).await?;
 
     // Cleanup any leftover table from previous runs
-    sqlx::query(&format!("DROP TABLE IF EXISTS {}", table_name))
+    dyn_query!("DROP TABLE IF EXISTS {}", table_name)
         .execute(&pool)
         .await
         .map_err(DsqlError::DatabaseError)?;
@@ -461,10 +459,10 @@ async fn test_return_value_preserved_across_retries() -> Result<()> {
     pool.transaction_with_retry(None, |tx| {
         let t = table_name.clone();
         txn!({
-            sqlx::query(&format!(
+            dyn_query!(
                 "CREATE TABLE IF NOT EXISTS {} (id INT PRIMARY KEY, val INT)",
                 t
-            ))
+            )
             .execute(&mut **tx)
             .await?;
             Ok(())
@@ -475,7 +473,7 @@ async fn test_return_value_preserved_across_retries() -> Result<()> {
     pool.transaction_with_retry(None, |tx| {
         let t = table_name.clone();
         txn!({
-            sqlx::query(&format!("INSERT INTO {} VALUES (1, 42)", t))
+            dyn_query!("INSERT INTO {} VALUES (1, 42)", t)
                 .execute(&mut **tx)
                 .await?;
             Ok(())
@@ -500,7 +498,7 @@ async fn test_return_value_preserved_across_retries() -> Result<()> {
             .transaction_with_retry(None, |tx| {
                 let t = table_clone.clone();
                 txn!({
-                    sqlx::query(&format!("UPDATE {} SET val = 100 WHERE id = 1", t))
+                    dyn_query!("UPDATE {} SET val = 100 WHERE id = 1", t)
                         .execute(&mut **tx)
                         .await?;
                     Ok(())
@@ -516,13 +514,13 @@ async fn test_return_value_preserved_across_retries() -> Result<()> {
             let t = table_name.clone();
             txn!({
                 c.fetch_add(1, Ordering::SeqCst);
-                let row = sqlx::query(&format!("SELECT val FROM {} WHERE id = 1", t))
+                let row = dyn_query!("SELECT val FROM {} WHERE id = 1", t)
                     .fetch_one(&mut **tx)
                     .await?;
                 let val: i32 = row.get("val");
 
                 // Update it
-                sqlx::query(&format!("UPDATE {} SET val = $1 WHERE id = 1", t))
+                dyn_query!("UPDATE {} SET val = $1 WHERE id = 1", t)
                     .bind(val + 10)
                     .execute(&mut **tx)
                     .await?;
@@ -546,7 +544,7 @@ async fn test_return_value_preserved_across_retries() -> Result<()> {
     pool.transaction_with_retry(None, |tx| {
         let t = table_name.clone();
         txn!({
-            sqlx::query(&format!("DROP TABLE IF EXISTS {}", t))
+            dyn_query!("DROP TABLE IF EXISTS {}", t)
                 .execute(&mut **tx)
                 .await?;
             Ok(())

--- a/rust/sqlx/tests/integration/test_util.rs
+++ b/rust/sqlx/tests/integration/test_util.rs
@@ -6,3 +6,23 @@ pub fn build_conn_str() -> String {
     let user = std::env::var("CLUSTER_USER").unwrap_or_else(|_| "admin".to_string());
     format!("postgres://{}@{}/postgres", user, endpoint)
 }
+
+/// Wraps a dynamic SQL string for compatibility with sqlx 0.9's `SqlSafeStr` trait.
+/// In sqlx 0.8, this is a no-op passthrough.
+#[cfg(feature = "sqlx-0_9")]
+macro_rules! dyn_query {
+    ($($arg:tt)*) => {
+        ::aurora_dsql_sqlx_connector::sqlx_compat::sqlx::query(
+            ::aurora_dsql_sqlx_connector::sqlx_compat::sqlx::AssertSqlSafe(format!($($arg)*))
+        )
+    };
+}
+
+#[cfg(feature = "sqlx-0_8")]
+macro_rules! dyn_query {
+    ($($arg:tt)*) => {
+        ::aurora_dsql_sqlx_connector::sqlx_compat::sqlx::query(&format!($($arg)*))
+    };
+}
+
+pub(crate) use dyn_query;


### PR DESCRIPTION
## Summary

Adds mutually exclusive Cargo feature flags (`sqlx-0_8` default, `sqlx-0_9` opt-in) so users on sqlx 0.9 can use the connector without the dual `sqlx-core` type mismatch.

- Introduces `sqlx_compat` re-export module that aliases the selected sqlx version
- Replaces the direct `sqlx = "0.8"` dependency with two optional renamed deps (`sqlx-0_8`, `sqlx-0_9`)
- Adds `compile_error!` guards for mutual exclusivity
- Adds `dyn_query!` test macro to handle sqlx 0.9's `SqlSafeStr` trait in integration tests
- Updates CI with matrix strategy to test both sqlx versions
- Updates README with feature flag table, migration instructions, and re-export usage
- Fixes `docs.rs` metadata (`all-features = true` → explicit feature list since the flags are mutually exclusive)

## Usage

Existing users (sqlx 0.8) — no change needed:
```toml
aurora-dsql-sqlx-connector = { version = "0.1.2", features = ["pool", "occ"] }
```

Users on sqlx 0.9:
```toml
aurora-dsql-sqlx-connector = { version = "0.1.2", default-features = false, features = ["sqlx-0_9", "pool", "occ"] }
```

## Test plan

- [x] `cargo check --features sqlx-0_8,pool,occ` passes
- [x] `cargo check --features sqlx-0_9,pool,occ` passes
- [x] `cargo check --features sqlx-0_8,pool,occ --tests` passes
- [x] `cargo check --features sqlx-0_9,pool,occ --tests` passes
- [x] `cargo check --all-features` produces expected `compile_error!`
- [x] Example crate compiles (unchanged, uses sqlx 0.8 directly)
- [x] CI matrix tests both `sqlx-0_8` and `sqlx-0_9` (examples only run for 0.8)

Closes #518

*Issue #, if available:*
N/A

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.