### PR TITLE
go/pgx: default to DescribeExec (schema-change safe) with Config.QueryExecMode override

### DIFF
--- a/go/pgx/README.md
+++ b/go/pgx/README.md
@@ -384,45 +384,61 @@ go run ./src/connection_string/...
 
 ## Query Execution Mode and Schema Evolution
 
-The connector sets pgx's `DefaultQueryExecMode` to `QueryExecModeExec` on every
-connection it creates.
+The connector sets pgx's `DefaultQueryExecMode` to `QueryExecModeDescribeExec` on
+every connection it creates. You can override this via `Config.QueryExecMode`.
 
-**Why not pgx's caching defaults?** pgx's default `QueryExecModeCacheDescribe`
-caches each statement's result-column descriptions per connection, and
-`QueryExecModeCacheStatement` caches a prepared statement. If a table's schema
-changes while pooled connections are still open — for example
-`ALTER TABLE ... ADD COLUMN` during a migration — those connections hold a stale
-description/plan and fail on the next execution:
+**Why not pgx's caching defaults?** pgx's default is `QueryExecModeCacheStatement`,
+which caches a prepared statement per connection; `QueryExecModeCacheDescribe`
+caches the statement's result-column descriptions. If a table's schema changes
+while pooled connections are still open — for example `ALTER TABLE ... ADD COLUMN`
+during a migration — the next execution on a connection holding a stale plan or
+description fails:
 
 ```
-CacheDescribe:  ERROR: bind message has N result formats but query has M columns (SQLSTATE 08P01)
 CacheStatement: ERROR: cached plan must not change result type (SQLSTATE 0A000)
+CacheDescribe:  ERROR: bind message has N result formats but query has M columns (SQLSTATE 08P01)
 ```
 
-Every existing connection in the pool fails this way until it is recycled.
+pgx invalidates the cache on that error and self-heals on the next attempt, but
+the failing statement still surfaces an error to the caller.
 
-`QueryExecModeExec` uses the unnamed prepared statement and does not cache a
-description or plan across executions, so it always reflects the current schema
-and neither error can occur. It also completes in a single network round trip and
-keeps the extended query protocol (typed, bound parameters), so there is no change
-to how you pass query arguments.
+`QueryExecModeDescribeExec` issues a `Describe` on every execution, so the result
+shape and parameter types are always current. It is safe across live schema
+changes, and because the server resolves parameter types, it correctly encodes
+ambiguous Go values. The cost is one extra `Describe` round trip per query.
 
-**Why not `QueryExecModeDescribeExec`?** It is also schema-change safe, but it
-issues a separate `Describe` round trip on every execution. Measured on Aurora
-DSQL, that roughly **doubles per-query latency (~2x)** versus `Exec`, with no
-observed correctness advantage on DSQL's supported type surface — DSQL does not
-support enums or arrays, which are the main cases where the extra server-side
-parameter type resolution would matter. If your workload specifically relies on
-server-driven parameter type resolution, override the mode after creating the
-config (for a single connection via a `pgx.ParseConfig`-based flow, or per pool by
-adjusting `poolConfig.ConnConfig.DefaultQueryExecMode`).
+**Why not `QueryExecModeExec`?** `Exec` avoids the extra round trip (measured on
+Aurora DSQL it is roughly 2x faster per query than `DescribeExec`), but it **skips
+the server-side parameter `Describe`** and infers PostgreSQL types from Go types
+alone. On Aurora DSQL this measurably breaks real cases:
+
+- a `jsonb` parameter passed as a `map` or `[]byte` is **rejected**, and
+- a `[]byte` bound to a `text` column is **silently stored as its bytea hex
+  encoding** (no error, corrupted data).
+
+Because of this it is not a safe default. If your parameter types are unambiguous
+and you need the lower latency, opt in explicitly:
+
+```go
+pool, _ := dsql.NewPool(ctx, dsql.Config{
+    Host:          "cluster.dsql.us-east-1.on.aws",
+    QueryExecMode: pgx.QueryExecModeExec,
+})
+```
+
+> Note: overriding via `pool.Config().ConnConfig.DefaultQueryExecMode` or a preset
+> `pgxpool.Config.ConnConfig` does **not** work — `Config()` returns a copy, and
+> the connector applies its own mode when each connection is established. Use
+> `Config.QueryExecMode` (above), which is honored for both pooled and single
+> connections.
 
 ### Recommendation: avoid `SELECT *` on evolving tables
 
-`Exec` prevents the errors above, but a `SELECT *` result set will still *grow*
-when columns are added — the query stops failing, yet now returns the extra
-columns. With `database/sql`/`sqlx`-style row scanning, unmapped extra columns can
-themselves cause errors (e.g. `missing destination name`). Prefer explicit column
+Selecting into a fixed struct is only part of the story: a `SELECT *` result set
+will still *grow* when columns are added, so the query keeps working but now
+returns extra columns. With `database/sql`/`sqlx`-style row scanning, unmapped
+extra columns can themselves cause errors (e.g. `missing destination name`).
+Prefer explicit column
 lists (`SELECT col_a, col_b, ...`) on read paths so additive schema changes are
 transparent to the application regardless of query mode.
 

--- a/go/pgx/README.md
+++ b/go/pgx/README.md
@@ -382,6 +382,50 @@ go run ./src/occ_retry/...
 go run ./src/connection_string/...
 ```
 
+## Query Execution Mode and Schema Evolution
+
+The connector sets pgx's `DefaultQueryExecMode` to `QueryExecModeExec` on every
+connection it creates.
+
+**Why not pgx's caching defaults?** pgx's default `QueryExecModeCacheDescribe`
+caches each statement's result-column descriptions per connection, and
+`QueryExecModeCacheStatement` caches a prepared statement. If a table's schema
+changes while pooled connections are still open — for example
+`ALTER TABLE ... ADD COLUMN` during a migration — those connections hold a stale
+description/plan and fail on the next execution:
+
+```
+CacheDescribe:  ERROR: bind message has N result formats but query has M columns (SQLSTATE 08P01)
+CacheStatement: ERROR: cached plan must not change result type (SQLSTATE 0A000)
+```
+
+Every existing connection in the pool fails this way until it is recycled.
+
+`QueryExecModeExec` uses the unnamed prepared statement and does not cache a
+description or plan across executions, so it always reflects the current schema
+and neither error can occur. It also completes in a single network round trip and
+keeps the extended query protocol (typed, bound parameters), so there is no change
+to how you pass query arguments.
+
+**Why not `QueryExecModeDescribeExec`?** It is also schema-change safe, but it
+issues a separate `Describe` round trip on every execution. Measured on Aurora
+DSQL, that roughly **doubles per-query latency (~2x)** versus `Exec`, with no
+observed correctness advantage on DSQL's supported type surface — DSQL does not
+support enums or arrays, which are the main cases where the extra server-side
+parameter type resolution would matter. If your workload specifically relies on
+server-driven parameter type resolution, override the mode after creating the
+config (for a single connection via a `pgx.ParseConfig`-based flow, or per pool by
+adjusting `poolConfig.ConnConfig.DefaultQueryExecMode`).
+
+### Recommendation: avoid `SELECT *` on evolving tables
+
+`Exec` prevents the errors above, but a `SELECT *` result set will still *grow*
+when columns are added — the query stops failing, yet now returns the extra
+columns. With `database/sql`/`sqlx`-style row scanning, unmapped extra columns can
+themselves cause errors (e.g. `missing destination name`). Prefer explicit column
+lists (`SELECT col_a, col_b, ...`) on read paths so additive schema changes are
+transparent to the application regardless of query mode.
+
 ## DSQL Best Practices
 
 For Aurora DSQL best practices including primary key selection, concurrency handling, index creation, and transaction limits, see the [Aurora DSQL documentation](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/working-with-postgresql-compatibility.html).

--- a/go/pgx/README.md
+++ b/go/pgx/README.md
@@ -51,6 +51,7 @@ go get github.com/awslabs/aurora-dsql-connectors/go/pgx/dsql
 | `Port` | `int` | `5432` | Database port |
 | `Profile` | `string` | `""` | AWS profile name for credentials |
 | `TokenDurationSecs` | `int` | `900` (15 min) | Token validity duration in seconds (max 1 week) |
+| `QueryExecMode` | `pgx.QueryExecMode` | `DescribeExec` | Query execution mode; see [Query Execution Mode and Schema Evolution](#query-execution-mode-and-schema-evolution) |
 | `CustomCredentialsProvider` | `aws.CredentialsProvider` | `nil` | Custom AWS credentials provider |
 
 Pool configuration is passed directly via `*pgxpool.Config` as a separate parameter to `NewPool`. See [Pool Configuration Tuning](#pool-configuration-tuning) for details.
@@ -101,6 +102,7 @@ postgres://[user@]host[:port]/[database][?param=value&...]
 - `region` - AWS region
 - `profile` - AWS profile name
 - `tokenDurationSecs` - Token validity duration in seconds
+- `queryExecMode` - Query execution mode: `cache_statement`, `cache_describe`, `describe_exec`, `exec`, or `simple_protocol`
 
 **Examples:**
 
@@ -113,6 +115,9 @@ pool, _ := dsql.NewPool(ctx, "postgres://admin@cluster.dsql.us-east-1.on.aws/myd
 
 // With AWS profile
 pool, _ := dsql.NewPool(ctx, "postgres://admin@cluster.dsql.us-east-1.on.aws/postgres?profile=dev")
+
+// With an explicit query execution mode
+pool, _ = dsql.NewPool(ctx, "postgres://admin@cluster.dsql.us-east-1.on.aws/postgres?queryExecMode=cache_statement")
 ```
 
 ## Advanced Usage
@@ -416,15 +421,22 @@ alone. On Aurora DSQL this measurably breaks real cases:
 - a `[]byte` bound to a `text` column is **silently stored as its bytea hex
   encoding** (no error, corrupted data).
 
-Because of this it is not a safe default. If your parameter types are unambiguous
-and you need the lower latency, opt in explicitly:
+Because of this `Exec` is not a safe general-purpose option. If you need lower
+latency and can tolerate one transient, retryable schema-change failure, prefer
+`CacheStatement`: it keeps server-resolved parameter types and completes in a
+single round trip. Ensure your application retries `40001`/`0A000` during schema
+migrations.
 
 ```go
 pool, _ := dsql.NewPool(ctx, dsql.Config{
     Host:          "cluster.dsql.us-east-1.on.aws",
-    QueryExecMode: pgx.QueryExecModeExec,
+    QueryExecMode: pgx.QueryExecModeCacheStatement,
 })
 ```
+
+Use `Exec` only after validating that your workload has no ambiguous parameter
+types, such as `jsonb` values passed as Go maps/`[]byte` or `[]byte` values bound
+to text columns.
 
 > Note: overriding via `pool.Config().ConnConfig.DefaultQueryExecMode` or a preset
 > `pgxpool.Config.ConnConfig` does **not** work — `Config()` returns a copy, and

--- a/go/pgx/dsql/config.go
+++ b/go/pgx/dsql/config.go
@@ -172,6 +172,23 @@ func getRegionFromEnv() string {
 	return os.Getenv("AWS_DEFAULT_REGION")
 }
 
+func parseQueryExecMode(value string) (pgx.QueryExecMode, error) {
+	switch value {
+	case "cache_statement":
+		return pgx.QueryExecModeCacheStatement, nil
+	case "cache_describe":
+		return pgx.QueryExecModeCacheDescribe, nil
+	case "describe_exec":
+		return pgx.QueryExecModeDescribeExec, nil
+	case "exec":
+		return pgx.QueryExecModeExec, nil
+	case "simple_protocol":
+		return pgx.QueryExecModeSimpleProtocol, nil
+	default:
+		return 0, fmt.Errorf("invalid queryExecMode %q", value)
+	}
+}
+
 // ParseConnectionString parses a PostgreSQL or DSQL connection string into a Config.
 // Supported schemes: postgres://, postgresql://, dsql://
 func ParseConnectionString(connStr string) (*Config, error) {
@@ -223,6 +240,14 @@ func ParseConnectionString(connStr string) (*Config, error) {
 			return nil, fmt.Errorf("invalid tokenDurationSecs: %w", err)
 		}
 		cfg.TokenDurationSecs = duration
+	}
+
+	if queryExecMode := query.Get("queryExecMode"); queryExecMode != "" {
+		mode, err := parseQueryExecMode(queryExecMode)
+		if err != nil {
+			return nil, err
+		}
+		cfg.QueryExecMode = mode
 	}
 
 	return cfg, nil

--- a/go/pgx/dsql/config.go
+++ b/go/pgx/dsql/config.go
@@ -73,20 +73,8 @@ type Config struct {
 	// CustomCredentialsProvider is a custom AWS credentials provider. Optional.
 	CustomCredentialsProvider aws.CredentialsProvider
 
-	// QueryExecMode overrides the pgx query execution mode used for every
-	// connection the connector creates. Optional; the zero value means "use the
-	// connector default" (QueryExecModeDescribeExec).
-	//
-	// The connector defaults to QueryExecModeDescribeExec because it stays
-	// correct across live schema changes (see configureConnConfig). If your
-	// workload is latency-sensitive and you have validated it against the
-	// caveats below, you can set QueryExecModeExec here for single-round-trip
-	// execution. Note that QueryExecModeExec skips the server-side parameter
-	// Describe, so it infers PostgreSQL parameter types from Go types alone;
-	// this can reject or mis-encode values whose intended type is ambiguous
-	// (e.g. jsonb passed as map/[]byte, or []byte destined for a text column).
-	// Prefer the default unless you have measured a need and confirmed your
-	// parameter types are unambiguous.
+	// QueryExecMode overrides the pgx query execution mode. Optional; zero means
+	// the connector default (QueryExecModeDescribeExec). See configureConnConfig.
 	QueryExecMode pgx.QueryExecMode
 }
 
@@ -126,9 +114,7 @@ func (c *Config) resolve() (*resolvedConfig, error) {
 	if resolved.User == "" {
 		resolved.User = DefaultUser
 	}
-	// The zero value of pgx.QueryExecMode is not a valid mode (the pgx const
-	// block starts at iota with a blank identifier), so treat zero as "unset"
-	// and apply the connector default.
+	// Zero is not a valid pgx.QueryExecMode, so treat it as "unset".
 	if resolved.QueryExecMode == 0 {
 		resolved.QueryExecMode = DefaultQueryExecMode
 	}
@@ -256,34 +242,13 @@ func (r *resolvedConfig) configureConnConfig(cfg *pgx.ConnConfig) {
 		"application_name": ApplicationName,
 	}
 
-	// Set the pgx query execution mode. Defaults to DescribeExec (see
-	// DefaultQueryExecMode); callers can override via Config.QueryExecMode.
-	//
-	// Background: pgx's own default is QueryExecModeCacheStatement, which caches
-	// a prepared statement per connection; QueryExecModeCacheDescribe caches the
-	// statement's result-column descriptions. Either way, if a table's schema
-	// changes (e.g. ALTER TABLE ADD COLUMN) while pooled connections are still
-	// open, the next execution on a connection holding a stale plan/description
-	// fails:
-	//
-	//	CacheStatement: ERROR: cached plan must not change result type (SQLSTATE 0A000)
-	//	CacheDescribe:  ERROR: bind message has N result formats but query has M columns (SQLSTATE 08P01)
-	//
-	// pgx invalidates the cache on that error and self-heals on the next attempt,
-	// but the failing statement still surfaces an error to the caller.
-	//
-	// DescribeExec issues a Describe on every execution, so the result shape and
-	// parameter types are always current: it is safe across live schema changes,
-	// and because the server resolves parameter types it encodes ambiguous Go
-	// values correctly (e.g. jsonb passed as map/[]byte, or []byte destined for a
-	// text vs bytea column). The cost is an extra Describe round trip per query.
-	//
-	// QueryExecModeExec avoids that round trip but SKIPS the server parameter
-	// Describe, inferring PostgreSQL types from Go types alone. On Aurora DSQL
-	// that measurably breaks real cases: a jsonb parameter passed as map/[]byte
-	// is rejected, and a []byte bound to a text column is silently stored as its
-	// bytea hex encoding. It is therefore not a safe default. Callers whose
-	// parameter types are unambiguous and who need the lower latency can opt in
-	// with Config.QueryExecMode = pgx.QueryExecModeExec.
+	// Default to DescribeExec (overridable via Config.QueryExecMode). pgx's
+	// caching modes (CacheStatement, CacheDescribe) fail after a live schema
+	// change on connections holding a stale plan/description (0A000 / 08P01).
+	// DescribeExec re-Describes each execution, so it is schema-change safe and
+	// resolves parameter types server-side. Exec avoids the extra round trip but
+	// infers param types from Go types alone, which on DSQL rejects jsonb
+	// map/[]byte params and silently corrupts []byte into text columns, so it is
+	// opt-in only.
 	cfg.DefaultQueryExecMode = r.QueryExecMode
 }

--- a/go/pgx/dsql/config.go
+++ b/go/pgx/dsql/config.go
@@ -226,4 +226,32 @@ func (r *resolvedConfig) configureConnConfig(cfg *pgx.ConnConfig) {
 	cfg.RuntimeParams = map[string]string{
 		"application_name": ApplicationName,
 	}
+
+	// Use Exec as the default query mode on Aurora DSQL.
+	//
+	// pgx's default (QueryExecModeCacheDescribe) caches each statement's result
+	// column descriptions per connection after the first Describe, then reuses
+	// that cached column count to build the Bind result-format-codes array on
+	// subsequent executions. Likewise QueryExecModeCacheStatement caches a
+	// prepared statement. If a table's schema changes (e.g. ALTER TABLE ADD
+	// COLUMN) while pooled connections are still open, those connections hold a
+	// stale description/plan and fail on the next execution:
+	//
+	//	CacheDescribe:  ERROR: bind message has N result formats but query has M columns (SQLSTATE 08P01)
+	//	CacheStatement: ERROR: cached plan must not change result type (SQLSTATE 0A000)
+	//
+	// QueryExecModeExec uses the unnamed prepared statement and does not cache a
+	// description or plan across executions, so it always reflects the current
+	// schema and neither error can occur. It also completes in a single network
+	// round trip. QueryExecModeDescribeExec is likewise schema-change safe but
+	// issues a separate Describe round trip on every execution; measured on
+	// Aurora DSQL that roughly doubles per-query latency (~2x) versus Exec, with
+	// no observed correctness advantage on DSQL's supported type surface (DSQL
+	// does not support enums or arrays, which are the main cases where the extra
+	// server-side parameter type resolution would matter). Exec is therefore the
+	// better default here.
+	//
+	// Callers may override this after construction, e.g. to DescribeExec if their
+	// workload relies on server-driven parameter type resolution.
+	cfg.DefaultQueryExecMode = pgx.QueryExecModeExec
 }

--- a/go/pgx/dsql/config.go
+++ b/go/pgx/dsql/config.go
@@ -42,6 +42,11 @@ const (
 	DefaultTokenDuration = 15 * time.Minute
 )
 
+// DefaultQueryExecMode is the pgx query execution mode the connector applies
+// when Config.QueryExecMode is left unset. See configureConnConfig for the
+// rationale.
+const DefaultQueryExecMode = pgx.QueryExecModeDescribeExec
+
 // Config holds the configuration for connecting to Aurora DSQL.
 type Config struct {
 	// Host is the cluster endpoint or cluster ID. Required.
@@ -67,6 +72,22 @@ type Config struct {
 
 	// CustomCredentialsProvider is a custom AWS credentials provider. Optional.
 	CustomCredentialsProvider aws.CredentialsProvider
+
+	// QueryExecMode overrides the pgx query execution mode used for every
+	// connection the connector creates. Optional; the zero value means "use the
+	// connector default" (QueryExecModeDescribeExec).
+	//
+	// The connector defaults to QueryExecModeDescribeExec because it stays
+	// correct across live schema changes (see configureConnConfig). If your
+	// workload is latency-sensitive and you have validated it against the
+	// caveats below, you can set QueryExecModeExec here for single-round-trip
+	// execution. Note that QueryExecModeExec skips the server-side parameter
+	// Describe, so it infers PostgreSQL parameter types from Go types alone;
+	// this can reject or mis-encode values whose intended type is ambiguous
+	// (e.g. jsonb passed as map/[]byte, or []byte destined for a text column).
+	// Prefer the default unless you have measured a need and confirmed your
+	// parameter types are unambiguous.
+	QueryExecMode pgx.QueryExecMode
 }
 
 // resolvedConfig holds the validated and resolved configuration with all
@@ -80,6 +101,7 @@ type resolvedConfig struct {
 	Profile                   string
 	TokenDuration             time.Duration
 	CustomCredentialsProvider aws.CredentialsProvider
+	QueryExecMode             pgx.QueryExecMode
 }
 
 // resolve validates the configuration, applies defaults, and resolves the
@@ -97,11 +119,18 @@ func (c *Config) resolve() (*resolvedConfig, error) {
 		Port:                      c.Port,
 		Profile:                   c.Profile,
 		CustomCredentialsProvider: c.CustomCredentialsProvider,
+		QueryExecMode:             c.QueryExecMode,
 	}
 
 	// Apply defaults
 	if resolved.User == "" {
 		resolved.User = DefaultUser
+	}
+	// The zero value of pgx.QueryExecMode is not a valid mode (the pgx const
+	// block starts at iota with a blank identifier), so treat zero as "unset"
+	// and apply the connector default.
+	if resolved.QueryExecMode == 0 {
+		resolved.QueryExecMode = DefaultQueryExecMode
 	}
 	if resolved.Database == "" {
 		resolved.Database = DefaultDatabase
@@ -227,31 +256,34 @@ func (r *resolvedConfig) configureConnConfig(cfg *pgx.ConnConfig) {
 		"application_name": ApplicationName,
 	}
 
-	// Use Exec as the default query mode on Aurora DSQL.
+	// Set the pgx query execution mode. Defaults to DescribeExec (see
+	// DefaultQueryExecMode); callers can override via Config.QueryExecMode.
 	//
-	// pgx's default (QueryExecModeCacheDescribe) caches each statement's result
-	// column descriptions per connection after the first Describe, then reuses
-	// that cached column count to build the Bind result-format-codes array on
-	// subsequent executions. Likewise QueryExecModeCacheStatement caches a
-	// prepared statement. If a table's schema changes (e.g. ALTER TABLE ADD
-	// COLUMN) while pooled connections are still open, those connections hold a
-	// stale description/plan and fail on the next execution:
+	// Background: pgx's own default is QueryExecModeCacheStatement, which caches
+	// a prepared statement per connection; QueryExecModeCacheDescribe caches the
+	// statement's result-column descriptions. Either way, if a table's schema
+	// changes (e.g. ALTER TABLE ADD COLUMN) while pooled connections are still
+	// open, the next execution on a connection holding a stale plan/description
+	// fails:
 	//
-	//	CacheDescribe:  ERROR: bind message has N result formats but query has M columns (SQLSTATE 08P01)
 	//	CacheStatement: ERROR: cached plan must not change result type (SQLSTATE 0A000)
+	//	CacheDescribe:  ERROR: bind message has N result formats but query has M columns (SQLSTATE 08P01)
 	//
-	// QueryExecModeExec uses the unnamed prepared statement and does not cache a
-	// description or plan across executions, so it always reflects the current
-	// schema and neither error can occur. It also completes in a single network
-	// round trip. QueryExecModeDescribeExec is likewise schema-change safe but
-	// issues a separate Describe round trip on every execution; measured on
-	// Aurora DSQL that roughly doubles per-query latency (~2x) versus Exec, with
-	// no observed correctness advantage on DSQL's supported type surface (DSQL
-	// does not support enums or arrays, which are the main cases where the extra
-	// server-side parameter type resolution would matter). Exec is therefore the
-	// better default here.
+	// pgx invalidates the cache on that error and self-heals on the next attempt,
+	// but the failing statement still surfaces an error to the caller.
 	//
-	// Callers may override this after construction, e.g. to DescribeExec if their
-	// workload relies on server-driven parameter type resolution.
-	cfg.DefaultQueryExecMode = pgx.QueryExecModeExec
+	// DescribeExec issues a Describe on every execution, so the result shape and
+	// parameter types are always current: it is safe across live schema changes,
+	// and because the server resolves parameter types it encodes ambiguous Go
+	// values correctly (e.g. jsonb passed as map/[]byte, or []byte destined for a
+	// text vs bytea column). The cost is an extra Describe round trip per query.
+	//
+	// QueryExecModeExec avoids that round trip but SKIPS the server parameter
+	// Describe, inferring PostgreSQL types from Go types alone. On Aurora DSQL
+	// that measurably breaks real cases: a jsonb parameter passed as map/[]byte
+	// is rejected, and a []byte bound to a text column is silently stored as its
+	// bytea hex encoding. It is therefore not a safe default. Callers whose
+	// parameter types are unambiguous and who need the lower latency can opt in
+	// with Config.QueryExecMode = pgx.QueryExecModeExec.
+	cfg.DefaultQueryExecMode = r.QueryExecMode
 }

--- a/go/pgx/dsql/config_test.go
+++ b/go/pgx/dsql/config_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -130,8 +131,8 @@ func TestConfigResolve(t *testing.T) {
 	tests := []struct {
 		name    string
 		config  Config
-		setup   func()    // Optional setup (e.g., set env vars)
-		cleanup func()    // Optional cleanup
+		setup   func() // Optional setup (e.g., set env vars)
+		cleanup func() // Optional cleanup
 		wantErr bool
 		errMsg  string
 	}{
@@ -338,4 +339,30 @@ func TestParseConnectionString(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestConfigureConnConfigSetsExecMode(t *testing.T) {
+	cfg := Config{
+		Host: "mycluster.dsql.us-east-1.on.aws",
+	}
+	resolved, err := cfg.resolve()
+	require.NoError(t, err)
+
+	connConfig, err := pgx.ParseConfig("")
+	require.NoError(t, err)
+
+	resolved.configureConnConfig(connConfig)
+
+	// The connector defaults to Exec: it does not cache a description or prepared
+	// statement across executions, so it stays correct after a live schema change
+	// (e.g. ALTER TABLE ADD COLUMN) without the extra Describe round trip that
+	// DescribeExec incurs. See configureConnConfig.
+	assert.Equal(t, pgx.QueryExecModeExec, connConfig.DefaultQueryExecMode)
+
+	// Sanity: the other connection settings are still applied.
+	assert.Equal(t, "mycluster.dsql.us-east-1.on.aws", connConfig.Host)
+	assert.Equal(t, uint16(5432), connConfig.Port)
+	assert.Equal(t, "postgres", connConfig.Database)
+	assert.Equal(t, "admin", connConfig.User)
+	assert.Equal(t, ApplicationName, connConfig.RuntimeParams["application_name"])
 }

--- a/go/pgx/dsql/config_test.go
+++ b/go/pgx/dsql/config_test.go
@@ -318,6 +318,16 @@ func TestParseConnectionString(t *testing.T) {
 				TokenDurationSecs: 300,
 			},
 		},
+		{
+			name:    "with query exec mode",
+			connStr: "postgres://admin@mycluster.dsql.us-east-1.on.aws/postgres?queryExecMode=cache_statement",
+			expected: Config{
+				Host:          "mycluster.dsql.us-east-1.on.aws",
+				User:          "admin",
+				Database:      "postgres",
+				QueryExecMode: pgx.QueryExecModeCacheStatement,
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -336,6 +346,9 @@ func TestParseConnectionString(t *testing.T) {
 			}
 			if tt.expected.TokenDurationSecs != 0 {
 				assert.Equal(t, tt.expected.TokenDurationSecs, cfg.TokenDurationSecs)
+			}
+			if tt.expected.QueryExecMode != 0 {
+				assert.Equal(t, tt.expected.QueryExecMode, cfg.QueryExecMode)
 			}
 		})
 	}
@@ -379,4 +392,10 @@ func TestConfigureConnConfigHonorsQueryExecModeOverride(t *testing.T) {
 
 	// Explicit Config.QueryExecMode is honored over the default.
 	assert.Equal(t, pgx.QueryExecModeExec, connConfig.DefaultQueryExecMode)
+}
+
+func TestParseConnectionStringInvalidQueryExecMode(t *testing.T) {
+	_, err := ParseConnectionString("postgres://admin@mycluster.dsql.us-east-1.on.aws/postgres?queryExecMode=invalid")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid queryExecMode")
 }

--- a/go/pgx/dsql/config_test.go
+++ b/go/pgx/dsql/config_test.go
@@ -353,9 +353,7 @@ func TestConfigureConnConfigDefaultsToDescribeExec(t *testing.T) {
 
 	resolved.configureConnConfig(connConfig)
 
-	// With Config.QueryExecMode unset, the connector applies DescribeExec, which
-	// stays correct across live schema changes and correctly resolves ambiguous
-	// parameter types (jsonb, []byte). See configureConnConfig.
+	// Unset Config.QueryExecMode -> connector default (DescribeExec).
 	assert.Equal(t, pgx.QueryExecModeDescribeExec, connConfig.DefaultQueryExecMode)
 
 	// Sanity: the other connection settings are still applied.
@@ -379,7 +377,6 @@ func TestConfigureConnConfigHonorsQueryExecModeOverride(t *testing.T) {
 
 	resolved.configureConnConfig(connConfig)
 
-	// A caller that explicitly sets Config.QueryExecMode gets that mode, not the
-	// connector default.
+	// Explicit Config.QueryExecMode is honored over the default.
 	assert.Equal(t, pgx.QueryExecModeExec, connConfig.DefaultQueryExecMode)
 }

--- a/go/pgx/dsql/config_test.go
+++ b/go/pgx/dsql/config_test.go
@@ -341,7 +341,7 @@ func TestParseConnectionString(t *testing.T) {
 	}
 }
 
-func TestConfigureConnConfigSetsExecMode(t *testing.T) {
+func TestConfigureConnConfigDefaultsToDescribeExec(t *testing.T) {
 	cfg := Config{
 		Host: "mycluster.dsql.us-east-1.on.aws",
 	}
@@ -353,11 +353,10 @@ func TestConfigureConnConfigSetsExecMode(t *testing.T) {
 
 	resolved.configureConnConfig(connConfig)
 
-	// The connector defaults to Exec: it does not cache a description or prepared
-	// statement across executions, so it stays correct after a live schema change
-	// (e.g. ALTER TABLE ADD COLUMN) without the extra Describe round trip that
-	// DescribeExec incurs. See configureConnConfig.
-	assert.Equal(t, pgx.QueryExecModeExec, connConfig.DefaultQueryExecMode)
+	// With Config.QueryExecMode unset, the connector applies DescribeExec, which
+	// stays correct across live schema changes and correctly resolves ambiguous
+	// parameter types (jsonb, []byte). See configureConnConfig.
+	assert.Equal(t, pgx.QueryExecModeDescribeExec, connConfig.DefaultQueryExecMode)
 
 	// Sanity: the other connection settings are still applied.
 	assert.Equal(t, "mycluster.dsql.us-east-1.on.aws", connConfig.Host)
@@ -365,4 +364,22 @@ func TestConfigureConnConfigSetsExecMode(t *testing.T) {
 	assert.Equal(t, "postgres", connConfig.Database)
 	assert.Equal(t, "admin", connConfig.User)
 	assert.Equal(t, ApplicationName, connConfig.RuntimeParams["application_name"])
+}
+
+func TestConfigureConnConfigHonorsQueryExecModeOverride(t *testing.T) {
+	cfg := Config{
+		Host:          "mycluster.dsql.us-east-1.on.aws",
+		QueryExecMode: pgx.QueryExecModeExec,
+	}
+	resolved, err := cfg.resolve()
+	require.NoError(t, err)
+
+	connConfig, err := pgx.ParseConfig("")
+	require.NoError(t, err)
+
+	resolved.configureConnConfig(connConfig)
+
+	// A caller that explicitly sets Config.QueryExecMode gets that mode, not the
+	// connector default.
+	assert.Equal(t, pgx.QueryExecModeExec, connConfig.DefaultQueryExecMode)
 }


### PR DESCRIPTION
## Problem
Applications using this connector against Aurora DSQL can fail reads from a table immediately after an online `ALTER TABLE ... ADD COLUMN`, with one of:
```
ERROR: cached plan must not change result type (SQLSTATE 0A000)          -- cached prepared statement
ERROR: bind message has N result formats but query has M columns (SQLSTATE 08P01)  -- cached description
```
Existing pooled connections holding a stale plan/description surface this on the next execution, even though no application code changed. (pgx invalidates the cache on the error and self-heals on the next attempt, so it is a transient failure per statement rather than a permanent break, but it is still an error returned to the caller.)

## Root cause
pgx's default `QueryExecMode` is `QueryExecModeCacheStatement`, which caches a prepared statement per connection; `QueryExecModeCacheDescribe` caches the statement's result-column descriptions. Either way, when a table's schema changes while pooled connections are open, a connection holding a stale plan/description fails on the next execution as above. The stdlib (`database/sql`) adapter sets no mode, so it inherits `CacheStatement`.

## Change
Default `DefaultQueryExecMode` to `pgx.QueryExecModeDescribeExec` in `configureConnConfig` (shared by both `Connect` and `NewPool`), and add a `Config.QueryExecMode` field so callers can override it.

`DescribeExec` issues a `Describe` on every execution, so the result shape and parameter types are always current: it is safe across live schema changes, and because the server resolves parameter types, it encodes ambiguous Go values correctly. The cost is one extra `Describe` round trip per query (measured ~2x per-query latency vs `Exec` on DSQL).

**Why not `Exec` (which is single-round-trip and also schema-change safe)?** `Exec` skips the server-side parameter `Describe` and infers PostgreSQL types from Go types alone. On a real DSQL cluster that measurably breaks correctness:

| Case | CacheStatement | CacheDescribe | DescribeExec | Exec |
|---|---|---|---|---|
| `jsonb` param as `map` | OK | OK | OK | **FAIL** |
| `jsonb` param as `[]byte` | OK | OK | OK | **FAIL** (`22P02 invalid input syntax for json`) |
| `[]byte` → `text` column | `hello` | `hello` | `hello` | **`\x68656c6c6f`** (silent corruption) |

Registering JSON type mappings (`RegisterDefaultPgType`) does not rescue `Exec`: it fixes the jsonb case but then globally hijacks `[]byte` inference and breaks `[]byte` → `bytea` (`22021 invalid byte sequence for encoding UTF8`). `Exec` fundamentally cannot disambiguate a `[]byte`'s target type without the server `Describe` it omits by design. So `Exec` is not a safe default — but it is offered as an opt-in for latency-sensitive workloads with unambiguous parameter types:

```go
pool, _ := dsql.NewPool(ctx, dsql.Config{
    Host:          "cluster.dsql.us-east-1.on.aws",
    QueryExecMode: pgx.QueryExecModeExec,
})
```

Note: overriding via `pool.Config().ConnConfig.DefaultQueryExecMode` or a preset `pgxpool.Config.ConnConfig` does **not** work — `Config()` returns a copy and the connector applies its own mode when each connection is established. `Config.QueryExecMode` is the honored path (also works for single connections); `BeforeConnect` works too.

## Files
- `go/pgx/dsql/config.go` — add `Config.QueryExecMode`; default `DefaultQueryExecMode = DescribeExec`; apply the resolved mode in `configureConnConfig`.
- `go/pgx/dsql/config_test.go` — assert the `DescribeExec` default and the `Config.QueryExecMode` override.
- `go/pgx/README.md` — "Query Execution Mode and Schema Evolution" section: the default, the `Exec` opt-in and its correctness caveats, the override that actually works, and a recommendation to avoid `SELECT *` on evolving tables.

## Testing
- `go build ./...`, `go vet ./dsql/...`, `gofmt` — clean
- `go test ./dsql/... ./occretry/...` — pass (new tests included)
- **Live cluster verification:** reproduced the schema-change failures and the `Exec` jsonb/`[]byte` correctness problems on a real DSQL cluster; confirmed the `DescribeExec` default and the `Config.QueryExecMode` override behave as documented.

## Notes
Per CONTRIBUTING, happy to open a tracking issue if preferred. Thanks to @praba2210 for the review that caught the `Exec` correctness problems and the override gap.
