### PR TITLE
fix(jdbc): return null for unsupported URLs

### DIFF
--- a/java/jdbc/src/main/java/software/amazon/dsql/jdbc/DSQLConnector.java
+++ b/java/jdbc/src/main/java/software/amazon/dsql/jdbc/DSQLConnector.java
@@ -199,6 +199,9 @@ public class DSQLConnector implements java.sql.Driver {
      *
      * <h3>Error Scenarios</h3>
      *
+     * <p>Returns {@code null} for URLs this driver does not accept, allowing {@link DriverManager}
+     * to try the next registered driver.
+     *
      * <p>Throws {@link SQLException} for:
      *
      * <ul>
@@ -213,13 +216,21 @@ public class DSQLConnector implements java.sql.Driver {
      *     jdbc:aws-dsql:postgresql://cluster.dsql.region.on.aws} with optional database and
      *     property definitions
      * @param info connection properties which augment those provided in the URL
-     * @return a {@link Connection} to the Aurora DSQL cluster
+     * @return a {@link Connection} to the Aurora DSQL cluster, or {@code null} if this driver does
+     *     not accept the URL
      * @throws SQLException if connection cannot be established due to invalid input, credential
      *     issues, or connection failures
      * @see PropertyDefinition
      */
     @Override
     public Connection connect(final String url, final Properties info) throws SQLException {
+        if (url == null) {
+            throw new SQLException("URL is null");
+        }
+        if (!acceptsURL(url)) {
+            return null;
+        }
+
         // Parse properties from URL if provided
         final Properties props = PropertyUtils.copyProperties(info);
         try {

--- a/java/jdbc/src/test/java/software/amazon/dsql/jdbc/DSQLConnectorTest.java
+++ b/java/jdbc/src/test/java/software/amazon/dsql/jdbc/DSQLConnectorTest.java
@@ -19,6 +19,7 @@ package software.amazon.dsql.jdbc;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -269,6 +270,22 @@ class DSQLConnectorTest {
                 exception.getMessage().contains("URL")
                         || exception.getMessage().contains("null")
                         || exception.getMessage().contains("Invalid"));
+    }
+
+    @Test
+    void testConnect_NonDsqlUrl_ReturnsNull() throws SQLException {
+        // Arrange
+        String url = "jdbc:postgresql://localhost:5432/postgres";
+        Properties info = new Properties();
+        info.setProperty("user", "testuser");
+
+        // Act
+        Connection result = driver.connect(url, info);
+
+        // Assert
+        assertNull(result);
+        propertyUtilsMock.verifyNoInteractions();
+        credentialsManagerMock.verifyNoInteractions();
     }
 
     @Test


### PR DESCRIPTION
# JDBC connector throws SQLException instead of returning null for unsupported URLs

##  Description of changes:
- Return `null` from `DSQLConnector.connect()` when the URL is not accepted by this driver.
- Preserve the existing `SQLException` behavior for `null` URLs.
- Add a regression test for a non-DSQL PostgreSQL URL.

## Why
This aligns `DSQLConnector` with the `java.sql.Driver.connect` contract and lets
`DriverManager` continue to the next registered driver for unsupported URLs.

## Test
```bash
JAVA_HOME=/opt/homebrew/opt/openjdk@25/libexec/openjdk.jdk/Contents/Home ./gradlew check
```
Result: BUILD SUCCESSFUL
<img width="573" height="99" alt="image" src="https://github.com/user-attachments/assets/e45a846e-5de0-4cfe-82ce-eeb5f6215784" />


Closes #661

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
