### PR TITLE
Fix broken doc links in PHP, Rust, and Go READMEs

### DIFF
--- a/go/pgx/README.md
+++ b/go/pgx/README.md
@@ -25,7 +25,7 @@ For information about creating an Aurora DSQL cluster, see the [Getting started 
 
 ### Credentials Resolution
 
-The connector uses the [AWS SDK for Go v2 default credential chain](https://aws.github.io/aws-sdk-go-v2/docs/configuring-sdk/#specifying-credentials), which resolves credentials in the following order:
+The connector uses the [AWS SDK for Go v2 default credential chain](https://docs.aws.amazon.com/sdk-for-go/v2/developer-guide/configure-gosdk.html#specifying-credentials), which resolves credentials in the following order:
 
 1. **Environment variables** (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and optionally `AWS_SESSION_TOKEN`)
 2. **Shared credentials file** (`~/.aws/credentials`) with optional profile via `AWS_PROFILE` or `Config.Profile`
@@ -391,7 +391,7 @@ For Aurora DSQL best practices including primary key selection, concurrency hand
 - [Amazon Aurora DSQL Documentation](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/what-is-aurora-dsql.html)
 - [pgx Documentation](https://pkg.go.dev/github.com/jackc/pgx/v5)
 - [pgxpool Documentation](https://pkg.go.dev/github.com/jackc/pgx/v5/pgxpool)
-- [AWS SDK for Go v2](https://aws.github.io/aws-sdk-go-v2/)
+- [AWS SDK for Go v2](https://docs.aws.amazon.com/sdk-for-go/v2/developer-guide/)
 
 ---
 

--- a/php/pdo_pgsql/README.md
+++ b/php/pdo_pgsql/README.md
@@ -245,8 +245,8 @@ php example/src/example_preferred.php
 
 - [Aurora DSQL User Guide](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/what-is-aurora-dsql.html)
 - [Aurora DSQL PostgreSQL Compatibility](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/working-with-postgresql-compatibility.html)
-- [Aurora DSQL Unsupported Features](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/working-with-postgresql-compatibility-unsupported.html)
-- [Optimistic Concurrency Control in Aurora DSQL](https://aws.amazon.com/blogs/database/introducing-optimistic-concurrency-control-in-amazon-aurora-dsql/)
+- [Migrating from PostgreSQL to Aurora DSQL](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/working-with-postgresql-compatibility-migration-guide.html)
+- [Concurrency Control in Aurora DSQL](https://aws.amazon.com/blogs/database/concurrency-control-in-amazon-aurora-dsql/)
 - [PHP PDO Documentation](https://www.php.net/manual/en/book.pdo.php)
 - [AWS SDK for PHP](https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/welcome.html)
 

--- a/rust/sqlx/README.md
+++ b/rust/sqlx/README.md
@@ -428,7 +428,7 @@ cargo run --bin example_no_connection_pool
 ## Additional Resources
 
 - [Amazon Aurora DSQL Documentation](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/what-is-aurora-dsql.html)
-- [Aurora DSQL Best Practices](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/best-practices.html)
+- [Aurora DSQL Considerations](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/considerations.html)
 - [SQLx Documentation](https://docs.rs/sqlx/latest/sqlx/)
 - [AWS SDK for Rust](https://docs.aws.amazon.com/sdk-for-rust/latest/dg/welcome.html)
 


### PR DESCRIPTION
Updated broken and stale URLs.

| File | Old URL (status) | New URL |
| --- | --- | --- |
| `php/pdo_pgsql/README.md:248` | `…/working-with-postgresql-compatibility-unsupported.html` (302) | `…/working-with-postgresql-compatibility-migration-guide.html` |
| `php/pdo_pgsql/README.md:249` | `…/introducing-optimistic-concurrency-control-in-amazon-aurora-dsql/` (404) | `…/concurrency-control-in-amazon-aurora-dsql/` |
| `rust/sqlx/README.md:431` | `…/best-practices.html` (302) | `…/considerations.html` |
| `go/pgx/README.md:28` | `aws.github.io/aws-sdk-go-v2/docs/configuring-sdk/#specifying-credentials` (404) | `…/sdk-for-go/v2/developer-guide/configure-gosdk.html#specifying-credentials` |
| `go/pgx/README.md:394` | `aws.github.io/aws-sdk-go-v2/` (404) | `…/sdk-for-go/v2/developer-guide/` |

*Issue #, if available:*
N/A

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.