### PR TITLE
go/pgx: default to DescribeExec (schema-change safe) with Config.QueryExecMode override

### DIFF
--- a/go/pgx/README.md
+++ b/go/pgx/README.md
@@ -382,6 +382,66 @@ go run ./src/occ_retry/...
 go run ./src/connection_string/...
 ```
 
+## Query Execution Mode and Schema Evolution
+
+The connector sets pgx's `DefaultQueryExecMode` to `QueryExecModeDescribeExec` on
+every connection it creates. You can override this via `Config.QueryExecMode`.
+
+**Why not pgx's caching defaults?** pgx's default is `QueryExecModeCacheStatement`,
+which caches a prepared statement per connection; `QueryExecModeCacheDescribe`
+caches the statement's result-column descriptions. If a table's schema changes
+while pooled connections are still open — for example `ALTER TABLE ... ADD COLUMN`
+during a migration — the next execution on a connection holding a stale plan or
+description fails:
+
+```
+CacheStatement: ERROR: cached plan must not change result type (SQLSTATE 0A000)
+CacheDescribe:  ERROR: bind message has N result formats but query has M columns (SQLSTATE 08P01)
+```
+
+pgx invalidates the cache on that error and self-heals on the next attempt, but
+the failing statement still surfaces an error to the caller.
+
+`QueryExecModeDescribeExec` issues a `Describe` on every execution, so the result
+shape and parameter types are always current. It is safe across live schema
+changes, and because the server resolves parameter types, it correctly encodes
+ambiguous Go values. The cost is one extra `Describe` round trip per query.
+
+**Why not `QueryExecModeExec`?** `Exec` avoids the extra round trip (measured on
+Aurora DSQL it is roughly 2x faster per query than `DescribeExec`), but it **skips
+the server-side parameter `Describe`** and infers PostgreSQL types from Go types
+alone. On Aurora DSQL this measurably breaks real cases:
+
+- a `jsonb` parameter passed as a `map` or `[]byte` is **rejected**, and
+- a `[]byte` bound to a `text` column is **silently stored as its bytea hex
+  encoding** (no error, corrupted data).
+
+Because of this it is not a safe default. If your parameter types are unambiguous
+and you need the lower latency, opt in explicitly:
+
+```go
+pool, _ := dsql.NewPool(ctx, dsql.Config{
+    Host:          "cluster.dsql.us-east-1.on.aws",
+    QueryExecMode: pgx.QueryExecModeExec,
+})
+```
+
+> Note: overriding via `pool.Config().ConnConfig.DefaultQueryExecMode` or a preset
+> `pgxpool.Config.ConnConfig` does **not** work — `Config()` returns a copy, and
+> the connector applies its own mode when each connection is established. Use
+> `Config.QueryExecMode` (above), which is honored for both pooled and single
+> connections.
+
+### Recommendation: avoid `SELECT *` on evolving tables
+
+Selecting into a fixed struct is only part of the story: a `SELECT *` result set
+will still *grow* when columns are added, so the query keeps working but now
+returns extra columns. With `database/sql`/`sqlx`-style row scanning, unmapped
+extra columns can themselves cause errors (e.g. `missing destination name`).
+Prefer explicit column
+lists (`SELECT col_a, col_b, ...`) on read paths so additive schema changes are
+transparent to the application regardless of query mode.
+
 ## DSQL Best Practices
 
 For Aurora DSQL best practices including primary key selection, concurrency handling, index creation, and transaction limits, see the [Aurora DSQL documentation](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/working-with-postgresql-compatibility.html).

--- a/go/pgx/dsql/config.go
+++ b/go/pgx/dsql/config.go
@@ -42,6 +42,11 @@ const (
 	DefaultTokenDuration = 15 * time.Minute
 )
 
+// DefaultQueryExecMode is the pgx query execution mode the connector applies
+// when Config.QueryExecMode is left unset. See configureConnConfig for the
+// rationale.
+const DefaultQueryExecMode = pgx.QueryExecModeDescribeExec
+
 // Config holds the configuration for connecting to Aurora DSQL.
 type Config struct {
 	// Host is the cluster endpoint or cluster ID. Required.
@@ -67,6 +72,10 @@ type Config struct {
 
 	// CustomCredentialsProvider is a custom AWS credentials provider. Optional.
 	CustomCredentialsProvider aws.CredentialsProvider
+
+	// QueryExecMode overrides the pgx query execution mode. Optional; zero means
+	// the connector default (QueryExecModeDescribeExec). See configureConnConfig.
+	QueryExecMode pgx.QueryExecMode
 }
 
 // resolvedConfig holds the validated and resolved configuration with all
@@ -80,6 +89,7 @@ type resolvedConfig struct {
 	Profile                   string
 	TokenDuration             time.Duration
 	CustomCredentialsProvider aws.CredentialsProvider
+	QueryExecMode             pgx.QueryExecMode
 }
 
 // resolve validates the configuration, applies defaults, and resolves the
@@ -97,11 +107,16 @@ func (c *Config) resolve() (*resolvedConfig, error) {
 		Port:                      c.Port,
 		Profile:                   c.Profile,
 		CustomCredentialsProvider: c.CustomCredentialsProvider,
+		QueryExecMode:             c.QueryExecMode,
 	}
 
 	// Apply defaults
 	if resolved.User == "" {
 		resolved.User = DefaultUser
+	}
+	// Zero is not a valid pgx.QueryExecMode, so treat it as "unset".
+	if resolved.QueryExecMode == 0 {
+		resolved.QueryExecMode = DefaultQueryExecMode
 	}
 	if resolved.Database == "" {
 		resolved.Database = DefaultDatabase
@@ -226,4 +241,14 @@ func (r *resolvedConfig) configureConnConfig(cfg *pgx.ConnConfig) {
 	cfg.RuntimeParams = map[string]string{
 		"application_name": ApplicationName,
 	}
+
+	// Default to DescribeExec (overridable via Config.QueryExecMode). pgx's
+	// caching modes (CacheStatement, CacheDescribe) fail after a live schema
+	// change on connections holding a stale plan/description (0A000 / 08P01).
+	// DescribeExec re-Describes each execution, so it is schema-change safe and
+	// resolves parameter types server-side. Exec avoids the extra round trip but
+	// infers param types from Go types alone, which on DSQL rejects jsonb
+	// map/[]byte params and silently corrupts []byte into text columns, so it is
+	// opt-in only.
+	cfg.DefaultQueryExecMode = r.QueryExecMode
 }

--- a/go/pgx/dsql/config_test.go
+++ b/go/pgx/dsql/config_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -130,8 +131,8 @@ func TestConfigResolve(t *testing.T) {
 	tests := []struct {
 		name    string
 		config  Config
-		setup   func()    // Optional setup (e.g., set env vars)
-		cleanup func()    // Optional cleanup
+		setup   func() // Optional setup (e.g., set env vars)
+		cleanup func() // Optional cleanup
 		wantErr bool
 		errMsg  string
 	}{
@@ -338,4 +339,44 @@ func TestParseConnectionString(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestConfigureConnConfigDefaultsToDescribeExec(t *testing.T) {
+	cfg := Config{
+		Host: "mycluster.dsql.us-east-1.on.aws",
+	}
+	resolved, err := cfg.resolve()
+	require.NoError(t, err)
+
+	connConfig, err := pgx.ParseConfig("")
+	require.NoError(t, err)
+
+	resolved.configureConnConfig(connConfig)
+
+	// Unset Config.QueryExecMode -> connector default (DescribeExec).
+	assert.Equal(t, pgx.QueryExecModeDescribeExec, connConfig.DefaultQueryExecMode)
+
+	// Sanity: the other connection settings are still applied.
+	assert.Equal(t, "mycluster.dsql.us-east-1.on.aws", connConfig.Host)
+	assert.Equal(t, uint16(5432), connConfig.Port)
+	assert.Equal(t, "postgres", connConfig.Database)
+	assert.Equal(t, "admin", connConfig.User)
+	assert.Equal(t, ApplicationName, connConfig.RuntimeParams["application_name"])
+}
+
+func TestConfigureConnConfigHonorsQueryExecModeOverride(t *testing.T) {
+	cfg := Config{
+		Host:          "mycluster.dsql.us-east-1.on.aws",
+		QueryExecMode: pgx.QueryExecModeExec,
+	}
+	resolved, err := cfg.resolve()
+	require.NoError(t, err)
+
+	connConfig, err := pgx.ParseConfig("")
+	require.NoError(t, err)
+
+	resolved.configureConnConfig(connConfig)
+
+	// Explicit Config.QueryExecMode is honored over the default.
+	assert.Equal(t, pgx.QueryExecModeExec, connConfig.DefaultQueryExecMode)
 }


### PR DESCRIPTION
> This is a maintainer-hosted replacement for #774 by @rmconstantin. The commit preserves Raluca Constantin as the author, and the patch ID matches the final reviewed diff from #774 exactly. It is reopened from an `awslabs` branch solely so CI can access the repository's Aurora DSQL test credentials. Thanks also to @praba2210 for the detailed review and live-cluster verification.

## Problem
Applications using this connector against Aurora DSQL can fail reads from a table immediately after an online `ALTER TABLE ... ADD COLUMN`, with one of:

```
ERROR: cached plan must not change result type (SQLSTATE 0A000)
ERROR: bind message has N result formats but query has M columns (SQLSTATE 08P01)
```

Existing pooled connections holding a stale plan or description surface this on the next execution. pgx invalidates the cache on the error and self-heals on the next attempt, but the failing statement still returns an error to the caller.

## Change
Default `DefaultQueryExecMode` to `pgx.QueryExecModeDescribeExec` in `configureConnConfig`, shared by both `Connect` and `NewPool`, and add `Config.QueryExecMode` so callers can override it.

`DescribeExec` describes every execution, keeping result shapes and parameter types current across live schema changes. It also preserves server-side resolution for ambiguous values such as `jsonb` and `[]byte` parameters. Callers with unambiguous parameter types can explicitly opt into `Exec` when its lower latency is worth the documented tradeoffs.

The README documents the default, override path, `Exec` correctness caveats, and the recommendation to avoid `SELECT *` on evolving tables.

## Verification
Verification already performed on the final #774 revision:

- `go build ./...`
- `go vet ./dsql/...`
- `go test ./dsql/... ./occretry/...`
- live Aurora DSQL reproduction of the schema-change failures and `Exec` parameter-type issues

Replacement-branch checks:

- rebased onto current `main`
- patch ID identical to #774's final reviewed diff
- `gofmt` clean
- `git diff --check` clean

Local Go tests in the maintainer checkout could not download AWS SDK modules because DNS resolution for `proxy.golang.org` timed out. This PR's same-repository CI run is the authoritative fresh build and integration verification.
